### PR TITLE
Add __pycache__, eggs, egg-info to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 .coverage
 htmlcov
+**/__pycache__
+**/.eggs
+**/*.egg-info


### PR DESCRIPTION
Make lives of spltigraph developers easier by adding `**/__pycache__`, `**/.eggs`, and `**/*.egg-info` to `.gitignore`