### PR TITLE
Use images from splitgraphci/* for tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,5 +30,5 @@ before_script:
   # Stop the PG that ships with Travis and run our own integration test
   # SG driver/remote architecture instead.
   - sudo /etc/init.d/postgresql stop
-  - sudo docker-compose --file test/architecture/docker-compose.yml up -d
+  - sudo docker-compose --file test/architecture/docker-compose.yml up -d pgorigin mongoorigin local_driver remote_driver
   - sleep 30

--- a/test/architecture/docker-compose.yml
+++ b/test/architecture/docker-compose.yml
@@ -11,7 +11,7 @@ services:
     volumes:
       - ./data/pgorigin:/src
   mongoorigin:
-    image: splitgraphci/pgorigin
+    image: splitgraphci/mongoorigin
     ports:
       - "0.0.0.0:27017:27017"
     environment:

--- a/test/architecture/docker-compose.yml
+++ b/test/architecture/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   pgorigin:
-    build: ./src/pgorigin
+    image: splitgraphci/pgorigin
     environment:
       - ORIGIN_USER=originro
       - ORIGIN_PASS=originpass
@@ -10,6 +10,18 @@ services:
       - 5432
     volumes:
       - ./data/pgorigin:/src
+  mongoorigin:
+    image: splitgraphci/pgorigin
+    ports:
+      - "0.0.0.0:27017:27017"
+    environment:
+      - ORIGIN_USER=originro
+      - ORIGIN_PASS=originpass
+      - ORIGIN_MONGO_DB=origindb
+    expose:
+      - 27017
+    volumes:
+      - ./data/mongoorigin:/src
   local_driver:
     image: splitgraph/driver
     ports:
@@ -33,15 +45,9 @@ services:
       - PGPORT=5431
     expose:
       - 5431
-  mongoorigin:
+  ci_pgorigin:
+    image: splitgraphci/pgorigin
+    build: ./src/pgorigin
+  ci_mongoorigin:
+    image: splitgraphci/mongoorigin
     build: ./src/mongoorigin
-    ports:
-      - "0.0.0.0:27017:27017"
-    environment:
-      - ORIGIN_USER=originro
-      - ORIGIN_PASS=originpass
-      - ORIGIN_MONGO_DB=origindb
-    expose:
-      - 27017
-    volumes:
-      - ./data/mongoorigin:/src

--- a/test/architecture/scripts/build_and_publish_ci_images.sh
+++ b/test/architecture/scripts/build_and_publish_ci_images.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+DIR=$(cd -P -- "$(dirname -- "$0")" && pwd -P)
+
+usage() {
+    echo
+    echo "./scripts/build_and_publish_ci_images.sh"
+    echo
+    echo "1. Build images via scripts/build_ci_images.sh"
+    echo
+    echo
+
+    "$DIR"/build_ci_images.sh --help
+
+    echo
+    echo
+    echo "2. Publish images via scripts/publish_ci_images.sh"
+    echo
+    echo
+
+    "$DIR"/publish_ci_images.sh --help
+
+    echo
+    echo
+    echo
+}
+
+test "$1" == "--help" && { usage ; exit 1 ; }
+
+"$DIR"/build_ci_images.sh && "$DIR"/publish_ci_images.sh

--- a/test/architecture/scripts/build_ci_images.sh
+++ b/test/architecture/scripts/build_ci_images.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+usage() {
+    echo
+    echo "./scripts/build_ci_images.sh"
+    echo
+    echo "Find services defined in this docker-compose beginning with ci_"
+    echo "and build them. As long as they have an image: directive to tag"
+    echo "them with splitgraphci/imgname, they will be tagged so that"
+    echo "scripts/publish_ci_images.sh can detect and publish them."
+    echo
+}
+
+test "$1" == "--help" && { usage ; exit 1 ; }
+
+set -eo pipefail
+
+_log_error() {
+    echo "$@" 1>&2
+}
+
+fatal_error() {
+    _log_error "Fatal:" "$@"
+    exit 1
+}
+
+_log() {
+    echo "$@"
+}
+
+DIR=$(cd -P -- "$(dirname -- "$0")" && pwd -P)
+
+ARCH_DIR="$DIR"/../
+
+cd "$ARCH_DIR" || {
+    fatal_error "Failed to cd to architecture directory at $ARCH_DIR" ;
+}
+
+which docker-compose >/dev/null 2>&1|| {
+    fatal_error "docker-compose is not installed or not in \$PATH";
+}
+
+get_ci_services() {
+    docker-compose config --services \
+        | grep '^ci_'
+}
+
+_log "Building CI services:"
+get_ci_services
+
+get_ci_services | xargs docker-compose build || { \
+    fatal_error "Failed to build CI services."
+}
+
+_log "Success."

--- a/test/architecture/scripts/publish_ci_images.sh
+++ b/test/architecture/scripts/publish_ci_images.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+
+usage() {
+    echo
+    echo "./scripts/publish_ci_images.sh"
+    echo
+    echo "Find image tags created by this docker-compose file that begin with"
+    echo "splitgraphci/ and push them to docker hub."
+    echo
+    echo "Script will print tag names and then prompt to login before pushing,"
+    echo "so you have a chance to cancel it with ctrl+c if necessary."
+    echo
+}
+
+test "$1" == "--help" && { usage ; exit 1 ; }
+
+set -eo pipefail
+
+trap 'echo "Canceled by user"; exit 1;' INT
+
+_log_error() {
+    echo "$@" 1>&2
+}
+
+fatal_error() {
+    _log_error "Fatal:" "$@"
+    exit 1
+}
+
+_log() {
+    echo "$@"
+}
+
+DIR=$(cd -P -- "$(dirname -- "$0")" && pwd -P)
+
+ARCH_DIR="$DIR"/../
+
+cd "$ARCH_DIR" || {
+    fatal_error "Failed to cd to architecture directory at $ARCH_DIR" ;
+}
+
+which docker-compose >/dev/null 2>&1|| {
+    fatal_error "docker-compose is not installed or not in \$PATH";
+}
+
+# Get the CI image tags built from this docker-compose file, e.g.
+# splitgraphci/pgorigin
+get_ci_image_tags() {
+    docker-compose images -q \
+        | xargs docker inspect -f='{{.RepoTags}}' \
+        | grep -Eo 'splitgraphci/(.*?):' \
+        | cut -d ':' -f1
+}
+
+_log "Publishing CI tags:"
+get_ci_image_tags
+
+_log "Log into docker hub when prompted"
+docker login
+
+while IFS=' ' read -r image_tag ; do
+    echo "Publish Image: $image_tag"
+    docker push "$image_tag" \
+        || fatal_error "Failed to publish ${image_tag}. Stopping prematurely."
+done < <(get_ci_image_tags)
+
+echo "Success."


### PR DESCRIPTION
**Code Changes**:

- Add scripts in architecture/scripts:

    - scripts/build_ci_images.sh: Build services ci_*
    - scripts/publish_ci_images.sh: Publish image tags splitgraphci/*
    - scripts/build_and_publish_ci_image.sh: Do one after the other

    (Call any script with --help to see usage.)

- Update docker-compose.yml:

    - Set mongoorigin to use image splitgraphci/mongoorigin
    - Set pgorigin to use image splitgraphci/pgorigin
    - Add ci_mongoorigin and ci_pgorigin for build step

**Docker Hub Changes:**

- Create `splitgraphci` organization
- Publish `splitgraphci/mongoorigin` and `splitgraphci/pgorigin`

**Remember to run `./test/architecture/scripts/build_and_publish_ci_images.sh` after making any updates to the `pgorigin` or `mongoorigin` images.**