### PR TITLE
Stage 1 for the registry RLS

### DIFF
--- a/benchmarking/commit_chain_test.py
+++ b/benchmarking/commit_chain_test.py
@@ -56,7 +56,6 @@ if __name__ == '__main__':
         update_size = 1000
         commits = 100
 
-
         unmount(conn, MOUNTPOINT)
         init(conn, MOUNTPOINT)
         print("START")

--- a/docs/commands.rst
+++ b/docs/commands.rst
@@ -17,7 +17,7 @@ Managing images
 
 `sgr checkout`
     checks out a given commit into the schema, first deleting any uncommitted chances. Then,
-    every table in the given Splitgraph image is materialized (copied into the mountpoint as an actual table).
+    every table in the given Splitgraph image is materialized (copied into the repository as an actual table).
 
     As a part of this process, extra physical objects that are required to materialize the image can be downloaded.
 
@@ -31,25 +31,25 @@ There are various (commandline and API) commands that can be used to inspect the
 :mod:`splitgraph.meta_handler` contains more low-level commands that fetch data directly from the metadata
 tables without processing it.
 
-`sgr show MOUNTPOINT IMAGE_HASH`
+`sgr show REPOSITORY IMAGE_HASH`
     Outputs the information about a given image. The verbose mode (`-v`) also lists all the actual objects
     the image depends on.
 
-`sgr diff MOUNTPOINT IMAGE_HASH_1 [IMAGE_HASH_2]`
+`sgr diff REPOSITORY IMAGE_HASH_1 [IMAGE_HASH_2]`
     Also see: :mod:`splitgraph.commands.diff`
 
-    Shows the difference between two images in a mountpoint. If the two images are on the same path in `images`, it
+    Shows the difference between two images in a repository. If the two images are on the same path in `images`, it
     concatenates their DIFFs and displays that (or the aggregation of total inserts/deletes/updates).
     Note this might give wrong results if there's been a schema change.
 
     If the images are on different branches), it temporarily materializes both revisions and compares them row-by-row.
 
-`sgr log MOUNTPOINT`
+`sgr log REPOSITORY`
     Also see: :func:`splitgraph.commands.misc.get_log`
 
-    Returns the log of changes to a given mountpoint, starting from the current HEAD revision and crawling down.
+    Returns the log of changes to a given repository, starting from the current HEAD revision and crawling down.
     If `--tree` (`-t`) is passed, outputs the full image tree of the schema.
-    Otherwise, and if nothing in the mountpoint is checked out, raises an error.
+    Otherwise, and if nothing in the repository is checked out, raises an error.
 
 `sgr status`
     Lists the currently mounted schemata and their checked out images (if any).
@@ -64,7 +64,7 @@ Also see :mod:`splitgraph.commands.push_pull`
     a full connection string.
 
 `sgr clone`
-    Brings the metadata for the local mountpoint up to date with a remote one, optionally downloading the actual
+    Brings the metadata for the local repository up to date with a remote one, optionally downloading the actual
     physical objects.
 
 `sgr push`
@@ -77,8 +77,8 @@ Also see :mod:`splitgraph.commands.push_pull`
 Importing tables across repositories
 ====================================
 
-`sgr import SOURCE_MOUNTPOINT SOURCE_TABLE TARGET_MOUNTPOINT [TARGET_TABLE] [SOURCE_IMAGE_OR_TAG]`
-    Grafts one or more tables from one mountpoint into another, creating a new single commit on top of the current HEAD.
+`sgr import SOURCE_REPOSITORY SOURCE_TABLE TARGET_REPOSITORY [TARGET_TABLE] [SOURCE_IMAGE_OR_TAG]`
+    Grafts one or more tables from one repository into another, creating a new single commit on top of the current HEAD.
     This doesn't explicitly preserve the imported tables' history. If the new table(s) isn't/aren't materialized, this
     doesn't consume extra space apart from the new entries in the metadata tables. It also doesn't discard any pending
     changes.
@@ -95,7 +95,7 @@ See also :mod:`splitgraph.commands.mounting`.
 
 `sgr mount`
     Uses the Postgres FDW to mount a foreign Postgres/Mongo database as a set of tables into a temporary location
-    and then imports those tables into the target mountpoint as a new Splitgraph image.
+    and then imports those tables into the target repository as a new Splitgraph image.
 
 `sgr unmount`
     Destroys the local copy of a repository and all the metadata related to it in
@@ -103,7 +103,7 @@ See also :mod:`splitgraph.commands.mounting`.
     `splitgraph_meta` or references to them in
     `objects` / `object_locations`. There's a separate function, `sgr cleanup`
     (or :func:`splitgraph.commands.misc.cleanup_objects`) that crawls the `splitgraph_meta` for objects not required
-    by a current mountpoint and does that.
+    by a current repository and does that.
 
 `sgr init`
     Creates an empty repository with one single initial commit (hash `000000...`).
@@ -130,7 +130,7 @@ aren't publicly accessible.
 Provenance tracking allows Splitgraph to recreate the SGFile the image was made with, as well as rebase the image to
 use a different version of the datasets it was made from.
 
-`sgr provenance MOUNTPOINT IMAGE_OR_TAG`
+`sgr provenance REPOSITORY IMAGE_OR_TAG`
     Inspects the image's parents and outputs a list of datasets and their versions
     that were used to create this image (via `IMPORT` or `FROM` commands). If the `-f (--full)` flag is passed, then the
     command will try to reconstruct the full sgfile used to create the image, raising an error if there's a break in the
@@ -138,7 +138,7 @@ use a different version of the datasets it was made from.
     in the history of the image). If the `-e` flag is passed, the command will instead stop at the first break in the chain
     and base the resulting sgfile before the break (using the `FROM` command).
 
-`sgr rerun MOUNTPOINT IMAGE_OR_TAG -i DATASET1 IMAGE_OR_TAG1 -i ...`
+`sgr rerun REPOSITORY IMAGE_OR_TAG -i DATASET1 IMAGE_OR_TAG1 -i ...`
     Recreates the SGFile used to derive a given image
     and reruns it, replacing its dependencies as specified by the `-i` options. If the `-u` flag is passed, the image
     is rederived based on the `latest` tag of all its dependencies.

--- a/docs/commands.rst
+++ b/docs/commands.rst
@@ -38,7 +38,7 @@ tables without processing it.
 `sgr diff MOUNTPOINT IMAGE_HASH_1 [IMAGE_HASH_2]`
     Also see: :mod:`splitgraph.commands.diff`
 
-    Shows the difference between two images in a mountpoint. If the two images are on the same path in `snap_tree`, it
+    Shows the difference between two images in a mountpoint. If the two images are on the same path in `images`, it
     concatenates their DIFFs and displays that (or the aggregation of total inserts/deletes/updates).
     Note this might give wrong results if there's been a schema change.
 
@@ -99,9 +99,9 @@ See also :mod:`splitgraph.commands.mounting`.
 
 `sgr unmount`
     Destroys the local copy of a repository and all the metadata related to it in
-    `snap_tree`, `tables`, `remotes` and `snap_tags`. This command doesn't delete the actual physical objects in
+    `images`, `tables`, `remotes` and `snap_tags`. This command doesn't delete the actual physical objects in
     `splitgraph_meta` or references to them in
-    `object_tree` / `object_locations`. There's a separate function, `sgr cleanup`
+    `objects` / `object_locations`. There's a separate function, `sgr cleanup`
     (or :func:`splitgraph.commands.misc.cleanup_objects`) that crawls the `splitgraph_meta` for objects not required
     by a current mountpoint and does that.
 

--- a/docs/internals.rst
+++ b/docs/internals.rst
@@ -16,17 +16,17 @@ Here's an overview of the tables in this schema:
 
   * `images`: Describes all image hashes and their parents, as well as extra
     data about a given commit (the creation timestamp, the commit message and the details of the sgfile command that
-    generated this image). PKd on the mountpoint and the image hash, so the same image can exist in multiple schemas
+    generated this image). PKd on the repository and the image hash, so the same image can exist in multiple schemas
     at the same time.
   * `tables`: an image consists of multiple tables. Each table in a given version is represented by one or more objects.
     An object can be one of two types: SNAP (a snapshot, a full copy of the table) and a DIFF (list of changes to a parent
-    object). This is also mountpoint-specific.
+    object). This is also repository-specific.
   * `objects`: Lists the type and the parent of every object. A SNAP object doesn't have a parent and a DIFF object
     might have multiple parents (for example, the SNAP and the DIFF of a previous commit). This is not necessarily
     the object linked to the parent commit of a given object: if we're importing a table from a different repository,
     we would pull in its chain of DIFF objects without tying them to commits those objects were created in.
   * `remotes`: Currently, stores the connection string for the upstream repository a given repository was cloned from.
-  * `snap_tags`: maps images and their mountpoints to one or more tags. Tags (apart from HEAD) are pushed and pulled
+  * `snap_tags`: maps images and their repositories to one or more tags. Tags (apart from HEAD) are pushed and pulled
     to/from upstream repositories and are immutable (this is weakly enforced by the push/pull code).
     HEAD is a special tag: it points out to the currently checked-out local image.
   * `object_locations`: If a given object is not stored in the remote, this table specifies where to find it (protocol
@@ -66,7 +66,7 @@ Implementation of various Splitgraph commands
   * The `tables` table is inspected to find out which object is required to start materializing the table.
   * Then, `objects` is crawled to find a chain of DIFF objects that ends with a SNAP
     (`splitgraph.pg_replication.get_closest_parent_snap_object`).
-  * The SNAP is copied into the mountpoint and the DIFFs applied to it. Checkouts/repository clones are
+  * The SNAP is copied into the schema and the DIFFs applied to it. Checkouts/repository clones are
     lazy by default, so an object might not even exist locally. The lookup path for a physical object is:
 
       * Search locally in the `splitgraph_meta` schema for a cached/predownloaded object.

--- a/docs/sgfile.rst
+++ b/docs/sgfile.rst
@@ -21,10 +21,10 @@ The following commands are supported by the interpreter:
 Basing an image on another image
 --------------------------------
 
-`FROM mountpoint[:tag] [AS alias]`
+`FROM repository[:tag] [AS alias]`
     Bases the output of the sgfile on a certain revision of the remote/local repository.
     If `AS alias` is specified, the repository is cloned into `alias` and the current contents of `alias` destroyed.
-    Otherwise, the current output mountpoint (passed to the executor) is used.
+    Otherwise, the current output repository (passed to the executor) is used.
 
 `FROM` can also be used to perform Docker-like multistage builds.
 
@@ -39,31 +39,31 @@ For example::
 Importing tables from another image
 -----------------------------------
 
-`FROM (mountpoint[:tag])/(MOUNT handler conn_string handler_options) IMPORT table1/{query1} [AS table1_alias], [table2/{query2}...]`
-    Uses the `sgr import` command to import one or more tables from either a local mountpoint, a remote one, or an
+`FROM (repository[:tag])/(MOUNT handler conn_string handler_options) IMPORT table1/{query1} [AS table1_alias], [table2/{query2}...]`
+    Uses the `sgr import` command to import one or more tables from either a local repository, a remote one, or an
     FDW-mounted database.
 
 Optionally, the table name can be replaced with a SELECT query in curly braces that will get executed against the
-source mountpoint in order to create a table. This will be stored as a snapshot. For example:
+source repository in order to create a table. This will be stored as a snapshot. For example:
 
 `FROM internal_data:latest IMPORT {SELECT name, age FROM staff WHERE is_restricted = FALSE} AS visible_staff`
     Will create a new table that contains non-restricted staff names and ages in `internal_data.staff` without including
     any other entries in the table history.
 
     In the case of imports from FDW, the commit hash produced by this command is random. Otherwise, the commit hash will be
-    a combination of the current `OUTPUT` hash, the hash of the source mountpoint and the hashes of the names
+    a combination of the current `OUTPUT` hash, the hash of the source repository and the hashes of the names
     (or source SQL queries) and aliases of all imported tables.
 
 This is crude, but means that the layer is invalidated if there's a change on the remote or we import a different
 table/name it differently/use a different query to create a table.  We can improve on this by perhaps only considering
 the objects and table aliases that are actually imported (as opposed to the source image hash: maybe the tables
-we're importing haven't changed even if other parts of the mountpoint have).
+we're importing haven't changed even if other parts of the repository have).
 
 
 Repository lookups
 ------------------
 
-Currently, a repository name (mountpoint) is converted to a connection string as follows:
+Currently, a repository name is converted to a connection string as follows:
 
   * See if it exists locally (in the case of the sgfile executor). If it does, try to pull it (to update) and
     use it for `FROM`/`IMPORT` commands.
@@ -78,7 +78,7 @@ Running SQL statements
 
 `SQL command`
     Runs a (potentially arbitrary) SQL statement. Doesn't enforce any constraints on the SQL yet,
-    but the spirit of this command is performing actions on tables in the current `OUTPUT` mountpoint (the command is
+    but the spirit of this command is performing actions on tables in the current `OUTPUT` repository (the command is
     executed with the `OUTPUT` schema being the default one) and not changing/reading data from any other schemas.
 
 The image hash produced by this command is a combination of the current `OUTPUT` hash and the hash of the

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup_requirements = [
 ]
 
 setup(
-    name="splitgraph-prototype",
+    name="splitgraph",
     version="0.0",
     packages=['splitgraph'],
     entry_points={

--- a/splitgraph/commandline.py
+++ b/splitgraph/commandline.py
@@ -13,9 +13,9 @@ from splitgraph.commands.misc import cleanup_objects
 from splitgraph.commands.provenance import provenance, image_hash_to_sgfile
 from splitgraph.commands.publish import publish
 from splitgraph.config.repo_lookups import get_remote_connection_params
-from splitgraph.constants import POSTGRES_CONNECTION, SplitGraphException, serialize_connection_string
+from splitgraph.constants import POSTGRES_CONNECTION, SplitGraphException, serialize_connection_string, to_repository
 from splitgraph.drawing import render_tree
-from splitgraph.meta_handler.images import get_canonical_image_id
+from splitgraph.meta_handler.images import get_canonical_image_id, get_image
 from splitgraph.meta_handler.misc import get_current_repositories, get_remote_for
 from splitgraph.meta_handler.tables import get_tables_at, get_table
 from splitgraph.pg_utils import get_all_tables
@@ -34,23 +34,23 @@ def cli():
 
 
 @click.command(name='status')
-@click.argument('mountpoint', required=False)
-def status_c(mountpoint):
+@click.argument('repository', required=False, type=to_repository)
+def status_c(repository):
     conn = _conn()
-    if mountpoint is None:
-        mountpoints = get_current_repositories(conn)
+    if repository is None:
+        repositories = get_current_repositories(conn)
         print("Currently mounted databases: ")
-        for mp_name, mp_hash in mountpoints:
+        for mp_name, mp_hash in repositories:
             # Maybe should also show the remote DB address/server
             print("%s: \t %s" % (mp_name, mp_hash))
-        print("\nUse sgr status MOUNTPOINT to get information about a given mountpoint.")
+        print("\nUse sgr status repository to get information about a given repository.")
     else:
-        current_snap = get_current_head(conn, mountpoint, raise_on_none=False)
+        current_snap = get_current_head(conn, repository, raise_on_none=False)
         if not current_snap:
-            print("%s: nothing checked out." % mountpoint)
+            print("%s: nothing checked out." % str(repository))
             return
-        parent, children = get_parent_children(conn, mountpoint, current_snap)
-        print("%s: on snapshot %s." % (mountpoint, current_snap))
+        parent, children = get_parent_children(conn, repository, current_snap)
+        print("%s: on snapshot %s." % (str(repository), current_snap))
         if parent is not None:
             print("Parent: %s" % parent)
         if len(children) > 1:
@@ -60,32 +60,33 @@ def status_c(mountpoint):
 
 
 @click.command(name='log')
-@click.argument('mountpoint')
+@click.argument('repository', type=to_repository)
 @click.option('-t', '--tree', is_flag=True)
-def log_c(mountpoint, tree):
+def log_c(repository, tree):
     conn = _conn()
     if tree:
-        render_tree(conn, mountpoint)
+        render_tree(conn, repository)
     else:
-        head = get_current_head(conn, mountpoint)
-        log = get_log(conn, mountpoint, head)
+        head = get_current_head(conn, repository)
+        log = get_log(conn, repository, head)
         for entry in log:
-            _, created, comment = get_all_image_info(conn, mountpoint, entry)
-            print("%s %s %s %s" % ("H->" if entry == head else "   ", entry, created, comment or ""))
+            image_info = get_image(conn, repository, entry)
+            print("%s %s %s %s" % ("H->" if entry == head else "   ", entry, image_info.created,
+                                   image_info.comment or ""))
 
 
 @click.command(name='diff')
 @click.option('-v', '--verbose', default=False, is_flag=True)
 @click.option('-t', '--table-name')
-@click.argument('mountpoint')
+@click.argument('repository', type=to_repository)
 @click.argument('tag_or_hash_1', required=False)
 @click.argument('tag_or_hash_2', required=False)
-def diff_c(verbose, table_name, mountpoint, tag_or_hash_1, tag_or_hash_2):
+def diff_c(verbose, table_name, repository, tag_or_hash_1, tag_or_hash_2):
     conn = _conn()
-    tag_or_hash_1, tag_or_hash_2 = _get_actual_hashes(conn, mountpoint, tag_or_hash_1, tag_or_hash_2)
+    tag_or_hash_1, tag_or_hash_2 = _get_actual_hashes(conn, repository, tag_or_hash_1, tag_or_hash_2)
 
-    diffs = {table_name: diff(conn, mountpoint, table_name, tag_or_hash_1, tag_or_hash_2, aggregate=not verbose)
-             for table_name in ([table_name] if table_name else sorted(get_all_tables(conn, mountpoint)))}
+    diffs = {table_name: diff(conn, repository, table_name, tag_or_hash_1, tag_or_hash_2, aggregate=not verbose)
+             for table_name in ([table_name] if table_name else sorted(get_all_tables(conn, repository.to_schema())))}
 
     if tag_or_hash_2 is None:
         print("Between %s and the current working copy: " % tag_or_hash_1[:12])
@@ -126,25 +127,25 @@ def _emit_table_diff(table_name, diff_result, verbose):
         print(to_print + ("table added" if diff_result else "table removed"))
 
 
-def _get_actual_hashes(conn, mountpoint, image_1, image_2):
+def _get_actual_hashes(conn, repository, image_1, image_2):
     if image_1 is None and image_2 is None:
         # Comparing current working copy against the last commit
-        image_1 = get_current_head(conn, mountpoint)
+        image_1 = get_current_head(conn, repository)
     elif image_2 is None:
-        image_1 = tag_or_hash_to_actual_hash(conn, mountpoint, image_1)
+        image_1 = tag_or_hash_to_actual_hash(conn, repository, image_1)
         # One parameter: diff from that and its parent.
-        image_2 = get_image_parent(conn, mountpoint, image_1)
+        image_2 = get_image(conn, repository, image_1).parent_id
         if image_2 is None:
             print("%s has no parent to compare to!" % image_1)
         image_1, image_2 = image_2, image_1  # snap_1 has to come first
     else:
-        image_1 = tag_or_hash_to_actual_hash(conn, mountpoint, image_1)
-        image_2 = tag_or_hash_to_actual_hash(conn, mountpoint, image_2)
+        image_1 = tag_or_hash_to_actual_hash(conn, repository, image_1)
+        image_2 = tag_or_hash_to_actual_hash(conn, repository, image_2)
     return image_1, image_2
 
 
 @click.command(name='mount')
-@click.argument('mountpoint')
+@click.argument('schema')
 @click.option('--connection', '-c', help='Connection string in the form username:password@server:port')
 @click.option('--handler', '-h', help='Mount handler, one of mongo_fdw or postgres_fdw.')
 @click.option('--handler-options', '-o', help='JSON-encoded list of handler options. For postgres_fdw, use '
@@ -153,73 +154,73 @@ def _get_actual_hashes(conn, mountpoint, image_1, image_2):
                                               '{"table_name": {"db": <dbname>, "coll": <collection>, "schema": '
                                               '{"col1": "type1"...}}}',
               default='{}')
-def mount_c(mountpoint, connection, handler, handler_options):
+def mount_c(schema, connection, handler, handler_options):
     # Parse the connection string
     match = re.match(r'(\S+):(\S+)@(.+):(\d+)', connection)
     conn = _conn()
     handler_options = json.loads(handler_options)
     handler_options.update(dict(server=match.group(3), port=int(match.group(4)),
                                 username=match.group(1), password=match.group(2)))
-    mount(conn, mountpoint, mount_handler=handler, handler_kwargs=handler_options)
+    mount(conn, schema, mount_handler=handler, handler_kwargs=handler_options)
     conn.commit()
 
 
 @click.command(name='unmount')
-@click.argument('mountpoint')
-def unmount_c(mountpoint):
+@click.argument('repository', type=to_repository)
+def unmount_c(repository):
     conn = _conn()
-    unmount(conn, mountpoint)
+    unmount(conn, repository)
     conn.commit()
 
 
 @click.command(name='checkout')
-@click.argument('mountpoint')
+@click.argument('repository', type=to_repository)
 @click.argument('snapshot_or_tag')
-def checkout_c(mountpoint, snapshot_or_tag):
+def checkout_c(repository, snapshot_or_tag):
     conn = _conn()
-    snapshot = tag_or_hash_to_actual_hash(conn, mountpoint, snapshot_or_tag)
-    checkout(conn, mountpoint, snapshot)
-    print("Checked out %s:%s." % (mountpoint, snapshot[:12]))
+    snapshot = tag_or_hash_to_actual_hash(conn, repository, snapshot_or_tag)
+    checkout(conn, repository, snapshot)
+    print("Checked out %s:%s." % (str(repository), snapshot[:12]))
     conn.commit()
 
 
 @click.command(name='commit')
-@click.argument('mountpoint')
+@click.argument('repository', type=to_repository)
 @click.option('-h', '--commit-hash')
 @click.option('-s', '--include-snap', default=False, is_flag=True)
 @click.option('-m', '--message')
-def commit_c(mountpoint, commit_hash, include_snap, message):
+def commit_c(repository, commit_hash, include_snap, message):
     conn = _conn()
     if commit_hash and (len(commit_hash) != 64 or any([x not in 'abcdef0123456789' for x in set(commit_hash)])):
         print("Commit hash must be of the form [a-f0-9] x 64!")
         return
 
-    new_hash = commit(conn, mountpoint, commit_hash, include_snap=include_snap, comment=message)
-    print("Committed %s as %s." % (mountpoint, new_hash[:12]))
+    new_hash = commit(conn, repository, commit_hash, include_snap=include_snap, comment=message)
+    print("Committed %s as %s." % (str(repository), new_hash[:12]))
     conn.commit()
 
 
 @click.command(name='show')
-@click.argument('mountpoint')
+@click.argument('repository', type=to_repository)
 @click.argument('commit_tag_or_hash')
 @click.option('-v', '--verbose', default=False, is_flag=True)
-def show_c(mountpoint, commit_tag_or_hash, verbose):
+def show_c(repository, commit_tag_or_hash, verbose):
     conn = _conn()
-    commit_tag_or_hash = tag_or_hash_to_actual_hash(conn, mountpoint, commit_tag_or_hash)
+    commit_tag_or_hash = tag_or_hash_to_actual_hash(conn, repository, commit_tag_or_hash)
 
     print("Commit %s" % commit_tag_or_hash)
-    parent, created, comment = get_all_image_info(conn, mountpoint, commit_tag_or_hash)
-    print(comment or "")
-    print("Created at %s" % created.isoformat())
-    if parent:
-        print("Parent: %s" % parent)
+    image_info = get_image(conn, repository, commit_tag_or_hash)
+    print(image_info.comment or "")
+    print("Created at %s" % image_info.created.isoformat())
+    if image_info.parent_id:
+        print("Parent: %s" % image_info.parent_id)
     else:
         print("No parent (root commit)")
     if verbose:
         print()
         print("Tables:")
-        for t in get_tables_at(conn, mountpoint, commit_tag_or_hash):
-            table_objects = get_table(conn, mountpoint, t, commit_tag_or_hash)
+        for t in get_tables_at(conn, repository, commit_tag_or_hash):
+            table_objects = get_table(conn, repository, t, commit_tag_or_hash)
             if len(table_objects) == 1:
                 print("  %s: %s (%s)" % (t, table_objects[0][0], table_objects[0][1]))
             else:
@@ -231,12 +232,12 @@ def show_c(mountpoint, commit_tag_or_hash, verbose):
 @click.command(name='file')
 @click.argument('sgfile', type=click.File('r'))
 @click.option('-a', '--sgfile-args', multiple=True, type=(str, str))
-@click.option('-o', '--output-mountpoint', help='Mountpoint to store the result in.')
-def file_c(sgfile, sgfile_args, output_mountpoint):
+@click.option('-o', '--output-repository', help='Repository to store the result in.', type=to_repository)
+def file_c(sgfile, sgfile_args, output_repository):
     conn = _conn()
     sgfile_args = {k: v for k, v in sgfile_args}
     print("Executing SGFile %s with arguments %r" % (sgfile.name, sgfile_args))
-    execute_commands(conn, sgfile.read(), sgfile_args, output=output_mountpoint)
+    execute_commands(conn, sgfile.read(), sgfile_args, output=output_repository)
     conn.commit()
     conn.close()
 
@@ -259,27 +260,27 @@ def sql_c(sql, show_all):
 
 
 @click.command(name='init')
-@click.argument('mountpoint')
-def init_c(mountpoint):
+@click.argument('repository', type=to_repository)
+def init_c(repository):
     conn = _conn()
-    init(conn, mountpoint)
-    print("Initialized empty mountpoint %s" % mountpoint)
+    init(conn, repository)
+    print("Initialized empty repository %s" % str(repository))
     conn.commit()
 
 
 @click.command(name='pull')
-@click.argument('mountpoint')
+@click.argument('repository', type=to_repository)
 @click.argument('remote', default='origin')
 @click.option('-d', '--download-all', help='Download all objects immediately instead on checkout.')
-def pull_c(mountpoint, remote, download_all):
+def pull_c(repository, remote, download_all):
     conn = _conn()
-    pull(conn, mountpoint, remote, download_all)
+    pull(conn, repository, remote, download_all)
     conn.commit()
 
 
 @click.command(name='clone')
-@click.argument('remote_repository')
-@click.argument('local_repository', required=False)
+@click.argument('remote_repository', type=to_repository)
+@click.argument('local_repository', required=False, type=to_repository)
 @click.option('-d', '--download-all', help='Download all objects immediately instead on checkout.')
 def clone_c(remote_repository, local_repository, download_all):
     conn = _conn()
@@ -288,34 +289,34 @@ def clone_c(remote_repository, local_repository, download_all):
 
 
 @click.command(name='push')
-@click.argument('mountpoint')
+@click.argument('repository', type=to_repository)
 @click.argument('remote', default='origin')  # origin (must be specified in the config or remembered by the repo)
-@click.argument('remote_mountpoint', required=False)
+@click.argument('remote_repository', required=False, type=to_repository)
 @click.option('-h', '--upload-handler', help='Where to upload objects (FILE or DB for the remote itself)', default='DB')
 @click.option('-o', '--upload-handler-options', help="""For FILE, e.g. '{"path": /mnt/sgobjects}'""", default="{}")
-def push_c(mountpoint, remote, remote_mountpoint, upload_handler, upload_handler_options):
+def push_c(repository, remote, remote_repository, upload_handler, upload_handler_options):
     conn = _conn()
-    if not remote_mountpoint:
-        # Get actual connection string and remote mountpoint
-        remote, remote_mountpoint = get_remote_for(conn, mountpoint, remote)
+    if not remote_repository:
+        # Get actual connection string and remote repository
+        remote, remote_repository = get_remote_for(conn, repository, remote)
     else:
         remote = serialize_connection_string(*get_remote_connection_params(remote))
-    push(conn, mountpoint, remote, remote_mountpoint, handler=upload_handler,
+    push(conn, repository, remote, remote_repository, handler=upload_handler,
          handler_options=json.loads(upload_handler_options))
     conn.commit()
 
 
 @click.command(name='tag')
-@click.argument('mountpoint')
+@click.argument('repository', type=to_repository)
 @click.option('-i', '--image')
 @click.argument('tag', required=False)
 @click.option('-f', '--force', required=False, is_flag=True)
-def tag_c(mountpoint, image, tag, force):
+def tag_c(repository, image, tag, force):
     conn = _conn()
     if tag is None:
         # List all tags
         tag_dict = defaultdict(list)
-        for img, img_tag in get_all_hashes_tags(conn, mountpoint):
+        for img, img_tag in get_all_hashes_tags(conn, repository):
             tag_dict[img].append(img_tag)
         if image is None:
             for img, tags in tag_dict.items():
@@ -323,30 +324,30 @@ def tag_c(mountpoint, image, tag, force):
                 if img:
                     print("%s: %s" % (img[:12], ', '.join(tags)))
         else:
-            print(', '.join(tag_dict[get_canonical_image_id(conn, mountpoint, image)]))
+            print(', '.join(tag_dict[get_canonical_image_id(conn, repository, image)]))
         return
 
     if tag == 'HEAD':
         raise SplitGraphException("HEAD is a reserved tag!")
 
     if image is None:
-        image = get_current_head(conn, mountpoint)
+        image = get_current_head(conn, repository)
     else:
-        image = get_canonical_image_id(conn, mountpoint, image)
-    set_tag(conn, mountpoint, image, tag, force)
-    print("Tagged %s:%s with %s." % (mountpoint, image, tag))
+        image = get_canonical_image_id(conn, repository, image)
+    set_tag(conn, repository, image, tag, force)
+    print("Tagged %s:%s with %s." % (str(repository), image, tag))
     conn.commit()
 
 
 @click.command(name='import')
-@click.argument('mountpoint')
+@click.argument('repository', type=to_repository)
 @click.argument('table_or_query')
-@click.argument('target_mountpoint')
+@click.argument('target_repository', type=to_repository)
 @click.argument('target_table', required=False)
 @click.argument('image', required=False)
 @click.option('-q', 'is_query', is_flag=True, default=False)
 @click.option('-f', 'foreign_tables', is_flag=True, default=False)
-def import_c(mountpoint, table_or_query, target_mountpoint, target_table, image, is_query, foreign_tables):
+def import_c(repository, table_or_query, target_repository, target_table, image, is_query, foreign_tables):
     if is_query and not target_table:
         print("TARGET_TABLE is required when is_query is True!")
         sys.exit(1)
@@ -354,16 +355,16 @@ def import_c(mountpoint, table_or_query, target_mountpoint, target_table, image,
     conn = _conn()
     if not foreign_tables:
         if not image:
-            image = get_current_head(conn, mountpoint)
+            image = get_current_head(conn, repository)
         else:
-            image = get_canonical_image_id(conn, mountpoint, image)
+            image = get_canonical_image_id(conn, repository, image)
     else:
         image = None
-    import_tables(conn, mountpoint, [table_or_query], target_mountpoint, [target_table] if target_table else [],
+    import_tables(conn, repository, [table_or_query], target_repository, [target_table] if target_table else [],
                   image_hash=image, foreign_tables=foreign_tables, table_queries=[] if not is_query else [True])
 
-    print("%s:%s has been imported from %s:%s%s" % (target_mountpoint, target_table, mountpoint, table_or_query,
-                                                    (' (%s)' % image[:12] if image else '')))
+    print("%s:%s has been imported from %s:%s%s" % (str(target_repository), target_table, str(repository),
+                                                    table_or_query, (' (%s)' % image[:12] if image else '')))
 
     conn.commit()
 
@@ -378,54 +379,54 @@ def cleanup_c():
 
 
 @click.command(name='provenance')
-@click.argument('mountpoint')
+@click.argument('repository', type=to_repository)
 @click.argument('snapshot_or_tag')
 @click.option('-f', '--full', required=False, is_flag=True, help='Recreate the sgfile used to create this image')
 @click.option('-e', '--error-on-end', required=False, default=True, is_flag=True,
               help='If False, bases the recreated sgfile on the last image where the provenance chain breaks')
-def provenance_c(mountpoint, snapshot_or_tag, full, error_on_end):
+def provenance_c(repository, snapshot_or_tag, full, error_on_end):
     conn = _conn()
-    snapshot = tag_or_hash_to_actual_hash(conn, mountpoint, snapshot_or_tag)
+    snapshot = tag_or_hash_to_actual_hash(conn, repository, snapshot_or_tag)
 
     if full:
-        sgfile_commands = image_hash_to_sgfile(conn, mountpoint, snapshot, error_on_end)
-        print("# sgfile commands used to recreate %s:%s" % (mountpoint, snapshot))
+        sgfile_commands = image_hash_to_sgfile(conn, repository, snapshot, error_on_end)
+        print("# sgfile commands used to recreate %s:%s" % (str(repository), snapshot))
         print('\n'.join(sgfile_commands))
     else:
-        result = provenance(conn, mountpoint, snapshot)
-        print("%s:%s depends on:" % (mountpoint, snapshot))
+        result = provenance(conn, repository, snapshot)
+        print("%s:%s depends on:" % (str(repository), snapshot))
         print('\n'.join("%s:%s" % rs for rs in result))
     conn.close()
 
 
 @click.command(name='rerun')
-@click.argument('mountpoint')
+@click.argument('repository', type=to_repository)
 @click.argument('snapshot_or_tag')
 @click.option('-u', '--update', is_flag=True, help='Rederive the image against the latest version of all dependencies.')
-@click.option('-i', '--repo-image', multiple=True, type=(str, str))
-def rerun_c(mountpoint, snapshot_or_tag, update, repo_image):
+@click.option('-i', '--repo-image', multiple=True, type=(to_repository, str))
+def rerun_c(repository, snapshot_or_tag, update, repo_image):
     conn = _conn()
-    snapshot = tag_or_hash_to_actual_hash(conn, mountpoint, snapshot_or_tag)
+    snapshot = tag_or_hash_to_actual_hash(conn, repository, snapshot_or_tag)
 
     # Replace the sources used to construct the image with either the latest ones or the images specified by the user.
     # This doesn't require us at this point to have pulled all the dependencies: the sgfile executor will do it
     # after we feed in the reconstructed and patched sgfile.
-    deps = {k: v for k, v in provenance(conn, mountpoint, snapshot)}
+    deps = {k: v for k, v in provenance(conn, repository, snapshot)}
     new_images = {repo: image for repo, image in repo_image} if not update \
         else {repo: 'latest' for repo, _ in deps.items()}
     deps.update(new_images)
 
-    print("Rerunning %s:%s against:" % (mountpoint, snapshot))
+    print("Rerunning %s:%s against:" % (str(repository), snapshot))
     print('\n'.join("%s:%s" % rs for rs in new_images.items()))
 
-    rerun_image_with_replacement(conn, mountpoint, snapshot, new_images)
+    rerun_image_with_replacement(conn, repository, snapshot, new_images)
 
     conn.commit()
     conn.close()
 
 
 @click.command(name='publish')
-@click.argument('repository')
+@click.argument('repository', type=to_repository)
 @click.argument('tag')
 @click.option('-r', '--readme', type=click.File('r'))
 @click.option('--skip-provenance', is_flag=True, help='Don''t include provenance in the published information.')

--- a/splitgraph/commandline.py
+++ b/splitgraph/commandline.py
@@ -283,7 +283,7 @@ def pull_c(mountpoint, remote, download_all):
 @click.option('-d', '--download-all', help='Download all objects immediately instead on checkout.')
 def clone_c(remote_repository, local_repository, download_all):
     conn = _conn()
-    clone(conn, remote_repository, local_mountpoint=local_repository, download_all=download_all)
+    clone(conn, remote_repository, local_repository=local_repository, download_all=download_all)
     conn.commit()
 
 
@@ -360,7 +360,7 @@ def import_c(mountpoint, table_or_query, target_mountpoint, target_table, image,
     else:
         image = None
     import_tables(conn, mountpoint, [table_or_query], target_mountpoint, [target_table] if target_table else [],
-                  image_hash=image, table_queries=[] if not is_query else [True], foreign_tables=foreign_tables)
+                  image_hash=image, foreign_tables=foreign_tables, table_queries=[] if not is_query else [True])
 
     print("%s:%s has been imported from %s:%s%s" % (target_mountpoint, target_table, mountpoint, table_or_query,
                                                     (' (%s)' % image[:12] if image else '')))

--- a/splitgraph/commandline.py
+++ b/splitgraph/commandline.py
@@ -15,9 +15,10 @@ from splitgraph.commands.publish import publish
 from splitgraph.config.repo_lookups import get_remote_connection_params
 from splitgraph.constants import POSTGRES_CONNECTION, SplitGraphException, serialize_connection_string
 from splitgraph.drawing import render_tree
-from splitgraph.meta_handler.images import get_image_parent, get_all_image_info, get_canonical_image_id
-from splitgraph.meta_handler.misc import get_current_mountpoints_hashes, get_remote_for
-from splitgraph.meta_handler.tables import get_all_tables, get_tables_at, get_table
+from splitgraph.meta_handler.images import get_canonical_image_id
+from splitgraph.meta_handler.misc import get_current_repositories, get_remote_for
+from splitgraph.meta_handler.tables import get_tables_at, get_table
+from splitgraph.pg_utils import get_all_tables
 from splitgraph.meta_handler.tags import get_current_head, get_all_hashes_tags, set_tag, tag_or_hash_to_actual_hash
 from splitgraph.sgfile.execution import execute_commands, rerun_image_with_replacement
 
@@ -37,7 +38,7 @@ def cli():
 def status_c(mountpoint):
     conn = _conn()
     if mountpoint is None:
-        mountpoints = get_current_mountpoints_hashes(conn)
+        mountpoints = get_current_repositories(conn)
         print("Currently mounted databases: ")
         for mp_name, mp_hash in mountpoints:
             # Maybe should also show the remote DB address/server

--- a/splitgraph/commands/checkout.py
+++ b/splitgraph/commands/checkout.py
@@ -4,41 +4,42 @@ from contextlib import contextmanager
 from psycopg2.sql import Identifier, SQL
 
 from splitgraph.commands.misc import delete_objects
-from splitgraph.constants import get_random_object_id, SplitGraphException, SPLITGRAPH_META_SCHEMA
+from splitgraph.constants import get_random_object_id, SplitGraphException, SPLITGRAPH_META_SCHEMA, to_mountpoint
 from splitgraph.meta_handler.images import get_canonical_image_id, get_closest_parent_image_object
 from splitgraph.meta_handler.misc import get_remote_for
 from splitgraph.meta_handler.objects import get_external_object_locations
-from splitgraph.meta_handler.tables import get_all_tables, get_tables_at, get_table_with_format
+from splitgraph.meta_handler.tables import get_tables_at, get_object_for_table
 from splitgraph.meta_handler.tags import get_tagged_id, set_head
 from splitgraph.objects.applying import apply_record_to_staging
 from splitgraph.objects.loading import download_objects
 from splitgraph.pg_audit import has_pending_changes, manage_audit, discard_pending_changes
-from splitgraph.pg_utils import copy_table, get_primary_keys
+from splitgraph.pg_utils import copy_table, get_primary_keys, get_all_tables
 
 
-def materialize_table(conn, mountpoint, image_hash, table, destination, destination_mountpoint=None):
+def materialize_table(conn, repository, image_hash, table, destination, destination_schema=None, namespace=''):
     """
     Materializes a SplitGraph table in the target schema as a normal Postgres table, potentially downloading all
     required objects and using them to reconstruct the table.
 
     :param conn: psycopg connection object
-    :param mountpoint: Target mountpoint to materialize the table in.
+    :param repository: Target mountpoint to materialize the table in.
     :param image_hash: Hash of the commit to get the table from.
     :param table: Name of the table.
     :param destination: Name of the destination table.
-    :param destination_mountpoint: Name of the destination schema.
+    :param destination_schema: Name of the destination schema.
+    :param namespace: Namespace that the repository belongs to
     :return: A set of IDs of downloaded objects used to construct the table.
     """
-    destination_mountpoint = destination_mountpoint or mountpoint
+    destination_schema = destination_schema or to_mountpoint(namespace, repository)
     with conn.cursor() as cur:
         cur.execute(
-            SQL("DROP TABLE IF EXISTS {}.{}").format(Identifier(destination_mountpoint), Identifier(destination)))
+            SQL("DROP TABLE IF EXISTS {}.{}").format(Identifier(destination_schema), Identifier(destination)))
         # Get the closest snapshot from the table's parents
         # and then apply all deltas consecutively from it.
-        object_id, to_apply = get_closest_parent_image_object(conn, mountpoint, table, image_hash)
+        object_id, to_apply = get_closest_parent_image_object(conn, repository, table, image_hash, namespace=namespace)
 
         # Make sure all the objects have been downloaded from remote if it exists
-        remote_info = get_remote_for(conn, mountpoint)
+        remote_info = get_remote_for(conn, repository, namespace=namespace)
         if remote_info:
             remote_conn, _ = remote_info
             object_locations = get_external_object_locations(conn, to_apply + [object_id])
@@ -46,65 +47,68 @@ def materialize_table(conn, mountpoint, image_hash, table, destination, destinat
                                                object_locations=object_locations)
 
         # Copy the given snap id over to "staging"
-        copy_table(conn, SPLITGRAPH_META_SCHEMA, object_id, destination_mountpoint, destination,
+        copy_table(conn, SPLITGRAPH_META_SCHEMA, object_id, destination_schema, destination,
                    with_pk_constraints=True)
         # This is to work around logical replication not reflecting deletions from non-PKd tables. However, this makes
         # it emit all column values in the row, not just the updated ones.
-        if not get_primary_keys(conn, destination_mountpoint, destination):
+        if not get_primary_keys(conn, destination_schema, destination):
             logging.warning("Table %s has no primary key. "
                             "This means that changes will have to be recorded as whole-row.", destination)
-            cur.execute(SQL("ALTER TABLE {}.{} REPLICA IDENTITY FULL").format(Identifier(destination_mountpoint),
+            cur.execute(SQL("ALTER TABLE {}.{} REPLICA IDENTITY FULL").format(Identifier(destination_schema),
                                                                               Identifier(destination)))
         else:
-            cur.execute(SQL("ALTER TABLE {}.{} REPLICA IDENTITY DEFAULT").format(Identifier(destination_mountpoint),
+            cur.execute(SQL("ALTER TABLE {}.{} REPLICA IDENTITY DEFAULT").format(Identifier(destination_schema),
                                                                                  Identifier(destination)))
 
         # Apply the deltas sequentially to the checked out table
         for pack_object in reversed(to_apply):
             logging.info("Applying %s...", pack_object)
-            apply_record_to_staging(conn, pack_object, destination_mountpoint, destination)
+            apply_record_to_staging(conn, pack_object, destination_schema, destination)
 
         return fetched_objects if remote_info else set()
 
 
 @manage_audit
-def checkout(conn, mountpoint, image_hash=None, tag=None, tables=None, keep_downloaded_objects=True):
+def checkout(conn, repository, image_hash=None, tag=None, tables=None, keep_downloaded_objects=True, namespace=''):
     """
     Discards all pending changes in the current mountpoint and checks out an image, changing the current HEAD pointer.
 
+    :param namespace:
     :param conn: psycopg connection object
-    :param mountpoint: Mountpoint to check out.
+    :param repository: Mountpoint to check out.
     :param image_hash: Hash of the image to check out.
     :param tag: Tag of the image to check out. One of `image_hash` or `tag` must be specified.
     :param tables: List of tables to materialize in the mountpoint.
     :param keep_downloaded_objects: If False, deletes externally downloaded objects after they've been used.
+    :param namespace: Namespace
     """
+    target_schema = to_mountpoint(namespace, repository)
     if tables is None:
         tables = []
-    if has_pending_changes(conn, mountpoint):
-        logging.warning("%s has pending changes, discarding...", mountpoint)
-    discard_pending_changes(conn, mountpoint)
+    if has_pending_changes(conn, target_schema):
+        logging.warning("%s has pending changes, discarding...", target_schema)
+    discard_pending_changes(conn, target_schema)
     # Detect the actual schema snap we want to check out
     if image_hash:
         # get_canonical_image_hash called twice if the commandline entry point already called it. How to fix?
-        image_hash = get_canonical_image_id(conn, mountpoint, image_hash)
+        image_hash = get_canonical_image_id(conn, repository, image_hash, namespace=namespace)
     elif tag:
-        image_hash = get_tagged_id(conn, mountpoint, tag)
+        image_hash = get_tagged_id(conn, repository, tag, namespace=namespace)
     else:
         raise SplitGraphException("One of schema_snap or tag must be specified!")
 
-    tables = tables or get_tables_at(conn, mountpoint, image_hash)
+    tables = tables or get_tables_at(conn, repository, image_hash, namespace=namespace)
     with conn.cursor() as cur:
         # Drop all current tables in staging
-        for table in get_all_tables(conn, mountpoint):
-            cur.execute(SQL("DROP TABLE IF EXISTS {}.{}").format(Identifier(mountpoint), Identifier(table)))
+        for table in get_all_tables(conn, target_schema):
+            cur.execute(SQL("DROP TABLE IF EXISTS {}.{}").format(Identifier(target_schema), Identifier(table)))
 
     downloaded_object_ids = set()
     for table in tables:
-        downloaded_object_ids |= materialize_table(conn, mountpoint, image_hash, table, table)
+        downloaded_object_ids |= materialize_table(conn, repository, image_hash, table, table, namespace=namespace)
 
     # Repoint the current HEAD for this mountpoint to the new snap ID
-    set_head(conn, mountpoint, image_hash)
+    set_head(conn, repository, image_hash, namespace=namespace)
 
     if not keep_downloaded_objects:
         logging.info("Removing %d downloaded objects from cache..." % len(downloaded_object_ids))
@@ -112,28 +116,28 @@ def checkout(conn, mountpoint, image_hash=None, tag=None, tables=None, keep_down
 
 
 @contextmanager
-def materialized_table(conn, mountpoint, table_name, image_hash):
+def materialized_table(conn, repository, table_name, image_hash, namespace=''):
     """A context manager that returns a pointer to a read-only materialized table in a given image.
     If the table is already stored as a SNAP, this doesn't use any extra space.
     Otherwise, the table is materialized and deleted on exit from the context manager.
 
+    :param namespace: Namespace
     :param conn: Psycopg connection object
-    :param mountpoint: Mounpoint that the table belongs to
+    :param repository: Mounpoint that the table belongs to
     :param table_name: Name of the table
     :param image_hash: Image hash to materialize
-    :return: (mountpoint, table_name) where the materialized table is located.
+    :return: (schema, table_name) where the materialized table is located.
         The table must not be changed, as it might be a pointer to a real SG SNAP object.
     """
     if image_hash is None:
         # No snapshot -- just return the current staging table.
-        yield mountpoint, table_name
+        yield to_mountpoint(namespace, repository), table_name
     # See if the table snapshot already exists, otherwise reconstruct it
-    object_id = get_table_with_format(conn, mountpoint, table_name, image_hash, 'SNAP')
+    object_id = get_object_for_table(conn, repository, table_name, image_hash, 'SNAP', namespace=namespace)
     if object_id is None:
         # Materialize the SNAP into a new object
         new_id = get_random_object_id()
-        materialize_table(conn, mountpoint, image_hash, table_name, new_id,
-                          destination_mountpoint=SPLITGRAPH_META_SCHEMA)
+        materialize_table(conn, repository, image_hash, table_name, new_id, destination_schema=SPLITGRAPH_META_SCHEMA)
         yield SPLITGRAPH_META_SCHEMA, new_id
         # Maybe some cache management/expiry strategies here
         delete_objects(conn, [new_id])

--- a/splitgraph/commands/checkout.py
+++ b/splitgraph/commands/checkout.py
@@ -86,7 +86,7 @@ def checkout(conn, mountpoint, image_hash=None, tag=None, tables=None, keep_down
     discard_pending_changes(conn, mountpoint)
     # Detect the actual schema snap we want to check out
     if image_hash:
-        # get_canonical_snap_id called twice if the commandline entry point already called it. How to fix?
+        # get_canonical_image_hash called twice if the commandline entry point already called it. How to fix?
         image_hash = get_canonical_image_id(conn, mountpoint, image_hash)
     elif tag:
         image_hash = get_tagged_id(conn, mountpoint, tag)

--- a/splitgraph/commands/commit.py
+++ b/splitgraph/commands/commit.py
@@ -3,7 +3,6 @@ from random import getrandbits
 
 from psycopg2.sql import SQL, Identifier
 
-from splitgraph.constants import to_mountpoint
 from splitgraph.meta_handler.common import ensure_metadata_schema
 from splitgraph.meta_handler.images import add_new_image
 from splitgraph.meta_handler.misc import table_schema_changed
@@ -15,20 +14,19 @@ from splitgraph.objects.creation import record_table_as_diff, record_table_as_sn
 from splitgraph.pg_audit import manage_audit_triggers, discard_pending_changes
 
 
-def commit(conn, repository, image_hash=None, include_snap=False, comment=None, namespace=''):
+def commit(conn, repository, image_hash=None, include_snap=False, comment=None):
     """
     Commits all pending changes to a given mountpoint, creating a new image.
 
-    :param namespace:
     :param conn: psycopg connection object.
-    :param repository: Mountpoint to commit.
+    :param repository: Repository to commit.
     :param image_hash: Hash of the commit. Chosen by random if unspecified.
     :param include_snap: If True, also creates a SNAP object with a full copy of the table. This will speed up
         checkouts, but consumes extra space.
     :param comment: Optional comment to add to the commit.
     :return: The image hash the current state of the mountpoint was committed under.
     """
-    target_schema = to_mountpoint(namespace, repository)
+    target_schema = repository.to_schema()
 
     ensure_metadata_schema(conn)
     conn.commit()
@@ -36,13 +34,13 @@ def commit(conn, repository, image_hash=None, include_snap=False, comment=None, 
 
     logging.info("Committing %s...", target_schema)
 
-    head = get_current_head(conn, repository, namespace=namespace)
+    head = get_current_head(conn, repository)
 
     if image_hash is None:
         image_hash = "%0.2x" % getrandbits(256)
 
     # Add the new snap ID to the tree
-    add_new_image(conn, repository, head, image_hash, comment=comment, namespace=namespace)
+    add_new_image(conn, repository, head, image_hash, comment=comment)
 
     commit_pending_changes(conn, repository, head, image_hash, include_snap=include_snap)
 
@@ -52,7 +50,7 @@ def commit(conn, repository, image_hash=None, include_snap=False, comment=None, 
     return image_hash
 
 
-def commit_pending_changes(conn, repository, current_head, image_hash, include_snap=False, namespace=''):
+def commit_pending_changes(conn, repository, current_head, image_hash, include_snap=False):
     """
     Reads the recorded pending changes to all tables in a given mountpoint, conflates them and possibly stores them
     as new object(s) as follows:
@@ -67,39 +65,37 @@ def commit_pending_changes(conn, repository, current_head, image_hash, include_s
     :param current_head: Current HEAD pointer to base the commit on.
     :param image_hash: Hash of the image to commit changes under.
     :param include_snap: If True, also stores the table as a SNAP.
-    :param namespace:
     """
 
-    target_schema = to_mountpoint(namespace, repository)
+    target_schema = repository.to_schema()
     with conn.cursor() as cur:
         cur.execute(SQL("""SELECT DISTINCT(table_name) FROM {}.{}
                        WHERE schema_name = %s""").format(Identifier("audit"),
-                                                         Identifier("logged_actions")),
-                    (to_mountpoint(namespace, repository),))
+                                                         Identifier("logged_actions")), (target_schema,))
         changed_tables = [c[0] for c in cur.fetchall()]
     for table in get_all_tables(conn, target_schema):
-        table_info = get_table(conn, repository, table, current_head, namespace)
+        table_info = get_table(conn, repository, table, current_head)
         # Table already exists at the current HEAD
         if table_info:
             # If there has been a schema change, we currently just snapshot the whole table.
             # This is obviously wasteful (say if just one column has been added/dropped or we added a PK,
             # but it's a starting point to support schema changes.
-            if table_schema_changed(conn, repository, table, image_1=current_head, image_2=None, namespace=namespace):
-                record_table_as_snap(conn, repository, image_hash, table, table_info, namespace)
+            if table_schema_changed(conn, repository, table, image_1=current_head, image_2=None):
+                record_table_as_snap(conn, repository, image_hash, table, table_info)
                 continue
 
             if table in changed_tables:
-                record_table_as_diff(conn, repository, image_hash, table, table_info, namespace=namespace)
+                record_table_as_diff(conn, repository, image_hash, table, table_info)
             else:
                 # If the table wasn't changed, point the commit to the old table objects (including
                 # any of snaps or diffs).
                 # This feels slightly weird: are we denormalized here?
                 for prev_object_id, _ in table_info:
-                    register_table(conn, repository, table, image_hash, prev_object_id, namespace)
+                    register_table(conn, repository, table, image_hash, prev_object_id)
 
         # If table created (or we want to store a snap anyway), copy the whole table over as well.
         if not table_info or include_snap:
-            record_table_as_snap(conn, repository, image_hash, table, table_info, namespace)
+            record_table_as_snap(conn, repository, image_hash, table, table_info)
 
     # Make sure that all pending changes have been discarded by this point (e.g. if we created just a snapshot for
     # some tables and didn't consume the WAL).

--- a/splitgraph/commands/commit.py
+++ b/splitgraph/commands/commit.py
@@ -3,51 +3,56 @@ from random import getrandbits
 
 from psycopg2.sql import SQL, Identifier
 
+from splitgraph.constants import to_mountpoint
 from splitgraph.meta_handler.common import ensure_metadata_schema
 from splitgraph.meta_handler.images import add_new_image
 from splitgraph.meta_handler.misc import table_schema_changed
 from splitgraph.meta_handler.objects import register_table
-from splitgraph.meta_handler.tables import get_all_tables, get_table
+from splitgraph.meta_handler.tables import get_table
+from splitgraph.pg_utils import get_all_tables
 from splitgraph.meta_handler.tags import get_current_head, set_head
 from splitgraph.objects.creation import record_table_as_diff, record_table_as_snap
 from splitgraph.pg_audit import manage_audit_triggers, discard_pending_changes
 
 
-def commit(conn, mountpoint, image_hash=None, include_snap=False, comment=None):
+def commit(conn, repository, image_hash=None, include_snap=False, comment=None, namespace=''):
     """
     Commits all pending changes to a given mountpoint, creating a new image.
 
+    :param namespace:
     :param conn: psycopg connection object.
-    :param mountpoint: Mountpoint to commit.
+    :param repository: Mountpoint to commit.
     :param image_hash: Hash of the commit. Chosen by random if unspecified.
     :param include_snap: If True, also creates a SNAP object with a full copy of the table. This will speed up
         checkouts, but consumes extra space.
     :param comment: Optional comment to add to the commit.
     :return: The image hash the current state of the mountpoint was committed under.
     """
+    target_schema = to_mountpoint(namespace, repository)
+
     ensure_metadata_schema(conn)
     conn.commit()
     manage_audit_triggers(conn)
 
-    logging.info("Committing %s...", mountpoint)
+    logging.info("Committing %s...", target_schema)
 
-    head = get_current_head(conn, mountpoint)
+    head = get_current_head(conn, repository, namespace=namespace)
 
     if image_hash is None:
         image_hash = "%0.2x" % getrandbits(256)
 
     # Add the new snap ID to the tree
-    add_new_image(conn, mountpoint, head, image_hash, comment=comment)
+    add_new_image(conn, repository, head, image_hash, comment=comment, namespace=namespace)
 
-    commit_pending_changes(conn, mountpoint, head, image_hash, include_snap=include_snap)
+    commit_pending_changes(conn, repository, head, image_hash, include_snap=include_snap)
 
-    set_head(conn, mountpoint, image_hash)
+    set_head(conn, repository, image_hash)
     conn.commit()
     manage_audit_triggers(conn)
     return image_hash
 
 
-def commit_pending_changes(conn, mountpoint, current_head, image_hash, include_snap=False):
+def commit_pending_changes(conn, repository, current_head, image_hash, include_snap=False, namespace=''):
     """
     Reads the recorded pending changes to all tables in a given mountpoint, conflates them and possibly stores them
     as new object(s) as follows:
@@ -58,41 +63,45 @@ def commit_pending_changes(conn, mountpoint, current_head, image_hash, include_s
         * Otherwise, the table is stored as a conflated (1 change per PK) DIFF object and an optional SNAP.
 
     :param conn: psycopg connection object.
-    :param mountpoint: Mountpoint to commit.
+    :param repository: Repository to commit.
     :param current_head: Current HEAD pointer to base the commit on.
     :param image_hash: Hash of the image to commit changes under.
     :param include_snap: If True, also stores the table as a SNAP.
+    :param namespace:
     """
+
+    target_schema = to_mountpoint(namespace, repository)
     with conn.cursor() as cur:
         cur.execute(SQL("""SELECT DISTINCT(table_name) FROM {}.{}
                        WHERE schema_name = %s""").format(Identifier("audit"),
-                                                         Identifier("logged_actions")), (mountpoint,))
+                                                         Identifier("logged_actions")),
+                    (to_mountpoint(namespace, repository),))
         changed_tables = [c[0] for c in cur.fetchall()]
-    for table in get_all_tables(conn, mountpoint):
-        table_info = get_table(conn, mountpoint, table, current_head)
+    for table in get_all_tables(conn, target_schema):
+        table_info = get_table(conn, repository, table, current_head, namespace)
         # Table already exists at the current HEAD
         if table_info:
             # If there has been a schema change, we currently just snapshot the whole table.
             # This is obviously wasteful (say if just one column has been added/dropped or we added a PK,
             # but it's a starting point to support schema changes.
-            if table_schema_changed(conn, mountpoint, table, image_1=current_head, image_2=None):
-                record_table_as_snap(conn, mountpoint, image_hash, table, table_info)
+            if table_schema_changed(conn, repository, table, image_1=current_head, image_2=None, namespace=namespace):
+                record_table_as_snap(conn, repository, image_hash, table, table_info, namespace)
                 continue
 
             if table in changed_tables:
-                record_table_as_diff(conn, mountpoint, image_hash, table, table_info)
+                record_table_as_diff(conn, repository, image_hash, table, table_info, namespace=namespace)
             else:
                 # If the table wasn't changed, point the commit to the old table objects (including
                 # any of snaps or diffs).
                 # This feels slightly weird: are we denormalized here?
                 for prev_object_id, _ in table_info:
-                    register_table(conn, mountpoint, table, image_hash, prev_object_id)
+                    register_table(conn, repository, table, image_hash, prev_object_id, namespace)
 
         # If table created (or we want to store a snap anyway), copy the whole table over as well.
         if not table_info or include_snap:
-            record_table_as_snap(conn, mountpoint, image_hash, table, table_info)
+            record_table_as_snap(conn, repository, image_hash, table, table_info, namespace)
 
     # Make sure that all pending changes have been discarded by this point (e.g. if we created just a snapshot for
     # some tables and didn't consume the WAL).
     # NB if we allow partial commits, this will have to be changed (only discard for committed tables).
-    discard_pending_changes(conn, mountpoint)
+    discard_pending_changes(conn, target_schema)

--- a/splitgraph/commands/diff.py
+++ b/splitgraph/commands/diff.py
@@ -4,8 +4,8 @@ from psycopg2.sql import SQL, Identifier
 
 from splitgraph.commands.checkout import materialized_table
 from splitgraph.commands.misc import table_exists_at, find_path
-from splitgraph.constants import SPLITGRAPH_META_SCHEMA
-from splitgraph.meta_handler.tables import get_table_with_format, get_table
+from splitgraph.constants import SPLITGRAPH_META_SCHEMA, to_mountpoint
+from splitgraph.meta_handler.tables import get_object_for_table, get_table
 from splitgraph.meta_handler.tags import get_current_head
 from splitgraph.objects.utils import get_replica_identity, convert_audit_change, KIND
 
@@ -17,14 +17,15 @@ def _changes_to_aggregation(query_result, initial=None):
     return tuple(result)
 
 
-def diff(conn, mountpoint, table_name, image_1, image_2, aggregate=False):
+def diff(conn, repository, table_name, image_1, image_2, aggregate=False, namespace=''):
     """
     Compares the state of the table in different images. If the two images are on the same path in the commit tree,
     it doesn't need to materialize any of the tables and simply aggregates their DIFF objects to produce a complete
     changelog. Otherwise, it materializes both tables into a temporary space and compares them row-to-row.
 
+    :param namespace:
     :param conn: psycopg connection
-    :param mountpoint: Mounpoint where the table exists.
+    :param repository: Mounpoint where the table exists.
     :param table_name: Name of the table.
     :param image_1: First image. If None, uses the state of the current staging area.
     :param image_2: Second image. If None, uses the state of the current staging area.
@@ -44,29 +45,29 @@ def diff(conn, mountpoint, table_name, image_1, image_2, aggregate=False):
     with conn.cursor() as cur:
         # If the table doesn't exist in the first or the second image, short-circuit and
         # return the bool.
-        if not table_exists_at(conn, mountpoint, table_name, image_1):
+        if not table_exists_at(conn, repository, table_name, image_1, namespace):
             return True
-        if not table_exists_at(conn, mountpoint, table_name, image_2):
+        if not table_exists_at(conn, repository, table_name, image_2, namespace):
             return False
 
         # Special case: if diffing HEAD and staging, then just return the current pending changes.
-        head = get_current_head(conn, mountpoint)
+        head = get_current_head(conn, repository, namespace)
 
         if image_1 == head and image_2 is None:
-            changes = dump_pending_changes(conn, mountpoint, table_name, aggregate=aggregate)
+            changes = dump_pending_changes(conn, to_mountpoint(namespace, repository), table_name, aggregate=aggregate)
             return changes if not aggregate else _changes_to_aggregation(changes)
 
         # If the table is the same in the two images, short circuit as well.
-        if set(get_table(conn, mountpoint, table_name, image_1)) == \
-                set(get_table(conn, mountpoint, table_name, image_2)):
+        if set(get_table(conn, repository, table_name, image_1, namespace)) == \
+                set(get_table(conn, repository, table_name, image_2, namespace)):
             return [] if not aggregate else (0, 0, 0)
 
         # Otherwise, check if snap_1 is a parent of snap_2, then we can merge all the diffs.
-        path = find_path(conn, mountpoint, image_1, (image_2 if image_2 is not None else head))
+        path = find_path(conn, repository, image_1, (image_2 if image_2 is not None else head))
         if path is not None:
             result = [] if not aggregate else (0, 0, 0)
             for image in reversed(path):
-                diff_id = get_table_with_format(conn, mountpoint, table_name, image, 'DIFF')
+                diff_id = get_object_for_table(conn, repository, table_name, image, 'DIFF', '')
                 if diff_id is None:
                     # TODO This entry on the path between the two nodes is a snapshot -- meaning there
                     # has been a schema change and we can't just accumulate diffs. For now, we just pretend
@@ -90,7 +91,7 @@ def diff(conn, mountpoint, table_name, image_1, image_2, aggregate=False):
 
             # If snap_2 is staging, also include all changes that have happened since the last commit.
             if image_2 is None:
-                changes = dump_pending_changes(conn, mountpoint, table_name, aggregate=aggregate)
+                changes = dump_pending_changes(conn, repository, table_name, aggregate=aggregate)
                 if aggregate:
                     result = _changes_to_aggregation(changes, result)
                 else:
@@ -98,8 +99,8 @@ def diff(conn, mountpoint, table_name, image_1, image_2, aggregate=False):
             return result
 
         # Finally, resort to manual diffing (images on different branches or reverse comparison order).
-        with materialized_table(conn, mountpoint, table_name, image_1) as (mp_1, table_1):
-            with materialized_table(conn, mountpoint, table_name, image_2) as (mp_2, table_2):
+        with materialized_table(conn, repository, table_name, image_1) as (mp_1, table_1):
+            with materialized_table(conn, repository, table_name, image_2) as (mp_2, table_2):
                 # Check both tables out at the same time since then table_2 calculation can be based
                 # on table_1's snapshot.
                 cur.execute(SQL("SELECT * FROM {}.{}").format(Identifier(mp_1),
@@ -115,23 +116,22 @@ def diff(conn, mountpoint, table_name, image_1, image_2, aggregate=False):
         return [(1, r) for r in left if r not in right] + [(0, r) for r in right if r not in left]
 
 
-def dump_pending_changes(conn, mountpoint, table, aggregate=False):
-    # First, make sure we're up to date on changes.
+def dump_pending_changes(conn, schema, table, aggregate=False):
     with conn.cursor() as cur:
         if aggregate:
             cur.execute(SQL(
                 "SELECT action, count(action) FROM {}.{} "
                 "WHERE schema_name = %s AND table_name = %s GROUP BY action").format(Identifier("audit"),
                                                                                      Identifier("logged_actions")),
-                        (mountpoint, table))
+                        (schema, table))
             return [(KIND[k], c) for k, c in cur.fetchall()]
 
         cur.execute(SQL(
             "SELECT action, row_data, changed_fields FROM {}.{} "
             "WHERE schema_name = %s AND table_name = %s").format(Identifier("audit"),
                                                                  Identifier("logged_actions")),
-                    (mountpoint, table))
-        repl_id = get_replica_identity(conn, mountpoint, table)
+                    (schema, table))
+        repl_id = get_replica_identity(conn, schema, table)
         ri_cols, _ = zip(*repl_id)
         result = []
         for action, row_data, changed_fields in cur:

--- a/splitgraph/commands/importing.py
+++ b/splitgraph/commands/importing.py
@@ -105,9 +105,9 @@ def _import_tables(conn, mountpoint, image_hash, tables, target_mountpoint, targ
     # Register the existing tables at the new commit as well.
     if head is not None:
         with conn.cursor() as cur:
-            cur.execute(SQL("""INSERT INTO {0}.tables (mountpoint, snap_id, table_name, object_id)
+            cur.execute(SQL("""INSERT INTO {0}.tables (mountpoint, image_hash, table_name, object_id)
                 (SELECT %s, %s, table_name, object_id FROM {0}.tables
-                WHERE mountpoint = %s AND snap_id = %s)""").format(Identifier(SPLITGRAPH_META_SCHEMA)),
+                WHERE mountpoint = %s AND image_hash = %s)""").format(Identifier(SPLITGRAPH_META_SCHEMA)),
                         (target_mountpoint, target_hash, target_mountpoint, head))
     set_head(conn, target_mountpoint, target_hash)
     return target_hash

--- a/splitgraph/commands/importing.py
+++ b/splitgraph/commands/importing.py
@@ -5,7 +5,7 @@ from psycopg2.sql import Identifier, SQL
 from splitgraph.commands.checkout import materialize_table, checkout
 from splitgraph.commands.misc import unmount
 from splitgraph.commands.push_pull import clone
-from splitgraph.constants import SPLITGRAPH_META_SCHEMA, get_random_object_id
+from splitgraph.constants import SPLITGRAPH_META_SCHEMA, get_random_object_id, Repository
 from splitgraph.meta_handler.images import add_new_image
 from splitgraph.meta_handler.objects import register_table, register_object
 from splitgraph.meta_handler.tables import get_tables_at, get_table
@@ -15,16 +15,16 @@ from splitgraph.pg_utils import copy_table, get_primary_keys, execute_sql_in, ge
 
 
 @manage_audit
-def import_tables(conn, mountpoint, tables, target_mountpoint, target_tables, image_hash=None, foreign_tables=False,
+def import_tables(conn, repository, tables, target_repository, target_tables, image_hash=None, foreign_tables=False,
                   do_checkout=True, target_hash=None, table_queries=[]):
     """
     Creates a new commit in target_mountpoint with one or more tables linked to already-existing tables.
     After this operation, the HEAD of the target mountpoint moves to the new commit and the new tables are materialized.
 
     :param conn: psycopg connection object
-    :param mountpoint: Mountpoint to get the source table(s) from.
+    :param repository: Mountpoint to get the source table(s) from.
     :param tables: List of tables to import. If empty, imports all tables.
-    :param target_mountpoint: Mountpoint to import tables into.
+    :param target_repository: Mountpoint to import tables into.
     :param target_tables: If not empty, must be the list of the same length as `tables` specifying names to store them
         under in the target mountpoint.
     :param image_hash: Commit hash on the source mountpoint to import tables from.
@@ -44,11 +44,11 @@ def import_tables(conn, mountpoint, tables, target_mountpoint, target_tables, im
     target_hash = target_hash or "%0.2x" % getrandbits(256)
 
     if not foreign_tables:
-        image_hash = image_hash or get_current_head(conn, mountpoint)
+        image_hash = image_hash or get_current_head(conn, repository)
 
     if not tables:
-        tables = get_tables_at(conn, mountpoint, image_hash) if not foreign_tables \
-            else get_all_foreign_tables(conn, mountpoint)
+        tables = get_tables_at(conn, repository, image_hash) if not foreign_tables \
+            else get_all_foreign_tables(conn, repository.to_schema())
     if not target_tables:
         if table_queries:
             raise ValueError("target_tables has to be defined if table_queries is True!")
@@ -58,29 +58,29 @@ def import_tables(conn, mountpoint, tables, target_mountpoint, target_tables, im
     if len(tables) != len(target_tables) or len(tables) != len(table_queries):
         raise ValueError("tables, target_tables and table_queries have mismatching lengths!")
 
-    existing_tables = get_all_tables(conn, target_mountpoint)
+    existing_tables = get_all_tables(conn, target_repository.to_schema())
     clashing = [t for t in target_tables if t in existing_tables]
     if clashing:
-        raise ValueError("Table(s) %r already exist(s) at %s!" % (clashing, target_mountpoint))
+        raise ValueError("Table(s) %r already exist(s) at %s!" % (clashing, target_repository))
 
-    return _import_tables(conn, mountpoint, image_hash, tables, target_mountpoint, target_hash, target_tables,
+    return _import_tables(conn, repository, image_hash, tables, target_repository, target_hash, target_tables,
                           do_checkout, table_queries, foreign_tables)
 
 
-def _import_tables(conn, mountpoint, image_hash, tables, target_mountpoint, target_hash, target_tables, do_checkout,
+def _import_tables(conn, repository, image_hash, tables, target_repository, target_hash, target_tables, do_checkout,
                    table_queries, foreign_tables):
     with conn.cursor() as cur:
-        cur.execute(SQL("CREATE SCHEMA IF NOT EXISTS {}").format(Identifier(target_mountpoint)))
+        cur.execute(SQL("CREATE SCHEMA IF NOT EXISTS {}").format(Identifier(target_repository.to_schema())))
 
-    head = get_current_head(conn, target_mountpoint, raise_on_none=False)
+    head = get_current_head(conn, target_repository, raise_on_none=False)
     # Add the new snap ID to the tree
-    add_new_image(conn, target_mountpoint, head, target_hash, comment="Importing %s from %s" % (tables, mountpoint))
+    add_new_image(conn, target_repository, head, target_hash, comment="Importing %s from %s" % (tables, repository))
 
     if any(table_queries) and not foreign_tables:
-        # If we want to run some queries against the source mountpoint to create the new tables,
+        # If we want to run some queries against the source repository to create the new tables,
         # we have to materialize it fully.
-        checkout(conn, mountpoint, image_hash)
-    # Materialize the actual tables in the target mountpoint and register them.
+        checkout(conn, repository, image_hash)
+    # Materialize the actual tables in the target repository and register them.
     for table, target_table, is_query in zip(tables, target_tables, table_queries):
         if foreign_tables or is_query:
             # For foreign tables/SELECT queries, we define a new object/table instead.
@@ -88,48 +88,50 @@ def _import_tables(conn, mountpoint, image_hash, tables, target_mountpoint, targ
             if is_query:
                 # is_query precedes foreign_tables: if we're importing using a query, we don't care if it's a
                 # foreign table or not since we're storing it as a full snapshot.
-                execute_sql_in(conn, mountpoint,
+                execute_sql_in(conn, repository.to_schema(),
                                SQL("CREATE TABLE {}.{} AS ").format(Identifier(SPLITGRAPH_META_SCHEMA),
                                                                     Identifier(object_id)) + SQL(table))
             elif foreign_tables:
-                copy_table(conn, mountpoint, table, SPLITGRAPH_META_SCHEMA, object_id)
+                copy_table(conn, repository.to_schema(), table, SPLITGRAPH_META_SCHEMA, object_id)
 
-            _register_and_checkout_new_table(conn, do_checkout, object_id, target_hash, target_mountpoint, target_table)
+            _register_and_checkout_new_table(conn, do_checkout, object_id, target_hash, target_repository, target_table)
         else:
-            for object_id, _ in get_table(conn, mountpoint, table, image_hash):
-                register_table(conn, target_mountpoint, target_table, target_hash, object_id)
+            for object_id, _ in get_table(conn, repository, table, image_hash):
+                register_table(conn, target_repository, target_table, target_hash, object_id)
             if do_checkout:
-                materialize_table(conn, mountpoint, image_hash, table, target_table,
-                                  destination_schema=target_mountpoint)
+                materialize_table(conn, repository, image_hash, table, target_table,
+                                  destination_schema=target_repository.to_schema())
     # Register the existing tables at the new commit as well.
     if head is not None:
         with conn.cursor() as cur:
-            cur.execute(SQL("""INSERT INTO {0}.tables (mountpoint, image_hash, table_name, object_id)
-                (SELECT %s, %s, table_name, object_id FROM {0}.tables
-                WHERE mountpoint = %s AND image_hash = %s)""").format(Identifier(SPLITGRAPH_META_SCHEMA)),
-                        (target_mountpoint, target_hash, target_mountpoint, head))
-    set_head(conn, target_mountpoint, target_hash)
+            cur.execute(SQL("""INSERT INTO {0}.tables (namespace, repository, image_hash, table_name, object_id)
+                (SELECT %s, %s, %s, table_name, object_id FROM {0}.tables
+                WHERE namespace = %s AND repository = %s AND image_hash = %s)""")
+                        .format(Identifier(SPLITGRAPH_META_SCHEMA)),
+                        (target_repository.namespace, target_repository.repository,
+                         target_hash, target_repository.namespace, target_repository.repository, head))
+    set_head(conn, target_repository, target_hash)
     return target_hash
 
 
-def _register_and_checkout_new_table(conn, do_checkout, object_id, target_hash, target_mountpoint, target_table):
+def _register_and_checkout_new_table(conn, do_checkout, object_id, target_hash, target_repository, target_table):
     # Might not be necessary if we don't actually want to materialize the snapshot (wastes space).
-    register_object(conn, object_id, 'SNAP', parent_object=None)
-    register_table(conn, target_mountpoint, target_table, target_hash, object_id)
+    register_object(conn, object_id, 'SNAP', parent_object=None, original_namespace=target_repository.namespace)
+    register_table(conn, target_repository, target_table, target_hash, object_id)
     if do_checkout:
-        copy_table(conn, SPLITGRAPH_META_SCHEMA, object_id, target_mountpoint, target_table)
-        if not get_primary_keys(conn, target_mountpoint, target_table):
+        copy_table(conn, SPLITGRAPH_META_SCHEMA, object_id, target_repository.to_schema(), target_table)
+        if not get_primary_keys(conn, target_repository.to_schema(), target_table):
             logging.warning(
                 "Table %s has no primary key. This means that changes will have to be recorded as "
                 "whole-row.", target_table)
             with conn.cursor() as cur:
                 cur.execute(
-                    SQL("ALTER TABLE {}.{} REPLICA IDENTITY FULL").format(Identifier(target_mountpoint),
+                    SQL("ALTER TABLE {}.{} REPLICA IDENTITY FULL").format(Identifier(target_repository.to_schema()),
                                                                           Identifier(target_table)))
 
 
-def import_table_from_unmounted(conn, remote_conn_string, remote_mountpoint, remote_tables, remote_image_hash,
-                                target_mountpoint, target_tables, target_hash=None):
+def import_table_from_remote(conn, remote_conn_string, remote_repository, remote_tables, remote_image_hash,
+                             target_repository, target_tables, target_hash=None):
     # Shorthand for importing one or more tables from a yet-uncloned remote. Here, the remote image hash
     # is required, as otherwise we aren't necessarily able to determine what the remote head is.
 
@@ -137,11 +139,12 @@ def import_table_from_unmounted(conn, remote_conn_string, remote_mountpoint, rem
     # metadata (object locations and relationships) into the local mountpoint. However, since the metadata is fairly
     # lightweight (we never download unneeded objects), we just clone it into a temporary mountpoint,
     # do the import into the target and destroy the temporary mp.
-    tmp_mountpoint = remote_mountpoint + '_clone_tmp'
+    tmp_mountpoint = Repository(namespace=remote_repository.namespace, repository=remote_repository.repository +
+                                                                                  '_clone_tmp')
 
-    clone(conn, remote_mountpoint, remote_conn_string=remote_conn_string,
-          local_mountpoint=tmp_mountpoint, download_all=False)
-    import_tables(conn, tmp_mountpoint, remote_tables, target_mountpoint, target_tables, image_hash=remote_image_hash,
+    clone(conn, remote_repository, remote_conn_string=remote_conn_string, local_repository=tmp_mountpoint,
+          download_all=False)
+    import_tables(conn, tmp_mountpoint, remote_tables, target_repository, target_tables, image_hash=remote_image_hash,
                   target_hash=target_hash)
 
     unmount(conn, tmp_mountpoint)

--- a/splitgraph/commands/importing.py
+++ b/splitgraph/commands/importing.py
@@ -7,12 +7,11 @@ from splitgraph.commands.misc import unmount
 from splitgraph.commands.push_pull import clone
 from splitgraph.constants import SPLITGRAPH_META_SCHEMA, get_random_object_id
 from splitgraph.meta_handler.images import add_new_image
-from splitgraph.meta_handler.misc import get_all_foreign_tables
 from splitgraph.meta_handler.objects import register_table, register_object
-from splitgraph.meta_handler.tables import get_all_tables, get_tables_at, get_table
+from splitgraph.meta_handler.tables import get_tables_at, get_table
 from splitgraph.meta_handler.tags import get_current_head, set_head
 from splitgraph.pg_audit import manage_audit
-from splitgraph.pg_utils import copy_table, get_primary_keys, execute_sql_in
+from splitgraph.pg_utils import copy_table, get_primary_keys, execute_sql_in, get_all_tables, get_all_foreign_tables
 
 
 @manage_audit
@@ -101,7 +100,7 @@ def _import_tables(conn, mountpoint, image_hash, tables, target_mountpoint, targ
                 register_table(conn, target_mountpoint, target_table, target_hash, object_id)
             if do_checkout:
                 materialize_table(conn, mountpoint, image_hash, table, target_table,
-                                  destination_mountpoint=target_mountpoint)
+                                  destination_schema=target_mountpoint)
     # Register the existing tables at the new commit as well.
     if head is not None:
         with conn.cursor() as cur:

--- a/splitgraph/commands/misc.py
+++ b/splitgraph/commands/misc.py
@@ -27,7 +27,7 @@ def get_parent_children(conn, mountpoint, image_hash):
     parent = get_image_parent(conn, mountpoint, image_hash)
 
     with conn.cursor() as cur:
-        cur.execute(SQL("""SELECT snap_id FROM {}.snap_tree WHERE mountpoint = %s AND parent_id = %s""").format(
+        cur.execute(SQL("""SELECT image_hash FROM {}.images WHERE mountpoint = %s AND parent_id = %s""").format(
             Identifier(SPLITGRAPH_META_SCHEMA)),
             (mountpoint, image_hash))
         children = [c[0] for c in cur.fetchall()]
@@ -63,8 +63,8 @@ def init(conn, mountpoint):
     """
     with conn.cursor() as cur:
         cur.execute(SQL("CREATE SCHEMA {}").format(Identifier(mountpoint)))
-    snap_id = '0' * 64
-    register_mountpoint(conn, mountpoint, snap_id, tables=[], table_object_ids=[])
+    image_hash = '0' * 64
+    register_mountpoint(conn, mountpoint, image_hash, tables=[], table_object_ids=[])
 
 
 def unmount(conn, mountpoint):
@@ -117,7 +117,7 @@ def cleanup_objects(conn, include_external=False):
 
     # Go through the tables that aren't mountpoint-dependent and delete entries there.
     with conn.cursor() as cur:
-        for table_name in ['object_tree', 'object_locations']:
+        for table_name in ['objects', 'object_locations']:
             query = SQL("DELETE FROM {}.{}").format(Identifier(SPLITGRAPH_META_SCHEMA), Identifier(table_name))
             if primary_objects:
                 query += SQL(" WHERE object_id NOT IN (" + ','.join('%s' for _ in range(len(primary_objects))) + ")")

--- a/splitgraph/commands/misc.py
+++ b/splitgraph/commands/misc.py
@@ -28,9 +28,10 @@ def get_parent_children(conn, repository, image_hash):
     parent = get_image(conn, repository, image_hash).parent_id
 
     with conn.cursor() as cur:
-        cur.execute(SQL("""SELECT image_hash FROM {}.images WHERE mountpoint = %s AND parent_id = %s""").format(
+        cur.execute(SQL("""SELECT image_hash FROM {}.images
+            WHERE namespace = %s AND repository = %s AND parent_id = %s""").format(
             Identifier(SPLITGRAPH_META_SCHEMA)),
-            (repository, image_hash))
+            (repository.namespace, repository.repository, image_hash))
         children = [c[0] for c in cur.fetchall()]
     return parent, children
 

--- a/splitgraph/commands/mounting.py
+++ b/splitgraph/commands/mounting.py
@@ -2,6 +2,7 @@ import logging
 
 from splitgraph.commands.misc import unmount
 from splitgraph.commands.mount_handlers import get_mount_handler
+from splitgraph.constants import to_repository
 from splitgraph.meta_handler.common import ensure_metadata_schema
 
 
@@ -18,7 +19,7 @@ def mount(conn, mountpoint, mount_handler, handler_kwargs):
     mh_func = get_mount_handler(mount_handler)
     logging.info("Connecting to remote server...")
 
-    unmount(conn, mountpoint)
+    unmount(conn, to_repository(mountpoint))
     mh_func(conn, mountpoint, **handler_kwargs)
 
     conn.commit()

--- a/splitgraph/commands/provenance.py
+++ b/splitgraph/commands/provenance.py
@@ -1,31 +1,32 @@
 import logging
 
-from splitgraph.constants import SplitGraphException
-from splitgraph.meta_handler.images import get_image_parent_provenance
+from splitgraph.constants import SplitGraphException, to_repository, Repository
+from splitgraph.meta_handler.images import get_image
 
 
-def provenance(conn, mountpoint, image_hash):
+def provenance(conn, repository, image_hash):
     """
     Inspects the parent chain of an sgfile-generated image to come up with a set of repositories and their hashes
     that it was created from.
 
     :param conn: Psycopg connection object
-    :param mountpoint: Mountpoint that contains the image
+    :param repository: Mountpoint that contains the image
     :param image_hash: Image hash to inspect
-    :return: List of (mountpoint, image_hash)
+    :return: List of (repository, image_hash)
     """
     result = set()
     while image_hash:
-        parent, prov_type, prov_data = get_image_parent_provenance(conn, mountpoint, image_hash)
+        image = get_image(conn, repository, image_hash)
+        parent, prov_type, prov_data = image.parent_id, image.provenance_type, image.provenance_data
         if prov_type == 'IMPORT':
-            result.add((prov_data['source'], prov_data['source_hash']))
+            result.add((Repository(prov_data['source_namespace'], prov_data['source']), prov_data['source_hash']))
         elif prov_type == 'FROM':
             # If we reached "FROM", then that's the first statement in the image build process (as it bases the build
             # on a completely different base image). Otherwise, let's say we have several versions of the source
             # repo and base some sgfile builds on each of them sequentially. In that case, the newest build will
             # have all of the previous FROM statements in it (since we clone the upstream commit history locally
             # and then add the FROM ... provenance data into it).
-            result.add((prov_data, image_hash))
+            result.add((Repository(prov_data['source_namespace'], prov_data['source']), image_hash))
             break
         elif prov_type in (None, 'MOUNT'):
             logging.warning("Image %s has provenance type %s, which means it might not be rederiveable.",
@@ -46,24 +47,25 @@ def prov_command_to_sgfile(prov_type, prov_data, image_hash, source_replacement)
     :return: String with the sgfile command.
     """
     if prov_type == "IMPORT":
-        repo, image = prov_data['source'], prov_data['source_hash']
-        result = "FROM %s:%s IMPORT " % (repo, source_replacement.get(repo, image))
+        repo, image = Repository(prov_data['source_namespace'], prov_data['source']), prov_data['source_hash']
+        result = "FROM %s:%s IMPORT " % (str(repo), source_replacement.get(repo, image))
         result += ", ".join("%s AS %s" % (tn if not q else "{" + tn.replace("}", "\\}") + "}", ta) for tn, ta, q
                             in zip(prov_data['tables'], prov_data['table_aliases'], prov_data['table_queries']))
         return result
     elif prov_type == "FROM":
-        return "FROM %s:%s" % (prov_data, source_replacement.get(prov_data, image_hash))
+        repo = Repository(prov_data['source_namespace'], prov_data['source'])
+        return "FROM %s:%s" % (str(repo), source_replacement.get(repo, image_hash))
     elif prov_type == "SQL":
         return "SQL " + prov_data.replace("\n", "\\\n")
     raise SplitGraphException("Cannot reconstruct provenance %s!" % prov_type)
 
 
-def image_hash_to_sgfile(conn, mountpoint, image_hash, err_on_end=True, source_replacement=None):
+def image_hash_to_sgfile(conn, repository, image_hash, err_on_end=True, source_replacement=None):
     """
     Crawls the image's parent chain to recreates an sgfile that can be used to reconstruct it.
 
     :param conn: Psycopg connection object
-    :param mountpoint: Mountpoint where the image is located.
+    :param repository: Repository where the image is located.
     :param image_hash: Image hash to reconstruct.
     :param err_on_end: If False, when an image with no provenance is reached and it still has a parent, then instead of
         raising an exception, it will base the sgfile (using the FROM command) on that image.
@@ -76,7 +78,8 @@ def image_hash_to_sgfile(conn, mountpoint, image_hash, err_on_end=True, source_r
         source_replacement = {}
     sgfile_commands = []
     while image_hash:
-        parent, prov_type, prov_data = get_image_parent_provenance(conn, mountpoint, image_hash)
+        image = get_image(conn, repository, image_hash)
+        parent, prov_type, prov_data = image.parent_id, image.provenance_type, image.provenance_data
         if prov_type in ('IMPORT', 'SQL', 'FROM'):
             sgfile_commands.append(prov_command_to_sgfile(prov_type, prov_data, image_hash, source_replacement))
             if prov_type == 'FROM':
@@ -86,7 +89,7 @@ def image_hash_to_sgfile(conn, mountpoint, image_hash, err_on_end=True, source_r
                 raise SplitGraphException("Image %s is linked to its parent with provenance %s"
                                           " that can't be reproduced!" % (image_hash, prov_type))
             else:
-                sgfile_commands.append("FROM %s:%s" % (mountpoint, image_hash))
+                sgfile_commands.append("FROM %s:%s" % (repository, image_hash))
                 break
         image_hash = parent
     return list(reversed(sgfile_commands))

--- a/splitgraph/commands/push_pull.py
+++ b/splitgraph/commands/push_pull.py
@@ -15,12 +15,12 @@ from splitgraph.objects.loading import download_objects, upload_objects
 from splitgraph.pg_audit import manage_audit
 
 
-def _get_required_snaps_objects(conn, remote_conn, local_mountpoint, remote_mountpoint):
+def _get_required_snaps_objects(conn, remote_conn, local_repository, remote_repository):
     local_snap_parents = {image_hash: parent_id for image_hash, parent_id, _, _, _, _ in
-                          get_all_images_parents(conn, local_mountpoint)}
+                          get_all_images_parents(conn, local_repository)}
     remote_snap_parents = {image_hash: (parent_id, created, comment, prov_type, prov_data)
                            for image_hash, parent_id, created, comment, prov_type, prov_data in
-                           get_all_images_parents(remote_conn, remote_mountpoint)}
+                           get_all_images_parents(remote_conn, remote_repository)}
 
     # We assume here that none of the remote snapshot IDs have changed (are immutable) since otherwise the remote
     # would have created a new snapshot.
@@ -29,18 +29,19 @@ def _get_required_snaps_objects(conn, remote_conn, local_mountpoint, remote_moun
     for image_hash in snaps_to_fetch:
         # This is not batched but there shouldn't be that many entries here anyway.
         remote_parent, remote_created, remote_comment, remote_prov, remote_provdata = remote_snap_parents[image_hash]
-        add_new_image(conn, local_mountpoint, remote_parent, image_hash, remote_created, remote_comment, remote_prov,
+        add_new_image(conn, local_repository, remote_parent, image_hash, remote_created, remote_comment, remote_prov,
                       remote_provdata)
         # Get the meta for all objects we'll need to fetch.
         with remote_conn.cursor() as cur:
             cur.execute(SQL("""SELECT image_hash, table_name, object_id FROM {0}.tables
-                           WHERE mountpoint = %s AND image_hash = %s""").format(Identifier(SPLITGRAPH_META_SCHEMA)),
-                        (remote_mountpoint, image_hash))
+                           WHERE namespace = %s AND repository = %s AND image_hash = %s""")
+                        .format(Identifier(SPLITGRAPH_META_SCHEMA)),
+                        (remote_repository.namespace, remote_repository.repository, image_hash))
             table_meta.extend(cur.fetchall())
 
     # Get the tags too
-    existing_tags = [t for s, t in get_all_hashes_tags(conn, local_mountpoint)]
-    tags = {t: s for s, t in get_all_hashes_tags(remote_conn, remote_mountpoint) if t not in existing_tags}
+    existing_tags = [t for s, t in get_all_hashes_tags(conn, local_repository)]
+    tags = {t: s for s, t in get_all_hashes_tags(remote_conn, remote_repository) if t not in existing_tags}
 
     # Crawl the object tree to get the IDs and other metadata for all required objects.
     distinct_objects, object_meta = _extract_recursive_object_meta(conn, remote_conn, table_meta)
@@ -69,37 +70,37 @@ def _extract_recursive_object_meta(conn, remote_conn, table_meta):
     return distinct_objects, object_meta
 
 
-def pull(conn, mountpoint, remote, download_all=False):
+def pull(conn, repository, remote, download_all=False):
     """
     Synchronizes the state of the local SplitGraph repository with the remote one, optionally downloading all new
     objects created on the remote.
 
     :param conn: psycopg connection objects
-    :param mountpoint: Mountpoint to pull changes from.
+    :param repository: Repository to pull changes from.
     :param remote: Name of the upstream to pull changes from.
     :param download_all: If True, downloads all objects and stores them locally. Otherwise, will only download required
         objects when a table is checked out.
     :return:
     """
-    remote_info = get_remote_for(conn, mountpoint, remote)
+    remote_info = get_remote_for(conn, repository, remote)
     if not remote_info:
-        raise SplitGraphException("No remote %s found for mountpoint %s!" % (remote, mountpoint))
+        raise SplitGraphException("No remote %s found for repository %s!" % (remote, repository))
 
-    remote_conn_string, remote_mountpoint = remote_info
-    clone(conn, remote_conn_string=remote_conn_string, remote_mountpoint=remote_mountpoint,
-          local_mountpoint=mountpoint, download_all=download_all)
+    remote_conn_string, remote_repository = remote_info
+    clone(conn, remote_repository=remote_repository, remote_conn_string=remote_conn_string, local_repository=repository,
+          download_all=download_all)
 
 
 @manage_audit
-def clone(conn, remote_mountpoint, remote_conn_string=None,
-          local_mountpoint=None, download_all=False, remote_conn=None):
+def clone(conn, remote_repository, remote_conn_string=None, local_repository=None, download_all=False,
+          remote_conn=None):
     """
     Clones a remote SplitGraph repository or synchronizes remote changes with the local ones.
 
     :param conn: psycopg connection object.
-    :param remote_mountpoint: Repository to clone.
+    :param remote_repository: Repository to clone.
     :param remote_conn_string: If set, overrides the default remote for this repository.
-    :param local_mountpoint: Local mountpoint to clone into. If None, uses the same name.
+    :param local_repository: Local repository to clone into. If None, uses the same name.
     :param download_all: If True, downloads all objects and stores them locally. Otherwise, will only download required
         objects when a table is checked out.
     :param remote_conn: If not None, must be a psycopg connection object used by the client to connect to the remote
@@ -108,11 +109,11 @@ def clone(conn, remote_mountpoint, remote_conn_string=None,
     """
     ensure_metadata_schema(conn)
 
-    local_mountpoint = local_mountpoint or remote_mountpoint
+    local_repository = local_repository or remote_repository
     with conn.cursor() as cur:
-        cur.execute(SQL("CREATE SCHEMA IF NOT EXISTS {}").format(Identifier(local_mountpoint)))
+        cur.execute(SQL("CREATE SCHEMA IF NOT EXISTS {}").format(Identifier(local_repository.to_schema())))
 
-    conn_params = lookup_repo(conn, remote_mountpoint) if not remote_conn_string \
+    conn_params = lookup_repo(conn, remote_repository) if not remote_conn_string \
         else parse_connection_string(remote_conn_string)
     logging.info("Connecting to the remote driver...")
     remote_conn = remote_conn or make_conn(*conn_params)
@@ -122,8 +123,8 @@ def clone(conn, remote_mountpoint, remote_conn_string=None,
 
     # This also registers the new versions locally.
     snaps_to_fetch, table_meta, object_locations, object_meta, tags = _get_required_snaps_objects(conn, remote_conn,
-                                                                                                  local_mountpoint,
-                                                                                                  remote_mountpoint)
+                                                                                                  local_repository,
+                                                                                                  remote_repository)
 
     if not snaps_to_fetch:
         logging.info("Nothing to do.")
@@ -142,28 +143,26 @@ def clone(conn, remote_mountpoint, remote_conn_string=None,
     # Map the tables to the actual objects no matter whether or not we're downloading them.
     register_objects(conn, object_meta)
     register_object_locations(conn, object_locations)
-    register_tables(conn, local_mountpoint, table_meta)
-    set_tags(conn, local_mountpoint, tags, force=False)
+    register_tables(conn, local_repository, table_meta)
+    set_tags(conn, local_repository, tags, force=False)
     # Don't check anything out, keep the repo bare.
-    set_head(conn, local_mountpoint, None)
+    set_head(conn, local_repository, None)
 
     print("Fetched metadata for %d object(s), %d table version(s) and %d tag(s)." % (len(object_meta),
                                                                                      len(table_meta),
                                                                                      len([t for t in tags if
                                                                                           t != 'HEAD'])))
 
-    if get_remote_for(conn, local_mountpoint) is None:
-        add_remote(conn, local_mountpoint, serialize_connection_string(*conn_params), remote_mountpoint)
+    if get_remote_for(conn, local_repository) is None:
+        add_remote(conn, local_repository, serialize_connection_string(*conn_params), remote_repository)
 
 
 def local_clone(conn, source, destination):
-    """Clones one local mountpoint into another, copying all of its commit history over. Doesn't do any checking out
+    """Clones one local repository into another, copying all of its commit history over. Doesn't do any checking out
     or materialization."""
     ensure_metadata_schema(conn)
 
-    _, table_meta, object_locations, object_meta, tags = _get_required_snaps_objects(conn, conn,
-                                                                                     destination,
-                                                                                     source)
+    _, table_meta, object_locations, object_meta, tags = _get_required_snaps_objects(conn, conn, destination, source)
 
     # Map the tables to the actual objects no matter whether or not we're downloading them.
     register_objects(conn, object_meta)
@@ -174,15 +173,15 @@ def local_clone(conn, source, destination):
     set_head(conn, destination, None)
 
 
-def push(conn, local_mountpoint, remote_conn_string=None, remote_mountpoint=None, handler='DB', handler_options=None):
+def push(conn, local_repository, remote_conn_string=None, remote_repository=None, handler='DB', handler_options=None):
     """
     Inverse of `pull`: Pushes all local changes to the remote and uploads new objects.
 
     :param conn: psycopg connection object
     :param remote_conn_string: Connection string to the remote SG driver of the form
         `username:password@hostname:port/database.`
-    :param remote_mountpoint: Remote mountpoint to push changes to.
-    :param local_mountpoint: Local mountpoint to push changes from.
+    :param remote_repository: Remote repository to push changes to.
+    :param local_repository: Local repository to push changes from.
     :param handler: Name of the handler to use to upload objects. Use `DB` to push them to the remote, `FILE`
         to store them in a directory that can be accessed from the client and `HTTP` to upload them to HTTP.
     :param handler_options: For `HTTP`, a dictionary `{"username": username, "password", password}`. For `FILE`,
@@ -192,20 +191,20 @@ def push(conn, local_mountpoint, remote_conn_string=None, remote_mountpoint=None
         handler_options = {}
     ensure_metadata_schema(conn)
 
-    remote_mountpoint = remote_mountpoint or local_mountpoint
+    remote_repository = remote_repository or local_repository
 
     # Could actually be done by flipping the arguments in pull but that assumes the remote SG driver can connect
     # to us directly, which might not be the case. Although tunnels? Still, a lot of code here similar to pull.
     logging.info("Connecting to the remote driver...")
-    conn_params = lookup_repo(conn, remote_mountpoint) if not remote_conn_string \
+    conn_params = lookup_repo(conn, remote_repository) if not remote_conn_string \
         else parse_connection_string(remote_conn_string)
     remote_conn = make_conn(*conn_params)
     try:
         logging.info("Gathering remote metadata...")
         # This also registers new commits remotely. Should make explicit and move down later on.
         snaps_to_push, table_meta, object_locations, object_meta, tags = _get_required_snaps_objects(remote_conn, conn,
-                                                                                                     remote_mountpoint,
-                                                                                                     local_mountpoint)
+                                                                                                     remote_repository,
+                                                                                                     local_repository)
 
         if not snaps_to_push:
             logging.info("Nothing to do.")
@@ -217,14 +216,14 @@ def push(conn, local_mountpoint, remote_conn_string=None, remote_mountpoint=None
         # Register the newly uploaded object locations locally and remotely.
         register_objects(remote_conn, object_meta)
         register_object_locations(remote_conn, object_locations + new_uploads)
-        register_tables(remote_conn, remote_mountpoint, table_meta)
-        set_tags(remote_conn, remote_mountpoint, tags, force=False)
+        register_tables(remote_conn, remote_repository, table_meta)
+        set_tags(remote_conn, remote_repository, tags, force=False)
         # Kind of have to commit here in any case?
         remote_conn.commit()
         register_object_locations(conn, new_uploads)
 
-        if not get_remote_for(conn, local_mountpoint, 'origin'):
-            add_remote(conn, local_mountpoint, serialize_connection_string(*conn_params), remote_mountpoint)
+        if not get_remote_for(conn, local_repository, 'origin'):
+            add_remote(conn, local_repository, serialize_connection_string(*conn_params), remote_repository)
 
         logging.info("Uploaded metadata for %d object(s), %d table version(s) and %d tag(s)." % (len(object_meta),
                                                                                                  len(table_meta),

--- a/splitgraph/config/repo_lookups.py
+++ b/splitgraph/config/repo_lookups.py
@@ -1,7 +1,7 @@
 from splitgraph.commands.misc import make_conn
 from splitgraph.config import CONFIG
 from splitgraph.constants import SplitGraphException
-from splitgraph.meta_handler.misc import mountpoint_exists
+from splitgraph.meta_handler.misc import repository_exists
 
 
 # Parse and set these on import. If we ever need to be able to reread the config on the fly, these have to be
@@ -35,12 +35,12 @@ def lookup_repo(conn, repo_name, include_local=False):
         return LOOKUP_PATH_OVERRIDE[repo_name]
 
     # Currently just check if the schema with that name exists on the remote.
-    if include_local and mountpoint_exists(conn, repo_name):
+    if include_local and repository_exists(conn, repo_name):
         return "LOCAL"
 
     for candidate in LOOKUP_PATH:
         remote_conn = make_conn(*candidate)
-        if mountpoint_exists(remote_conn, repo_name):
+        if repository_exists(remote_conn, repo_name):
             remote_conn.close()
             return candidate
         remote_conn.close()

--- a/splitgraph/constants.py
+++ b/splitgraph/constants.py
@@ -1,5 +1,6 @@
 import logging
 import re
+from collections import namedtuple
 from random import getrandbits
 
 from splitgraph.config import CONFIG
@@ -39,15 +40,6 @@ def serialize_connection_string(server, port, username, password, dbname):
     return '%s:%s@%s:%s/%s' % (username, password, server, port, dbname)
 
 
-def to_mountpoint(namespace, repository):
-    return repository if not namespace else namespace + '/' + repository
-
-
-def to_ns_repo(schema):
-    # temporary until we figure out a mapping
-    return schema if '/' not in schema else tuple(schema.split('/'))
-
-
 class Color:
     PURPLE = '\033[95m'
     CYAN = '\033[96m'
@@ -59,3 +51,19 @@ class Color:
     BOLD = '\033[1m'
     UNDERLINE = '\033[4m'
     END = '\033[0m'
+
+
+class Repository(namedtuple('Repository', ['namespace', 'repository'])):
+    def to_schema(self):
+        return self.repository if not self.namespace else self.namespace + '/' + self.repository
+
+    __repr__ = to_schema
+    __str__ = to_schema
+
+
+def to_repository(schema):
+    if '/' in schema:
+        namespace, repository = schema.split('/')
+        return Repository(namespace, repository)
+    else:
+        return Repository('', schema)

--- a/splitgraph/constants.py
+++ b/splitgraph/constants.py
@@ -39,6 +39,15 @@ def serialize_connection_string(server, port, username, password, dbname):
     return '%s:%s@%s:%s/%s' % (username, password, server, port, dbname)
 
 
+def to_mountpoint(namespace, repository):
+    return repository if not namespace else namespace + '/' + repository
+
+
+def to_ns_repo(schema):
+    # temporary until we figure out a mapping
+    return schema if '/' not in schema else tuple(schema.split('/'))
+
+
 class Color:
     PURPLE = '\033[95m'
     CYAN = '\033[96m'

--- a/splitgraph/drawing.py
+++ b/splitgraph/drawing.py
@@ -59,10 +59,10 @@ def render_tree(conn, mountpoint):
 
     # Get all commits in ascending time order
     snap_parents = get_all_images_parents(conn, mountpoint)
-    for snap_id, parent_id, _, _, _, _ in snap_parents:
+    for image_hash, parent_id, _, _, _, _ in snap_parents:
         if parent_id is None:
-            base_node = snap_id
-        children[parent_id].append(snap_id)
+            base_node = image_hash
+        children[parent_id].append(image_hash)
 
     if base_node is None:
         raise SplitGraphException("Something is seriously wrong with the index.")
@@ -70,6 +70,6 @@ def render_tree(conn, mountpoint):
     # Calculate the column in which each node should be displayed.
     node_cols = _calc_columns(children, base_node)
 
-    for snap_id, _, _, _, _, _ in reversed(snap_parents):
-        _render_node(snap_id, children, node_cols, mark_node=' H' if snap_id == head else '',
+    for image_hash, _, _, _, _, _ in reversed(snap_parents):
+        _render_node(image_hash, children, node_cols, mark_node=' H' if image_hash == head else '',
                      max_col=max(node_cols.values()))

--- a/splitgraph/drawing.py
+++ b/splitgraph/drawing.py
@@ -49,16 +49,16 @@ def _render_node(node_id, children, node_cols, max_col, mark_node='', node_width
     print(line)
 
 
-def render_tree(conn, mountpoint):
-    """Draws the mountpoint's commit graph as a Git-like tree."""
+def render_tree(conn, repository):
+    """Draws the repository's commit graph as a Git-like tree."""
     ensure_metadata_schema(conn)
     # Prepare the tree structure by loading the index from the db and flipping it
     children = defaultdict(list)
     base_node = None
-    head = get_current_head(conn, mountpoint, raise_on_none=False)
+    head = get_current_head(conn, repository, raise_on_none=False)
 
     # Get all commits in ascending time order
-    snap_parents = get_all_images_parents(conn, mountpoint)
+    snap_parents = get_all_images_parents(conn, repository)
     for image_hash, parent_id, _, _, _, _ in snap_parents:
         if parent_id is None:
             base_node = image_hash

--- a/splitgraph/meta_handler/common.py
+++ b/splitgraph/meta_handler/common.py
@@ -139,7 +139,4 @@ def setup_registry_mode(conn):
 
     :param conn: Psycopg admin connection object.
     """
-
-    with conn.cursor() as cur:
-        cur.execute(SQL("DROP TABLE {}.remotes").format(Identifier(SPLITGRAPH_META_SCHEMA)))
-
+    pass

--- a/splitgraph/meta_handler/common.py
+++ b/splitgraph/meta_handler/common.py
@@ -34,7 +34,7 @@ def _create_metadata_schema(conn):
                         repository      VARCHAR NOT NULL,
                         image_hash VARCHAR,
                         tag        VARCHAR,
-                        PRIMARY KEY (mountpoint, tag),
+                        PRIMARY KEY (namespace, repository, tag),
                         CONSTRAINT sh_fk FOREIGN KEY (namespace, repository, image_hash) REFERENCES {}.{})""").format(
             Identifier(SPLITGRAPH_META_SCHEMA), Identifier("snap_tags"),
             Identifier(SPLITGRAPH_META_SCHEMA), Identifier("images")))
@@ -52,16 +52,16 @@ def _create_metadata_schema(conn):
         # delta to a previous table).
         cur.execute(SQL("""CREATE TABLE {}.{} (
                         namespace  VARCHAR NOT NULL,
-                        repository VARCHAR NOT NULL
+                        repository VARCHAR NOT NULL,
                         image_hash VARCHAR NOT NULL,
                         table_name VARCHAR NOT NULL,
                         object_id  VARCHAR NOT NULL,
-                        PRIMARY KEY (mountpoint, image_hash, table_name, object_id),
+                        PRIMARY KEY (namespace, repository, image_hash, table_name, object_id),
                         CONSTRAINT tb_fk FOREIGN KEY (namespace, repository, image_hash) REFERENCES {}.{})""").format(
             Identifier(SPLITGRAPH_META_SCHEMA), Identifier("tables"),
             Identifier(SPLITGRAPH_META_SCHEMA), Identifier("images")))
 
-        # Keep track of what the remotes for a given mountpoint are (by default, we create an "origin" remote
+        # Keep track of what the remotes for a given repository are (by default, we create an "origin" remote
         # on initial pull)
         cur.execute(SQL("""CREATE TABLE {}.{} (
                         namespace          VARCHAR NOT NULL,

--- a/splitgraph/meta_handler/images.py
+++ b/splitgraph/meta_handler/images.py
@@ -11,27 +11,27 @@ from splitgraph.meta_handler.tables import get_table_with_format
 
 def get_image_parent(conn, mountpoint, image):
     with conn.cursor() as cur:
-        cur.execute(select("snap_tree", "parent_id", "mountpoint = %s AND snap_id = %s"), (mountpoint, image))
+        cur.execute(select("images", "parent_id", "mountpoint = %s AND image_hash = %s"), (mountpoint, image))
         return cur.fetchone()[0]
 
 
 def get_image_parent_provenance(conn, mountpoint, image):
     with conn.cursor() as cur:
-        cur.execute(select("snap_tree", "parent_id, provenance_type, provenance_data",
-                           "mountpoint = %s AND snap_id = %s"), (mountpoint, image))
+        cur.execute(select("images", "parent_id, provenance_type, provenance_data",
+                           "mountpoint = %s AND image_hash = %s"), (mountpoint, image))
         return cur.fetchone()
 
 
 def get_all_image_info(conn, mountpoint, image):
     with conn.cursor() as cur:
-        cur.execute(select("snap_tree", "parent_id, created, comment", "mountpoint = %s AND snap_id = %s"),
+        cur.execute(select("images", "parent_id, created, comment", "mountpoint = %s AND image_hash = %s"),
                     (mountpoint, image))
         return cur.fetchone()
 
 
 def get_all_images_parents(conn, mountpoint):
     with conn.cursor() as cur:
-        cur.execute(select("snap_tree", "snap_id, parent_id, created, comment, provenance_type, provenance_data",
+        cur.execute(select("images", "image_hash, parent_id, created, comment, provenance_type, provenance_data",
                            "mountpoint = %s") +
                     SQL(" ORDER BY created"),
                     (mountpoint,))
@@ -40,7 +40,7 @@ def get_all_images_parents(conn, mountpoint):
 
 def get_canonical_image_id(conn, mountpoint, short_image):
     with conn.cursor() as cur:
-        cur.execute(select("snap_tree", "snap_id", "mountpoint = %s AND snap_id LIKE %s"),
+        cur.execute(select("images", "image_hash", "mountpoint = %s AND image_hash LIKE %s"),
                     (mountpoint, short_image.lower() + '%'))
         candidates = [c[0] for c in cur.fetchall()]
 
@@ -76,7 +76,7 @@ def get_closest_parent_image_object(conn, mountpoint, table, image):
 def add_new_image(conn, mountpoint, parent_id, image, created=None, comment=None, provenance_type=None,
                   provenance_data=None):
     with conn.cursor() as cur:
-        cur.execute(insert("snap_tree", ("snap_id", "mountpoint", "parent_id", "created", "comment",
+        cur.execute(insert("images", ("image_hash", "mountpoint", "parent_id", "created", "comment",
                                          "provenance_type", "provenance_data")),
                     (image, mountpoint, parent_id, created or datetime.now(), comment,
                      provenance_type, Json(provenance_data)))

--- a/splitgraph/meta_handler/images.py
+++ b/splitgraph/meta_handler/images.py
@@ -1,51 +1,39 @@
 from datetime import datetime
 
-from psycopg2.extras import Json
+from psycopg2.extras import Json, NamedTupleCursor
 from psycopg2.sql import SQL
 
-from splitgraph.constants import SplitGraphException
+from splitgraph.constants import SplitGraphException, to_mountpoint
 from splitgraph.meta_handler.common import select, insert
 from splitgraph.meta_handler.objects import get_object_format, get_object_parents
-from splitgraph.meta_handler.tables import get_table_with_format
+from splitgraph.meta_handler.tables import get_object_for_table
+
+IMAGE_COLS = "image_hash, parent_id, created, comment, provenance_type, provenance_data"
 
 
-def get_image_parent(conn, mountpoint, image):
-    with conn.cursor() as cur:
-        cur.execute(select("images", "parent_id", "mountpoint = %s AND image_hash = %s"), (mountpoint, image))
-        return cur.fetchone()[0]
-
-
-def get_image_parent_provenance(conn, mountpoint, image):
-    with conn.cursor() as cur:
-        cur.execute(select("images", "parent_id, provenance_type, provenance_data",
-                           "mountpoint = %s AND image_hash = %s"), (mountpoint, image))
+def get_image(conn, repository, image, namespace=''):
+    with conn.cursor(cursor_factory=NamedTupleCursor) as cur:
+        cur.execute(select("images", IMAGE_COLS,
+                           "repository = %s AND image_hash = %s AND namespace = %s"), (repository, image, namespace))
         return cur.fetchone()
 
 
-def get_all_image_info(conn, mountpoint, image):
+def get_all_images_parents(conn, repository, namespace=''):
     with conn.cursor() as cur:
-        cur.execute(select("images", "parent_id, created, comment", "mountpoint = %s AND image_hash = %s"),
-                    (mountpoint, image))
-        return cur.fetchone()
-
-
-def get_all_images_parents(conn, mountpoint):
-    with conn.cursor() as cur:
-        cur.execute(select("images", "image_hash, parent_id, created, comment, provenance_type, provenance_data",
-                           "mountpoint = %s") +
-                    SQL(" ORDER BY created"),
-                    (mountpoint,))
+        cur.execute(select("images", IMAGE_COLS, "repository = %s AND namespace = %s") +
+                    SQL(" ORDER BY created"), (repository, namespace))
         return cur.fetchall()
 
 
-def get_canonical_image_id(conn, mountpoint, short_image):
+def get_canonical_image_id(conn, repository, short_image, namespace=''):
     with conn.cursor() as cur:
-        cur.execute(select("images", "image_hash", "mountpoint = %s AND image_hash LIKE %s"),
-                    (mountpoint, short_image.lower() + '%'))
+        cur.execute(select("images", "image_hash", "namespace = %s repository = %s AND image_hash LIKE %s"),
+                    (namespace, repository, short_image.lower() + '%'))
         candidates = [c[0] for c in cur.fetchall()]
 
     if not candidates:
-        raise SplitGraphException("No snapshots beginning with %s found for mountpoint %s!" % (short_image, mountpoint))
+        raise SplitGraphException("No snapshots beginning with %s found for mountpoint %s!" % (short_image,
+                                                                                               to_mountpoint(namespace, repository)))
 
     if len(candidates) > 1:
         result = "Multiple suitable candidates found: \n * " + "\n * ".join(candidates)
@@ -54,13 +42,13 @@ def get_canonical_image_id(conn, mountpoint, short_image):
     return candidates[0]
 
 
-def get_closest_parent_image_object(conn, mountpoint, table, image):
+def get_closest_parent_image_object(conn, repository, table, image, namespace=''):
     path = []
-    object_id = get_table_with_format(conn, mountpoint, table, image, object_format='SNAP')
+    object_id = get_object_for_table(conn, repository, table, image, object_format='SNAP', namespace=namespace)
     if object_id is not None:
         return object_id, path
 
-    object_id = get_table_with_format(conn, mountpoint, table, image, object_format='DIFF')
+    object_id = get_object_for_table(conn, repository, table, image, object_format='DIFF', namespace=namespace)
     while object_id is not None:
         path.append(object_id)
         parents = get_object_parents(conn, object_id)
@@ -69,14 +57,14 @@ def get_closest_parent_image_object(conn, mountpoint, table, image):
                 return object_id, path
             break  # Found 1 diff, will be added to the path at the next iteration.
 
-    # We didn't find an actual snapshot for this table -- either it doesn't exist in this
-    # version or something went wrong. Should we raise here?
+    # We didn't find an actual snapshot for this table -- something's wrong with the object tree.
+    raise SplitGraphException("Couldn't find a SNAP object for %s (malformed object tree)" % table)
 
 
-def add_new_image(conn, mountpoint, parent_id, image, created=None, comment=None, provenance_type=None,
-                  provenance_data=None):
+def add_new_image(conn, repository, parent_id, image, created=None, comment=None, provenance_type=None,
+                  provenance_data=None, namespace=''):
     with conn.cursor() as cur:
-        cur.execute(insert("images", ("image_hash", "mountpoint", "parent_id", "created", "comment",
+        cur.execute(insert("images", ("image_hash", "namespace", "repository", "parent_id", "created", "comment",
                                          "provenance_type", "provenance_data")),
-                    (image, mountpoint, parent_id, created or datetime.now(), comment,
+                    (image, namespace, repository, parent_id, created or datetime.now(), comment,
                      provenance_type, Json(provenance_data)))

--- a/splitgraph/meta_handler/images.py
+++ b/splitgraph/meta_handler/images.py
@@ -3,7 +3,7 @@ from datetime import datetime
 from psycopg2.extras import Json, NamedTupleCursor
 from psycopg2.sql import SQL
 
-from splitgraph.constants import SplitGraphException, to_mountpoint
+from splitgraph.constants import SplitGraphException
 from splitgraph.meta_handler.common import select, insert
 from splitgraph.meta_handler.objects import get_object_format, get_object_parents
 from splitgraph.meta_handler.tables import get_object_for_table
@@ -11,29 +11,30 @@ from splitgraph.meta_handler.tables import get_object_for_table
 IMAGE_COLS = "image_hash, parent_id, created, comment, provenance_type, provenance_data"
 
 
-def get_image(conn, repository, image, namespace=''):
+def get_image(conn, repository, image):
     with conn.cursor(cursor_factory=NamedTupleCursor) as cur:
         cur.execute(select("images", IMAGE_COLS,
-                           "repository = %s AND image_hash = %s AND namespace = %s"), (repository, image, namespace))
+                           "repository = %s AND image_hash = %s AND namespace = %s"), (repository.repository,
+                                                                                       image, repository.namespace))
         return cur.fetchone()
 
 
-def get_all_images_parents(conn, repository, namespace=''):
+def get_all_images_parents(conn, repository):
     with conn.cursor() as cur:
         cur.execute(select("images", IMAGE_COLS, "repository = %s AND namespace = %s") +
-                    SQL(" ORDER BY created"), (repository, namespace))
+                    SQL(" ORDER BY created"), (repository.repository, repository.namespace))
         return cur.fetchall()
 
 
-def get_canonical_image_id(conn, repository, short_image, namespace=''):
+def get_canonical_image_id(conn, repository, short_image):
     with conn.cursor() as cur:
-        cur.execute(select("images", "image_hash", "namespace = %s repository = %s AND image_hash LIKE %s"),
-                    (namespace, repository, short_image.lower() + '%'))
+        cur.execute(select("images", "image_hash", "namespace = %s AND repository = %s AND image_hash LIKE %s"),
+                    (repository.namespace, repository.repository, short_image.lower() + '%'))
         candidates = [c[0] for c in cur.fetchall()]
 
     if not candidates:
         raise SplitGraphException("No snapshots beginning with %s found for mountpoint %s!" % (short_image,
-                                                                                               to_mountpoint(namespace, repository)))
+                                                                                               repository.to_schema()))
 
     if len(candidates) > 1:
         result = "Multiple suitable candidates found: \n * " + "\n * ".join(candidates)
@@ -42,13 +43,13 @@ def get_canonical_image_id(conn, repository, short_image, namespace=''):
     return candidates[0]
 
 
-def get_closest_parent_image_object(conn, repository, table, image, namespace=''):
+def get_closest_parent_image_object(conn, repository, table, image):
     path = []
-    object_id = get_object_for_table(conn, repository, table, image, object_format='SNAP', namespace=namespace)
+    object_id = get_object_for_table(conn, repository, table, image, object_format='SNAP')
     if object_id is not None:
         return object_id, path
 
-    object_id = get_object_for_table(conn, repository, table, image, object_format='DIFF', namespace=namespace)
+    object_id = get_object_for_table(conn, repository, table, image, object_format='DIFF')
     while object_id is not None:
         path.append(object_id)
         parents = get_object_parents(conn, object_id)
@@ -62,9 +63,9 @@ def get_closest_parent_image_object(conn, repository, table, image, namespace=''
 
 
 def add_new_image(conn, repository, parent_id, image, created=None, comment=None, provenance_type=None,
-                  provenance_data=None, namespace=''):
+                  provenance_data=None):
     with conn.cursor() as cur:
         cur.execute(insert("images", ("image_hash", "namespace", "repository", "parent_id", "created", "comment",
                                          "provenance_type", "provenance_data")),
-                    (image, namespace, repository, parent_id, created or datetime.now(), comment,
+                    (image, repository.namespace, repository.repository, parent_id, created or datetime.now(), comment,
                      provenance_type, Json(provenance_data)))

--- a/splitgraph/meta_handler/misc.py
+++ b/splitgraph/meta_handler/misc.py
@@ -9,77 +9,71 @@ from splitgraph.meta_handler.objects import register_object, register_table
 from splitgraph.pg_utils import get_full_table_schema
 
 
-def get_all_foreign_tables(conn, mountpoint):
-    """Inspects the information_schema to see which foreign tables we have in a given mountpoint.
-    Used by `mount` to populate the metadata since if we did IMPORT FOREIGN SCHEMA we've no idea what tables we actually
-    fetched from the remote postgres."""
+def repository_exists(conn, repository, namespace=''):
     with conn.cursor() as cur:
-        cur.execute(
-            select("tables", "table_name", "table_schema = %s and table_type = 'FOREIGN TABLE'", "information_schema"),
-            (mountpoint,))
-        return [c[0] for c in cur.fetchall()]
-
-
-def mountpoint_exists(conn, mountpoint):
-    with conn.cursor() as cur:
-        cur.execute(SQL("SELECT 1 FROM {}.images WHERE mountpoint = %s").format(Identifier(SPLITGRAPH_META_SCHEMA)),
-                    (mountpoint,))
+        cur.execute(SQL("SELECT 1 FROM {}.images WHERE namespace = %s AND repository = %s")
+                    .format(Identifier(SPLITGRAPH_META_SCHEMA)),
+                    (namespace, repository,))
         return cur.fetchone() is not None
 
 
-def register_mountpoint(conn, mountpoint, initial_image, tables, table_object_ids):
+def register_repository(conn, repository, initial_image, tables, table_object_ids, namespace=''):
     with conn.cursor() as cur:
-        cur.execute(insert("images", ("image_hash", "mountpoint", "parent_id", "created")),
-                    (initial_image, mountpoint, None, datetime.now()))
+        cur.execute(insert("images", ("image_hash", "namespace", "repository", "parent_id", "created")),
+                    (initial_image, namespace, repository, None, datetime.now()))
         # Strictly speaking this is redundant since the checkout (of the "HEAD" commit) updates the tag table.
-        cur.execute(insert("snap_tags", ("mountpoint", "image_hash", "tag")),
-                    (mountpoint, initial_image, "HEAD"))
+        cur.execute(insert("snap_tags", ("namespace", "repository", "image_hash", "tag")),
+                    (namespace, repository, initial_image, "HEAD"))
         for t, ti in zip(tables, table_object_ids):
             # Register the tables and the object IDs they were stored under.
             # They're obviously stored as snaps since there's nothing to diff to...
             register_object(conn, ti, 'SNAP', None)
-            register_table(conn, mountpoint, t, initial_image, ti)
+            register_table(conn, repository, t, initial_image, ti)
 
 
-def unregister_mountpoint(conn, mountpoint):
+def unregister_repository(conn, repository, namespace):
     with conn.cursor() as cur:
         for meta_table in ["tables", "snap_tags", "images", "remotes"]:
-            cur.execute(SQL("DELETE FROM {}.{} WHERE mountpoint = %s").format(Identifier(SPLITGRAPH_META_SCHEMA),
-                                                                              Identifier(meta_table)),
-                        (mountpoint,))
+            cur.execute(SQL("DELETE FROM {}.{} WHERE namespace = %s AND repository = %s")
+                        .format(Identifier(SPLITGRAPH_META_SCHEMA),
+                                Identifier(meta_table)),
+                        (namespace, repository,))
 
 
-def get_current_mountpoints_hashes(conn):
+def get_current_repositories(conn):
     ensure_metadata_schema(conn)
     with conn.cursor() as cur:
-        cur.execute(select("snap_tags", "mountpoint, image_hash", "tag = 'HEAD'"))
+        cur.execute(select("snap_tags", "namespace, repository, image_hash", "tag = 'HEAD'"))
         return cur.fetchall()
 
 
-def get_remote_for(conn, mountpoint, remote_name='origin'):
+def get_remote_for(conn, repository, remote_name='origin', namespace=''):
     with conn.cursor() as cur:
-        cur.execute(select("remotes", "remote_conn_string, remote_mountpoint", "mountpoint = %s AND remote_name = %s"),
-                    (mountpoint, remote_name))
+        cur.execute(select("remotes", "remote_conn_string, remote_namespace, remote_repository",
+                           "namespace = %s AND repository = %s AND remote_name = %s"),
+                    (namespace, repository, remote_name))
         return cur.fetchone()
 
 
-def add_remote(conn, mountpoint, remote_conn, remote_mountpoint, remote_name='origin'):
+def add_remote(conn, repository, remote_conn, remote_repository, remote_name='origin', namespace='',
+               remote_namespace=''):
     with conn.cursor() as cur:
-        cur.execute(insert("remotes", ("mountpoint", "remote_name", "remote_conn_string", "remote_mountpoint")),
-                    (mountpoint, remote_name, remote_conn, remote_mountpoint))
+        cur.execute(insert("remotes", ("namespace", "repository", "remote_name", "remote_conn_string",
+                                       "remote_namespace", "remote_repository")),
+                    (namespace, repository, remote_name, remote_conn, remote_namespace, remote_repository))
 
 
-def table_schema_changed(conn, mountpoint, table_name, image_1, image_2=None):
-    snap_1 = get_closest_parent_image_object(conn, mountpoint, table_name, image_1)[0]
+def table_schema_changed(conn, repository, table_name, image_1, image_2=None, namespace=''):
+    snap_1 = get_closest_parent_image_object(conn, repository, table_name, image_1, namespace=namespace)[0]
     # image_2 = None here means the current staging area.
     if image_2 is not None:
-        snap_2 = get_closest_parent_image_object(conn, mountpoint, table_name, image_2)[0]
+        snap_2 = get_closest_parent_image_object(conn, repository, table_name, image_2, namespace=namespace)[0]
         return get_full_table_schema(conn, SPLITGRAPH_META_SCHEMA, snap_1) != \
                get_full_table_schema(conn, SPLITGRAPH_META_SCHEMA, snap_2)
     return get_full_table_schema(conn, SPLITGRAPH_META_SCHEMA, snap_1) != \
-           get_full_table_schema(conn, mountpoint, table_name)
+           get_full_table_schema(conn, repository, table_name)
 
 
-def get_schema_at(conn, mountpoint, table_name, image_hash):
-    snap_1 = get_closest_parent_image_object(conn, mountpoint, table_name, image_hash)[0]
+def get_schema_at(conn, repository, table_name, image_hash, namespace=''):
+    snap_1 = get_closest_parent_image_object(conn, repository, table_name, image_hash, namespace=namespace)[0]
     return get_full_table_schema(conn, SPLITGRAPH_META_SCHEMA, snap_1)

--- a/splitgraph/meta_handler/misc.py
+++ b/splitgraph/meta_handler/misc.py
@@ -2,78 +2,82 @@ from datetime import datetime
 
 from psycopg2.sql import SQL, Identifier
 
-from splitgraph.constants import SPLITGRAPH_META_SCHEMA
+from splitgraph.constants import SPLITGRAPH_META_SCHEMA, Repository
 from splitgraph.meta_handler.common import select, insert, ensure_metadata_schema
 from splitgraph.meta_handler.images import get_closest_parent_image_object
 from splitgraph.meta_handler.objects import register_object, register_table
 from splitgraph.pg_utils import get_full_table_schema
 
 
-def repository_exists(conn, repository, namespace=''):
+def repository_exists(conn, repository):
     with conn.cursor() as cur:
         cur.execute(SQL("SELECT 1 FROM {}.images WHERE namespace = %s AND repository = %s")
                     .format(Identifier(SPLITGRAPH_META_SCHEMA)),
-                    (namespace, repository,))
+                    (repository.namespace, repository.repository))
         return cur.fetchone() is not None
 
 
-def register_repository(conn, repository, initial_image, tables, table_object_ids, namespace=''):
+def register_repository(conn, repository, initial_image, tables, table_object_ids):
     with conn.cursor() as cur:
         cur.execute(insert("images", ("image_hash", "namespace", "repository", "parent_id", "created")),
-                    (initial_image, namespace, repository, None, datetime.now()))
+                    (initial_image, repository.namespace, repository.repository, None, datetime.now()))
         # Strictly speaking this is redundant since the checkout (of the "HEAD" commit) updates the tag table.
         cur.execute(insert("snap_tags", ("namespace", "repository", "image_hash", "tag")),
-                    (namespace, repository, initial_image, "HEAD"))
+                    (repository.namespace, repository.repository, initial_image, "HEAD"))
         for t, ti in zip(tables, table_object_ids):
             # Register the tables and the object IDs they were stored under.
             # They're obviously stored as snaps since there's nothing to diff to...
-            register_object(conn, ti, 'SNAP', None)
+            register_object(conn, ti, 'SNAP', repository.namespace, None)
             register_table(conn, repository, t, initial_image, ti)
 
 
-def unregister_repository(conn, repository, namespace):
+def unregister_repository(conn, repository):
     with conn.cursor() as cur:
         for meta_table in ["tables", "snap_tags", "images", "remotes"]:
             cur.execute(SQL("DELETE FROM {}.{} WHERE namespace = %s AND repository = %s")
                         .format(Identifier(SPLITGRAPH_META_SCHEMA),
                                 Identifier(meta_table)),
-                        (namespace, repository,))
+                        (repository.namespace, repository.repository))
 
 
 def get_current_repositories(conn):
     ensure_metadata_schema(conn)
     with conn.cursor() as cur:
         cur.execute(select("snap_tags", "namespace, repository, image_hash", "tag = 'HEAD'"))
-        return cur.fetchall()
+        return [(Repository(n, r), i) for n, r, i in cur.fetchall()]
 
 
-def get_remote_for(conn, repository, remote_name='origin', namespace=''):
+def get_remote_for(conn, repository, remote_name='origin'):
     with conn.cursor() as cur:
         cur.execute(select("remotes", "remote_conn_string, remote_namespace, remote_repository",
                            "namespace = %s AND repository = %s AND remote_name = %s"),
-                    (namespace, repository, remote_name))
-        return cur.fetchone()
+                    (repository.namespace, repository.repository, remote_name))
+        result = cur.fetchone()
+        if result is None:
+            return result
+        cs, ns, re = result
+        return cs, Repository(ns, re)
 
 
-def add_remote(conn, repository, remote_conn, remote_repository, remote_name='origin', namespace='',
-               remote_namespace=''):
+def add_remote(conn, repository, remote_conn, remote_repository, remote_name='origin'):
     with conn.cursor() as cur:
         cur.execute(insert("remotes", ("namespace", "repository", "remote_name", "remote_conn_string",
                                        "remote_namespace", "remote_repository")),
-                    (namespace, repository, remote_name, remote_conn, remote_namespace, remote_repository))
+                    (repository.namespace, repository.repository, remote_name,
+                     remote_conn, remote_repository.namespace, remote_repository.repository))
 
 
-def table_schema_changed(conn, repository, table_name, image_1, image_2=None, namespace=''):
-    snap_1 = get_closest_parent_image_object(conn, repository, table_name, image_1, namespace=namespace)[0]
+def table_schema_changed(conn, repository, table_name, image_1, image_2=None):
+    snap_1 = get_closest_parent_image_object(conn, repository, table_name, image_1)[0]
     # image_2 = None here means the current staging area.
     if image_2 is not None:
-        snap_2 = get_closest_parent_image_object(conn, repository, table_name, image_2, namespace=namespace)[0]
+        snap_2 = get_closest_parent_image_object(conn, repository, table_name, image_2)[0]
         return get_full_table_schema(conn, SPLITGRAPH_META_SCHEMA, snap_1) != \
                get_full_table_schema(conn, SPLITGRAPH_META_SCHEMA, snap_2)
     return get_full_table_schema(conn, SPLITGRAPH_META_SCHEMA, snap_1) != \
-           get_full_table_schema(conn, repository, table_name)
+           get_full_table_schema(conn, repository.to_schema(), table_name)
 
 
-def get_schema_at(conn, repository, table_name, image_hash, namespace=''):
-    snap_1 = get_closest_parent_image_object(conn, repository, table_name, image_hash, namespace=namespace)[0]
+def get_schema_at(conn, repository, table_name, image_hash):
+    snap_1 = get_closest_parent_image_object(conn, repository, table_name, image_hash)[0]
     return get_full_table_schema(conn, SPLITGRAPH_META_SCHEMA, snap_1)

--- a/splitgraph/meta_handler/objects.py
+++ b/splitgraph/meta_handler/objects.py
@@ -18,12 +18,12 @@ def get_object_format(conn, object_id):
         return None if result is None else result[0]
 
 
-def register_object(conn, object_id, object_format, parent_object=None):
+def register_object(conn, object_id, object_format, original_namespace, parent_object=None):
     if not parent_object and object_format != 'SNAP':
         raise ValueError("Non-SNAP objects can't have no parent!")
     with conn.cursor() as cur:
-        cur.execute(insert("objects", ("object_id", "format", "parent_id")),
-                    (object_id, object_format, parent_object))
+        cur.execute(insert("objects", ("object_id", "format", "parent_id", "original_namespace")),
+                    (object_id, object_format, parent_object, original_namespace))
 
 
 def deregister_table_object(conn, object_id):
@@ -34,11 +34,12 @@ def deregister_table_object(conn, object_id):
 
 def register_objects(conn, object_meta):
     with conn.cursor() as cur:
-        execute_batch(cur, insert("objects", ("object_id", "format", "parent_id")), object_meta, page_size=100)
+        execute_batch(cur, insert("objects", ("object_id", "format", "parent_id", "original_namespace")),
+                      object_meta, page_size=100)
 
 
-def register_tables(conn, repository, table_meta, namespace=''):
-    table_meta = [(namespace, repository) + o for o in table_meta]
+def register_tables(conn, repository, table_meta):
+    table_meta = [(repository.namespace, repository.repository) + o for o in table_meta]
     with conn.cursor() as cur:
         execute_batch(cur, insert("tables", ("namespace", "repository", "image_hash", "table_name", "object_id")),
                       table_meta, page_size=100)
@@ -85,12 +86,12 @@ def get_external_object_locations(conn, objects):
 
 def get_object_meta(conn, objects):
     with conn.cursor() as cur:
-        cur.execute(select("objects", "object_id, format, parent_id",
+        cur.execute(select("objects", "object_id, format, parent_id, original_namespace",
                            "object_id IN (" + ','.join('%s' for _ in objects) + ")"), objects)
         return cur.fetchall()
 
 
-def register_table(conn, repository, table, image, object_id, namespace=''):
+def register_table(conn, repository, table, image, object_id):
     with conn.cursor() as cur:
         cur.execute(insert("tables", ("namespace", "repository", "image_hash", "table_name", "object_id")),
-                    (namespace, repository, image, table, object_id))
+                    (repository.namespace, repository.repository, image, table, object_id))

--- a/splitgraph/meta_handler/objects.py
+++ b/splitgraph/meta_handler/objects.py
@@ -7,13 +7,13 @@ from splitgraph.meta_handler.common import select, insert
 
 def get_object_parents(conn, object_id):
     with conn.cursor() as cur:
-        cur.execute(select("object_tree", "parent_id", "object_id = %s"), (object_id,))
+        cur.execute(select("objects", "parent_id", "object_id = %s"), (object_id,))
         return [c[0] for c in cur.fetchall()]
 
 
 def get_object_format(conn, object_id):
     with conn.cursor() as cur:
-        cur.execute(select("object_tree", "format", "object_id = %s"), (object_id,))
+        cur.execute(select("objects", "format", "object_id = %s"), (object_id,))
         result = cur.fetchone()
         return None if result is None else result[0]
 
@@ -22,7 +22,7 @@ def register_object(conn, object_id, object_format, parent_object=None):
     if not parent_object and object_format != 'SNAP':
         raise ValueError("Non-SNAP objects can't have no parent!")
     with conn.cursor() as cur:
-        cur.execute(insert("object_tree", ("object_id", "format", "parent_id")),
+        cur.execute(insert("objects", ("object_id", "format", "parent_id")),
                     (object_id, object_format, parent_object))
 
 
@@ -34,13 +34,13 @@ def deregister_table_object(conn, object_id):
 
 def register_objects(conn, object_meta):
     with conn.cursor() as cur:
-        execute_batch(cur, insert("object_tree", ("object_id", "format", "parent_id")), object_meta, page_size=100)
+        execute_batch(cur, insert("objects", ("object_id", "format", "parent_id")), object_meta, page_size=100)
 
 
 def register_tables(conn, mountpoint, table_meta):
     table_meta = [(mountpoint,) + o for o in table_meta]
     with conn.cursor() as cur:
-        execute_batch(cur, insert("tables", ("mountpoint", "snap_id", "table_name", "object_id")),
+        execute_batch(cur, insert("tables", ("mountpoint", "image_hash", "table_name", "object_id")),
                       table_meta, page_size=100)
 
 
@@ -57,7 +57,7 @@ def register_object_locations(conn, object_locations):
 
 def get_existing_objects(conn):
     with conn.cursor() as cur:
-        cur.execute(select("object_tree", "object_id"))
+        cur.execute(select("objects", "object_id"))
         return set(c[0] for c in cur.fetchall())
 
 
@@ -85,12 +85,12 @@ def get_external_object_locations(conn, objects):
 
 def get_object_meta(conn, objects):
     with conn.cursor() as cur:
-        cur.execute(select("object_tree", "object_id, format, parent_id",
+        cur.execute(select("objects", "object_id, format, parent_id",
                            "object_id IN (" + ','.join('%s' for _ in objects) + ")"), objects)
         return cur.fetchall()
 
 
 def register_table(conn, mountpoint, table, image, object_id):
     with conn.cursor() as cur:
-        cur.execute(insert("tables", ("mountpoint", "snap_id", "table_name", "object_id")),
+        cur.execute(insert("tables", ("mountpoint", "image_hash", "table_name", "object_id")),
                     (mountpoint, image, table, object_id))

--- a/splitgraph/meta_handler/objects.py
+++ b/splitgraph/meta_handler/objects.py
@@ -37,10 +37,10 @@ def register_objects(conn, object_meta):
         execute_batch(cur, insert("objects", ("object_id", "format", "parent_id")), object_meta, page_size=100)
 
 
-def register_tables(conn, mountpoint, table_meta):
-    table_meta = [(mountpoint,) + o for o in table_meta]
+def register_tables(conn, repository, table_meta, namespace=''):
+    table_meta = [(namespace, repository) + o for o in table_meta]
     with conn.cursor() as cur:
-        execute_batch(cur, insert("tables", ("mountpoint", "image_hash", "table_name", "object_id")),
+        execute_batch(cur, insert("tables", ("namespace", "repository", "image_hash", "table_name", "object_id")),
                       table_meta, page_size=100)
 
 
@@ -90,7 +90,7 @@ def get_object_meta(conn, objects):
         return cur.fetchall()
 
 
-def register_table(conn, mountpoint, table, image, object_id):
+def register_table(conn, repository, table, image, object_id, namespace=''):
     with conn.cursor() as cur:
-        cur.execute(insert("tables", ("mountpoint", "image_hash", "table_name", "object_id")),
-                    (mountpoint, image, table, object_id))
+        cur.execute(insert("tables", ("namespace", "repository", "image_hash", "table_name", "object_id")),
+                    (namespace, repository, image, table, object_id))

--- a/splitgraph/meta_handler/provenance.py
+++ b/splitgraph/meta_handler/provenance.py
@@ -8,31 +8,32 @@ _QUERY = SQL("""UPDATE {}.images SET provenance_type = %s, provenance_data = %s 
     .format(Identifier(SPLITGRAPH_META_SCHEMA))
 
 
-def store_import_provenance(conn, namespace, repository, image_hash, source_namespace, source_repository, source_hash,
+def store_import_provenance(conn, repository, image_hash, source_repository, source_hash,
                             tables, table_aliases, table_queries):
     with conn.cursor() as cur:
         cur.execute(_QUERY,
                     ("IMPORT", Json({
-                        'source': source_repository,
-                        'source_namespace': source_namespace,
+                        'source': source_repository.repository,
+                        'source_namespace': source_repository.namespace,
                         'source_hash': source_hash,
                         'tables': tables,
                         'table_aliases': table_aliases,
-                        'table_queries': table_queries}), namespace, repository, image_hash))
+                        'table_queries': table_queries}), repository.namespace, repository.repository, image_hash))
 
 
-def store_sql_provenance(conn, namespace, repository, image_hash, sql):
+def store_sql_provenance(conn, repository, image_hash, sql):
     with conn.cursor() as cur:
-        cur.execute(_QUERY, ('SQL', Json(sql), namespace, repository, image_hash))
+        cur.execute(_QUERY, ('SQL', Json(sql), repository.namespace, repository.repository, image_hash))
 
 
-def store_mount_provenance(conn, namespace, repository, image_hash):
+def store_mount_provenance(conn, repository, image_hash):
     # We don't store the details of images that come from an sgr MOUNT command since those are assumed to be based
     # on an inaccessible db
     with conn.cursor() as cur:
-        cur.execute(_QUERY, ('MOUNT', None, namespace, repository, image_hash))
+        cur.execute(_QUERY, ('MOUNT', None, repository.namespace, repository.repository, image_hash))
 
 
-def store_from_provenance(conn, namespace, repository, image_hash, source):
+def store_from_provenance(conn, repository, image_hash, source):
     with conn.cursor() as cur:
-        cur.execute(_QUERY, ('FROM', Json(source), namespace, repository, image_hash))
+        cur.execute(_QUERY, ('FROM', Json({'source': source.repository, 'source_namespace': source.namespace}),
+                             repository.namespace, repository.repository, image_hash))

--- a/splitgraph/meta_handler/provenance.py
+++ b/splitgraph/meta_handler/provenance.py
@@ -7,8 +7,8 @@ from splitgraph.constants import SPLITGRAPH_META_SCHEMA
 def store_import_provenance(conn, mountpoint, image_hash, source_mountpoint, source_hash, tables,
                             table_aliases, table_queries):
     with conn.cursor() as cur:
-        cur.execute(SQL("""UPDATE {}.snap_tree SET provenance_type = %s, provenance_data = %s WHERE
-                            mountpoint = %s AND snap_id = %s""").format(Identifier(SPLITGRAPH_META_SCHEMA)),
+        cur.execute(SQL("""UPDATE {}.images SET provenance_type = %s, provenance_data = %s WHERE
+                            mountpoint = %s AND image_hash = %s""").format(Identifier(SPLITGRAPH_META_SCHEMA)),
                     ("IMPORT", Json({
                         'source': source_mountpoint,
                         'source_hash': source_hash,
@@ -19,8 +19,8 @@ def store_import_provenance(conn, mountpoint, image_hash, source_mountpoint, sou
 
 def store_sql_provenance(conn, mountpoint, image_hash, sql):
     with conn.cursor() as cur:
-        cur.execute(SQL("""UPDATE {}.snap_tree SET provenance_type = %s, provenance_data = %s WHERE
-                            mountpoint = %s AND snap_id = %s""").format(Identifier(SPLITGRAPH_META_SCHEMA)),
+        cur.execute(SQL("""UPDATE {}.images SET provenance_type = %s, provenance_data = %s WHERE
+                            mountpoint = %s AND image_hash = %s""").format(Identifier(SPLITGRAPH_META_SCHEMA)),
                     ('SQL', Json(sql), mountpoint, image_hash))
 
 
@@ -28,13 +28,13 @@ def store_mount_provenance(conn, mountpoint, image_hash):
     # We don't store the details of images that come from an sgr MOUNT command since those are assumed to be based
     # on an inaccessible db
     with conn.cursor() as cur:
-        cur.execute(SQL("""UPDATE {}.snap_tree SET provenance_type = %s, provenance_data = %s WHERE
-                            mountpoint = %s AND snap_id = %s""").format(Identifier(SPLITGRAPH_META_SCHEMA)),
+        cur.execute(SQL("""UPDATE {}.images SET provenance_type = %s, provenance_data = %s WHERE
+                            mountpoint = %s AND image_hash = %s""").format(Identifier(SPLITGRAPH_META_SCHEMA)),
                     ('MOUNT', None, mountpoint, image_hash))
 
 
 def store_from_provenance(conn, mountpoint, image_hash, source):
     with conn.cursor() as cur:
-        cur.execute(SQL("""UPDATE {}.snap_tree SET provenance_type = %s, provenance_data = %s WHERE
-                            mountpoint = %s AND snap_id = %s""").format(Identifier(SPLITGRAPH_META_SCHEMA)),
+        cur.execute(SQL("""UPDATE {}.images SET provenance_type = %s, provenance_data = %s WHERE
+                            mountpoint = %s AND image_hash = %s""").format(Identifier(SPLITGRAPH_META_SCHEMA)),
                     ('FROM', Json(source), mountpoint, image_hash))

--- a/splitgraph/meta_handler/provenance.py
+++ b/splitgraph/meta_handler/provenance.py
@@ -1,40 +1,38 @@
-from psycopg2._json import Json
+from psycopg2.extras import Json
 from psycopg2.sql import SQL, Identifier
 
 from splitgraph.constants import SPLITGRAPH_META_SCHEMA
 
+_QUERY = SQL("""UPDATE {}.images SET provenance_type = %s, provenance_data = %s WHERE
+                            namespace = %s AND repository = %s AND image_hash = %s""")\
+    .format(Identifier(SPLITGRAPH_META_SCHEMA))
 
-def store_import_provenance(conn, mountpoint, image_hash, source_mountpoint, source_hash, tables,
-                            table_aliases, table_queries):
+
+def store_import_provenance(conn, namespace, repository, image_hash, source_namespace, source_repository, source_hash,
+                            tables, table_aliases, table_queries):
     with conn.cursor() as cur:
-        cur.execute(SQL("""UPDATE {}.images SET provenance_type = %s, provenance_data = %s WHERE
-                            mountpoint = %s AND image_hash = %s""").format(Identifier(SPLITGRAPH_META_SCHEMA)),
+        cur.execute(_QUERY,
                     ("IMPORT", Json({
-                        'source': source_mountpoint,
+                        'source': source_repository,
+                        'source_namespace': source_namespace,
                         'source_hash': source_hash,
                         'tables': tables,
                         'table_aliases': table_aliases,
-                        'table_queries': table_queries}), mountpoint, image_hash))
+                        'table_queries': table_queries}), namespace, repository, image_hash))
 
 
-def store_sql_provenance(conn, mountpoint, image_hash, sql):
+def store_sql_provenance(conn, namespace, repository, image_hash, sql):
     with conn.cursor() as cur:
-        cur.execute(SQL("""UPDATE {}.images SET provenance_type = %s, provenance_data = %s WHERE
-                            mountpoint = %s AND image_hash = %s""").format(Identifier(SPLITGRAPH_META_SCHEMA)),
-                    ('SQL', Json(sql), mountpoint, image_hash))
+        cur.execute(_QUERY, ('SQL', Json(sql), namespace, repository, image_hash))
 
 
-def store_mount_provenance(conn, mountpoint, image_hash):
+def store_mount_provenance(conn, namespace, repository, image_hash):
     # We don't store the details of images that come from an sgr MOUNT command since those are assumed to be based
     # on an inaccessible db
     with conn.cursor() as cur:
-        cur.execute(SQL("""UPDATE {}.images SET provenance_type = %s, provenance_data = %s WHERE
-                            mountpoint = %s AND image_hash = %s""").format(Identifier(SPLITGRAPH_META_SCHEMA)),
-                    ('MOUNT', None, mountpoint, image_hash))
+        cur.execute(_QUERY, ('MOUNT', None, namespace, repository, image_hash))
 
 
-def store_from_provenance(conn, mountpoint, image_hash, source):
+def store_from_provenance(conn, namespace, repository, image_hash, source):
     with conn.cursor() as cur:
-        cur.execute(SQL("""UPDATE {}.images SET provenance_type = %s, provenance_data = %s WHERE
-                            mountpoint = %s AND image_hash = %s""").format(Identifier(SPLITGRAPH_META_SCHEMA)),
-                    ('FROM', Json(source), mountpoint, image_hash))
+        cur.execute(_QUERY, ('FROM', Json(source), namespace, repository, image_hash))

--- a/splitgraph/meta_handler/tables.py
+++ b/splitgraph/meta_handler/tables.py
@@ -4,43 +4,30 @@ from splitgraph.constants import SPLITGRAPH_META_SCHEMA
 from splitgraph.meta_handler.common import select
 
 
-def get_all_tables(conn, mountpoint):
-    # Gets all user tables in the current mountpoint, tracked or untracked
+def get_tables_at(conn, repository, image, namespace=''):
     with conn.cursor() as cur:
-        cur.execute(
-            """SELECT table_name FROM information_schema.tables
-                WHERE table_schema = %s and table_type = 'BASE TABLE'""", (mountpoint,))
-        all_table_names = {c[0] for c in cur.fetchall()}
-
-        # Exclude all snapshots/packed tables
-        cur.execute(select('tables', 'object_id', 'mountpoint = %s'), (mountpoint,))
-        sys_tables = [c[0] for c in cur.fetchall()]
-        return list(all_table_names.difference(sys_tables))
-
-
-def get_tables_at(conn, mountpoint, image):
-    # Returns all table names mounted at mountpoint.
-    with conn.cursor() as cur:
-        cur.execute(select('tables', 'table_name', 'mountpoint = %s AND image_hash = %s'), (mountpoint, image))
+        cur.execute(select('tables', 'table_name', 'namespace = %s AND repository = %s AND image_hash = %s'),
+                    (namespace, repository, image))
         return [t[0] for t in cur.fetchall()]
 
 
-def get_table_with_format(conn, mountpoint, table_name, image, object_format):
+def get_object_for_table(conn, repository, table_name, image, object_format, namespace=''):
     # Returns the object ID of a table at a given time, with a given format.
     with conn.cursor() as cur:
         cur.execute(SQL("""SELECT {0}.tables.object_id FROM {0}.tables JOIN {0}.objects
                             ON {0}.objects.object_id = {0}.tables.object_id
-                            WHERE mountpoint = %s AND image_hash = %s AND table_name = %s AND format = %s""").format(
-            Identifier(SPLITGRAPH_META_SCHEMA)), (mountpoint, image, table_name, object_format))
+                            WHERE namespace = %s AND repository = %s AND image_hash = %s
+                            AND table_name = %s AND format = %s""").format(
+            Identifier(SPLITGRAPH_META_SCHEMA)), (namespace, repository, image, table_name, object_format))
         result = cur.fetchone()
         return None if result is None else result[0]
 
 
-def get_table(conn, mountpoint, table_name, image):
+def get_table(conn, repository, table_name, image, namespace):
     # Returns a list of available[(object_id, object_format)] from the table meta
     with conn.cursor() as cur:
         cur.execute(SQL("""SELECT {0}.tables.object_id, format FROM {0}.tables JOIN {0}.objects
                             ON {0}.objects.object_id = {0}.tables.object_id
-                            WHERE mountpoint = %s AND image_hash = %s AND table_name = %s""").format(
-            Identifier(SPLITGRAPH_META_SCHEMA)), (mountpoint, image, table_name))
+                            WHERE namespace = %s AND repository = %s AND image_hash = %s AND table_name = %s""").format(
+            Identifier(SPLITGRAPH_META_SCHEMA)), (namespace, repository, image, table_name))
         return cur.fetchall()

--- a/splitgraph/meta_handler/tables.py
+++ b/splitgraph/meta_handler/tables.py
@@ -21,16 +21,16 @@ def get_all_tables(conn, mountpoint):
 def get_tables_at(conn, mountpoint, image):
     # Returns all table names mounted at mountpoint.
     with conn.cursor() as cur:
-        cur.execute(select('tables', 'table_name', 'mountpoint = %s AND snap_id = %s'), (mountpoint, image))
+        cur.execute(select('tables', 'table_name', 'mountpoint = %s AND image_hash = %s'), (mountpoint, image))
         return [t[0] for t in cur.fetchall()]
 
 
 def get_table_with_format(conn, mountpoint, table_name, image, object_format):
     # Returns the object ID of a table at a given time, with a given format.
     with conn.cursor() as cur:
-        cur.execute(SQL("""SELECT {0}.tables.object_id FROM {0}.tables JOIN {0}.object_tree
-                            ON {0}.object_tree.object_id = {0}.tables.object_id
-                            WHERE mountpoint = %s AND snap_id = %s AND table_name = %s AND format = %s""").format(
+        cur.execute(SQL("""SELECT {0}.tables.object_id FROM {0}.tables JOIN {0}.objects
+                            ON {0}.objects.object_id = {0}.tables.object_id
+                            WHERE mountpoint = %s AND image_hash = %s AND table_name = %s AND format = %s""").format(
             Identifier(SPLITGRAPH_META_SCHEMA)), (mountpoint, image, table_name, object_format))
         result = cur.fetchone()
         return None if result is None else result[0]
@@ -39,8 +39,8 @@ def get_table_with_format(conn, mountpoint, table_name, image, object_format):
 def get_table(conn, mountpoint, table_name, image):
     # Returns a list of available[(object_id, object_format)] from the table meta
     with conn.cursor() as cur:
-        cur.execute(SQL("""SELECT {0}.tables.object_id, format FROM {0}.tables JOIN {0}.object_tree
-                            ON {0}.object_tree.object_id = {0}.tables.object_id
-                            WHERE mountpoint = %s AND snap_id = %s AND table_name = %s""").format(
+        cur.execute(SQL("""SELECT {0}.tables.object_id, format FROM {0}.tables JOIN {0}.objects
+                            ON {0}.objects.object_id = {0}.tables.object_id
+                            WHERE mountpoint = %s AND image_hash = %s AND table_name = %s""").format(
             Identifier(SPLITGRAPH_META_SCHEMA)), (mountpoint, image, table_name))
         return cur.fetchall()

--- a/splitgraph/meta_handler/tables.py
+++ b/splitgraph/meta_handler/tables.py
@@ -4,30 +4,31 @@ from splitgraph.constants import SPLITGRAPH_META_SCHEMA
 from splitgraph.meta_handler.common import select
 
 
-def get_tables_at(conn, repository, image, namespace=''):
+def get_tables_at(conn, repository, image):
     with conn.cursor() as cur:
         cur.execute(select('tables', 'table_name', 'namespace = %s AND repository = %s AND image_hash = %s'),
-                    (namespace, repository, image))
+                    (repository.namespace, repository.repository, image))
         return [t[0] for t in cur.fetchall()]
 
 
-def get_object_for_table(conn, repository, table_name, image, object_format, namespace=''):
+def get_object_for_table(conn, repository, table_name, image, object_format):
     # Returns the object ID of a table at a given time, with a given format.
     with conn.cursor() as cur:
         cur.execute(SQL("""SELECT {0}.tables.object_id FROM {0}.tables JOIN {0}.objects
                             ON {0}.objects.object_id = {0}.tables.object_id
                             WHERE namespace = %s AND repository = %s AND image_hash = %s
                             AND table_name = %s AND format = %s""").format(
-            Identifier(SPLITGRAPH_META_SCHEMA)), (namespace, repository, image, table_name, object_format))
+            Identifier(SPLITGRAPH_META_SCHEMA)), (repository.namespace, repository.repository,
+                                                  image, table_name, object_format))
         result = cur.fetchone()
         return None if result is None else result[0]
 
 
-def get_table(conn, repository, table_name, image, namespace):
+def get_table(conn, repository, table_name, image):
     # Returns a list of available[(object_id, object_format)] from the table meta
     with conn.cursor() as cur:
         cur.execute(SQL("""SELECT {0}.tables.object_id, format FROM {0}.tables JOIN {0}.objects
                             ON {0}.objects.object_id = {0}.tables.object_id
                             WHERE namespace = %s AND repository = %s AND image_hash = %s AND table_name = %s""").format(
-            Identifier(SPLITGRAPH_META_SCHEMA)), (namespace, repository, image, table_name))
+            Identifier(SPLITGRAPH_META_SCHEMA)), (repository.namespace, repository.repository, image, table_name))
         return cur.fetchall()

--- a/splitgraph/meta_handler/tags.py
+++ b/splitgraph/meta_handler/tags.py
@@ -1,25 +1,25 @@
 from psycopg2.sql import SQL, Identifier
 
-from splitgraph.constants import SplitGraphException, SPLITGRAPH_META_SCHEMA, to_mountpoint
+from splitgraph.constants import SplitGraphException, SPLITGRAPH_META_SCHEMA
 from splitgraph.meta_handler.common import ensure_metadata_schema, select, insert
 from splitgraph.meta_handler.images import get_canonical_image_id
 from splitgraph.meta_handler.misc import repository_exists
 
 
-def get_current_head(conn, repository, raise_on_none=True, namespace=''):
-    return get_tagged_id(conn, repository, 'HEAD', raise_on_none, namespace)
+def get_current_head(conn, repository, raise_on_none=True):
+    return get_tagged_id(conn, repository, 'HEAD', raise_on_none)
 
 
-def get_tagged_id(conn, repository, tag, raise_on_none=True, namespace=''):
+def get_tagged_id(conn, repository, tag, raise_on_none=True):
     ensure_metadata_schema(conn)
-    if not repository_exists(conn, repository, namespace) and raise_on_none:
+    if not repository_exists(conn, repository) and raise_on_none:
         raise SplitGraphException("%s is not mounted." % repository)
 
     if tag == 'latest':
         # Special case, return the latest commit from the repository.
         with conn.cursor() as cur:
             cur.execute(select("images", "image_hash", "namespace = %s AND repository = %s")
-                        + SQL(" ORDER BY created DESC LIMIT 1"), (namespace, repository,))
+                        + SQL(" ORDER BY created DESC LIMIT 1"), (repository.namespace, repository.repository,))
             result = cur.fetchone()
             if result is None:
                 raise SplitGraphException("No commits found in %s!")
@@ -27,62 +27,62 @@ def get_tagged_id(conn, repository, tag, raise_on_none=True, namespace=''):
 
     with conn.cursor() as cur:
         cur.execute(select("snap_tags", "image_hash", "namespace = %s AND repository = %s AND tag = %s"),
-                    (namespace, repository, tag))
+                    (repository.namespace, repository.repository, tag))
         result = cur.fetchone()
         if result is None or result == (None,):
             if raise_on_none:
+                schema = repository.to_schema()
                 if tag == 'HEAD':
                     raise SplitGraphException("No current checked out revision found for %s. Check one out with \"sgr "
-                                              "checkout %s image_hash\"." %
-                                              (to_mountpoint(namespace, repository), to_mountpoint(namespace, repository)))
+                                              "checkout %s image_hash\"." % (schema, schema))
                 else:
-                    raise SplitGraphException("Tag %s not found in repository %s" %
-                                              (tag, to_mountpoint(namespace, repository)))
+                    raise SplitGraphException("Tag %s not found in repository %s" % (tag, schema))
             else:
                 return None
         return result[0]
 
 
-def get_all_hashes_tags(conn, repository, namespace=''):
+def get_all_hashes_tags(conn, repository):
     with conn.cursor() as cur:
-        cur.execute(select("snap_tags", "image_hash, tag", "namespace = %s, repository = %s"), (namespace, repository,))
+        cur.execute(select("snap_tags", "image_hash, tag", "namespace = %s AND repository = %s"),
+                    (repository.namespace, repository.repository,))
         return cur.fetchall()
 
 
-def set_tags(conn, repository, tags, force=False, namespace=''):
+def set_tags(conn, repository, tags, force=False):
     for tag, image_id in tags.items():
         if tag != 'HEAD':
-            set_tag(conn, repository, image_id, tag, force, namespace=namespace)
+            set_tag(conn, repository, image_id, tag, force)
 
 
-def set_head(conn, repository, image, namespace):
-    set_tag(conn, repository, image, 'HEAD', force=True, namespace=namespace)
+def set_head(conn, repository, image):
+    set_tag(conn, repository, image, 'HEAD', force=True)
 
 
-def set_tag(conn, repository, image, tag, force=False, namespace=''):
+def set_tag(conn, repository, image, tag, force=False):
     with conn.cursor() as cur:
         cur.execute(select("snap_tags", "1", "namespace = %s AND repository = %s AND tag = %s"),
-                    (namespace, repository, tag))
+                    (repository.namespace, repository.repository, tag))
         if cur.fetchone() is None:
             cur.execute(insert("snap_tags", ("image_hash", "namespace", "repository", "tag")),
-                        (image, namespace, repository, tag))
+                        (image, repository.namespace, repository.repository, tag))
         else:
             if force:
                 cur.execute(SQL("UPDATE {}.snap_tags SET image_hash = %s "
                                 "WHERE namespace = %s AND repository = %s AND tag = %s").format(
                     Identifier(SPLITGRAPH_META_SCHEMA)),
-                    (image, namespace, repository, tag))
+                    (image, repository.namespace, repository.repository, tag))
             else:
-                raise SplitGraphException("Tag %s already exists in %s!" % (tag, to_mountpoint(namespace, repository)))
+                raise SplitGraphException("Tag %s already exists in %s!" % (tag, repository.to_schema()))
 
 
-def tag_or_hash_to_actual_hash(conn, repository, tag_or_hash, namespace=''):
+def tag_or_hash_to_actual_hash(conn, repository, tag_or_hash):
     """Converts a tag or shortened hash to a full image hash that exists in the repository.
     """
     try:
-        return get_canonical_image_id(conn, repository, tag_or_hash, namespace=namespace)
+        return get_canonical_image_id(conn, repository, tag_or_hash)
     except SplitGraphException:
         try:
-            return get_tagged_id(conn, repository, tag_or_hash, namespace=namespace)
+            return get_tagged_id(conn, repository, tag_or_hash)
         except SplitGraphException:
             raise SplitGraphException("%s does not refer to either an image commit hash or a tag!" % tag_or_hash)

--- a/splitgraph/meta_handler/tags.py
+++ b/splitgraph/meta_handler/tags.py
@@ -1,82 +1,88 @@
 from psycopg2.sql import SQL, Identifier
 
-from splitgraph.constants import SplitGraphException, SPLITGRAPH_META_SCHEMA
+from splitgraph.constants import SplitGraphException, SPLITGRAPH_META_SCHEMA, to_mountpoint
 from splitgraph.meta_handler.common import ensure_metadata_schema, select, insert
 from splitgraph.meta_handler.images import get_canonical_image_id
-from splitgraph.meta_handler.misc import mountpoint_exists
+from splitgraph.meta_handler.misc import repository_exists
 
 
-def get_current_head(conn, mountpoint, raise_on_none=True):
-    return get_tagged_id(conn, mountpoint, 'HEAD', raise_on_none)
+def get_current_head(conn, repository, raise_on_none=True, namespace=''):
+    return get_tagged_id(conn, repository, 'HEAD', raise_on_none, namespace)
 
 
-def get_tagged_id(conn, mountpoint, tag, raise_on_none=True):
+def get_tagged_id(conn, repository, tag, raise_on_none=True, namespace=''):
     ensure_metadata_schema(conn)
-    if not mountpoint_exists(conn, mountpoint) and raise_on_none:
-        raise SplitGraphException("%s is not mounted." % mountpoint)
+    if not repository_exists(conn, repository, namespace) and raise_on_none:
+        raise SplitGraphException("%s is not mounted." % repository)
 
     if tag == 'latest':
-        # Special case, return the latest commit from the mountpoint.
+        # Special case, return the latest commit from the repository.
         with conn.cursor() as cur:
-            cur.execute(select("images", "image_hash", "mountpoint = %s")
-                        + SQL(" ORDER BY created DESC LIMIT 1"), (mountpoint,))
+            cur.execute(select("images", "image_hash", "namespace = %s AND repository = %s")
+                        + SQL(" ORDER BY created DESC LIMIT 1"), (namespace, repository,))
             result = cur.fetchone()
             if result is None:
                 raise SplitGraphException("No commits found in %s!")
             return result[0]
 
     with conn.cursor() as cur:
-        cur.execute(select("snap_tags", "image_hash", "mountpoint = %s AND tag = %s"), (mountpoint, tag))
+        cur.execute(select("snap_tags", "image_hash", "namespace = %s AND repository = %s AND tag = %s"),
+                    (namespace, repository, tag))
         result = cur.fetchone()
         if result is None or result == (None,):
             if raise_on_none:
                 if tag == 'HEAD':
                     raise SplitGraphException("No current checked out revision found for %s. Check one out with \"sgr "
-                                              "checkout MOUNTPOINT image_hash\"." % mountpoint)
+                                              "checkout %s image_hash\"." %
+                                              (to_mountpoint(namespace, repository), to_mountpoint(namespace, repository)))
                 else:
-                    raise SplitGraphException("Tag %s not found in mountpoint %s" % (tag, mountpoint))
+                    raise SplitGraphException("Tag %s not found in repository %s" %
+                                              (tag, to_mountpoint(namespace, repository)))
             else:
                 return None
         return result[0]
 
 
-def get_all_hashes_tags(conn, mountpoint):
+def get_all_hashes_tags(conn, repository, namespace=''):
     with conn.cursor() as cur:
-        cur.execute(select("snap_tags", "image_hash, tag", "mountpoint = %s"), (mountpoint,))
+        cur.execute(select("snap_tags", "image_hash, tag", "namespace = %s, repository = %s"), (namespace, repository,))
         return cur.fetchall()
 
 
-def set_tags(conn, mountpoint, tags, force=False):
+def set_tags(conn, repository, tags, force=False, namespace=''):
     for tag, image_id in tags.items():
         if tag != 'HEAD':
-            set_tag(conn, mountpoint, image_id, tag, force)
+            set_tag(conn, repository, image_id, tag, force, namespace=namespace)
 
 
-def set_head(conn, mountpoint, image):
-    set_tag(conn, mountpoint, image, 'HEAD', force=True)
+def set_head(conn, repository, image, namespace):
+    set_tag(conn, repository, image, 'HEAD', force=True, namespace=namespace)
 
 
-def set_tag(conn, mountpoint, image, tag, force=False):
+def set_tag(conn, repository, image, tag, force=False, namespace=''):
     with conn.cursor() as cur:
-        cur.execute(select("snap_tags", "1", "mountpoint = %s AND tag = %s"), (mountpoint, tag))
+        cur.execute(select("snap_tags", "1", "namespace = %s AND repository = %s AND tag = %s"),
+                    (namespace, repository, tag))
         if cur.fetchone() is None:
-            cur.execute(insert("snap_tags", ("image_hash", "mountpoint", "tag")),
-                        (image, mountpoint, tag))
+            cur.execute(insert("snap_tags", ("image_hash", "namespace", "repository", "tag")),
+                        (image, namespace, repository, tag))
         else:
             if force:
-                cur.execute(SQL("UPDATE {}.snap_tags SET image_hash = %s WHERE mountpoint = %s AND tag = %s").format(
+                cur.execute(SQL("UPDATE {}.snap_tags SET image_hash = %s "
+                                "WHERE namespace = %s AND repository = %s AND tag = %s").format(
                     Identifier(SPLITGRAPH_META_SCHEMA)),
-                    (image, mountpoint, tag))
+                    (image, namespace, repository, tag))
             else:
-                raise SplitGraphException("Tag %s already exists in mountpoint %s!" % (tag, mountpoint))
+                raise SplitGraphException("Tag %s already exists in %s!" % (tag, to_mountpoint(namespace, repository)))
 
 
-def tag_or_hash_to_actual_hash(conn, mountpoint, tag_or_hash):
-    """Converts a tag or shortened hash to a full image hash that exists in the mountpoint."""
+def tag_or_hash_to_actual_hash(conn, repository, tag_or_hash, namespace=''):
+    """Converts a tag or shortened hash to a full image hash that exists in the repository.
+    """
     try:
-        return get_canonical_image_id(conn, mountpoint, tag_or_hash)
+        return get_canonical_image_id(conn, repository, tag_or_hash, namespace=namespace)
     except SplitGraphException:
         try:
-            return get_tagged_id(conn, mountpoint, tag_or_hash)
+            return get_tagged_id(conn, repository, tag_or_hash, namespace=namespace)
         except SplitGraphException:
             raise SplitGraphException("%s does not refer to either an image commit hash or a tag!" % tag_or_hash)

--- a/splitgraph/objects/creation.py
+++ b/splitgraph/objects/creation.py
@@ -3,7 +3,7 @@ import json
 from psycopg2.extras import execute_batch, Json
 from psycopg2.sql import SQL, Identifier
 
-from splitgraph.constants import SPLITGRAPH_META_SCHEMA, get_random_object_id, to_ns_repo, to_mountpoint
+from splitgraph.constants import SPLITGRAPH_META_SCHEMA, get_random_object_id
 from splitgraph.meta_handler.objects import register_table, register_object
 from splitgraph.meta_handler.tables import get_object_for_table
 from splitgraph.objects.utils import get_replica_identity, conflate_changes, convert_audit_change
@@ -32,11 +32,9 @@ def _create_diff_table(conn, object_id, replica_identity_cols_types):
         # RI is PK anyway, so has an index by default
 
 
-def record_table_as_diff(conn, repository, image_hash, table, table_info, namespace):
-    schema = to_mountpoint(namespace, repository)
-
+def record_table_as_diff(conn, repository, image_hash, table, table_info):
     object_id = get_random_object_id()
-    repl_id = get_replica_identity(conn, schema, table)
+    repl_id = get_replica_identity(conn, repository.to_schema(), table)
     ri_cols, _ = zip(*repl_id)
     _create_diff_table(conn, object_id, repl_id)
     with conn.cursor() as cur:
@@ -44,7 +42,7 @@ def record_table_as_diff(conn, repository, image_hash, table, table_info, namesp
         cur.execute(
             SQL("""DELETE FROM {}.{} WHERE schema_name = %s AND table_name = %s
                                    RETURNING action, row_data, changed_fields""").format(
-                Identifier("audit"), Identifier("logged_actions")), (schema, table))
+                Identifier("audit"), Identifier("logged_actions")), (repository.to_schema(), table))
         # Accumulate the diff in-memory.
         changeset = {}
         for action, row_data, changed_fields in cur:
@@ -59,18 +57,18 @@ def record_table_as_diff(conn, repository, image_hash, table, table_info, namesp
             execute_batch(cur, query, changeset, page_size=1000)
 
             for parent_id, _ in table_info:
-                register_object(conn, object_id, object_format='DIFF', parent_object=parent_id)
+                register_object(conn, object_id, object_format='DIFF', parent_object=parent_id,
+                                original_namespace=repository.namespace)
 
-            register_table(conn, repository, table, image_hash, object_id, namespace=namespace)
+            register_table(conn, repository, table, image_hash, object_id)
         else:
             # Changes in the audit log cancelled each other out. Delete the diff table and just point
             # the commit to the old table objects.
             cur.execute(
                 SQL("DROP TABLE {}.{}").format(Identifier(SPLITGRAPH_META_SCHEMA),
                                                Identifier(object_id)))
-            namespace, repository = to_ns_repo(schema)
             for prev_object_id, _ in table_info:
-                register_table(conn, repository, table, image_hash, prev_object_id, namespace=namespace)
+                register_table(conn, repository, table, image_hash, prev_object_id)
 
 
 def _convert_vals(vals):
@@ -83,16 +81,17 @@ def _convert_vals(vals):
     return [v if not isinstance(v, dict) else Json(v) for v in vals]
 
 
-def record_table_as_snap(conn, repository, image_hash, table, table_info, namespace):
+def record_table_as_snap(conn, repository, image_hash, table, table_info):
     # Make sure we didn't actually create a snap for this table.
-    schema = to_mountpoint(namespace, repository)
 
-    if get_object_for_table(conn, repository, table, image_hash, 'SNAP', namespace=namespace) is None:
+    if get_object_for_table(conn, repository, table, image_hash, 'SNAP') is None:
         object_id = get_random_object_id()
-        copy_table(conn, schema, table, SPLITGRAPH_META_SCHEMA, object_id, with_pk_constraints=True)
+        copy_table(conn, repository.to_schema(), table, SPLITGRAPH_META_SCHEMA, object_id, with_pk_constraints=True)
         if table_info:
             for parent_id, _ in table_info:
-                register_object(conn, object_id, object_format='SNAP', parent_object=parent_id)
+                register_object(conn, object_id, object_format='SNAP', parent_object=parent_id,
+                                original_namespace=repository.namespace)
         else:
-            register_object(conn, object_id, object_format='SNAP', parent_object=None)
-        register_table(conn, repository, table, image_hash, object_id, namespace=namespace)
+            register_object(conn, object_id, object_format='SNAP', parent_object=None,
+                            original_namespace=repository.namespace)
+        register_table(conn, repository, table, image_hash, object_id)

--- a/splitgraph/objects/utils.py
+++ b/splitgraph/objects/utils.py
@@ -4,17 +4,17 @@ from splitgraph.constants import SplitGraphException
 from splitgraph.pg_utils import get_primary_keys, get_column_names_types
 
 
-def get_replica_identity(conn, mountpoint, table):
-    return get_primary_keys(conn, mountpoint, table) or get_column_names_types(conn, mountpoint, table)
+def get_replica_identity(conn, schema, table):
+    return get_primary_keys(conn, schema, table) or get_column_names_types(conn, schema, table)
 
 
-def _generate_where_clause(mountpoint, table, cols, table_2=None, mountpoint_2=None):
+def _generate_where_clause(schema, table, cols, table_2=None, schema_2=None):
     if not table_2:
         return SQL(" AND ").join(SQL("{}.{}.{} = %s").format(
-            Identifier(mountpoint), Identifier(table), Identifier(c)) for c in cols)
+            Identifier(schema), Identifier(table), Identifier(c)) for c in cols)
     return SQL(" AND ").join(SQL("{}.{}.{} = {}.{}.{}").format(
-        Identifier(mountpoint), Identifier(table), Identifier(c),
-        Identifier(mountpoint_2), Identifier(table_2), Identifier(c)) for c in cols)
+        Identifier(schema), Identifier(table), Identifier(c),
+        Identifier(schema_2), Identifier(table_2), Identifier(c)) for c in cols)
 
 
 def _split_ri_cols(action, row_data, changed_fields, ri_cols):

--- a/splitgraph/registry_meta_handler.py
+++ b/splitgraph/registry_meta_handler.py
@@ -13,6 +13,7 @@ def _create_registry_schema(conn):
     with conn.cursor() as cur:
         cur.execute(SQL("CREATE SCHEMA {}").format(Identifier(REGISTRY_META_SCHEMA)))
         cur.execute(SQL("""CREATE TABLE {}.{} (
+                        namespace  VARCHAR NOT NULL,
                         repository VARCHAR NOT NULL,
                         tag        VARCHAR NOT NULL,
                         image_hash VARCHAR NOT NULL,
@@ -21,8 +22,8 @@ def _create_registry_schema(conn):
                         readme     VARCHAR,
                         schemata   JSON,
                         previews   JSON,
-                        PRIMARY KEY (repository, tag))""").format(Identifier(REGISTRY_META_SCHEMA),
-                                                                  Identifier("images")))
+                        PRIMARY KEY (namespace, repository, tag))""").format(Identifier(REGISTRY_META_SCHEMA),
+                                                                             Identifier("images")))
 
 
 def ensure_registry_schema(conn):
@@ -32,7 +33,7 @@ def ensure_registry_schema(conn):
             _create_registry_schema(conn)
 
 
-def publish_tag(conn, repository, tag, image_hash, published, provenance, readme, schemata, previews):
+def publish_tag(conn, repository, tag, image_hash, published, provenance, readme, schemata, previews, namespace=''):
     """
     Publishes a given tag in the remote catalog. Should't be called directly.
     Use splitgraph.commands.publish instead.
@@ -46,25 +47,26 @@ def publish_tag(conn, repository, tag, image_hash, published, provenance, readme
     :param readme: An optional README for the repo
     :param schemata: Dict mapping table name to a list of (column name, column type)
     :param previews: Dict mapping table name to a list of tuples with a preview
+    :param namespace: Namespace (username or organisation) to publish the repository to.
     """
     with conn.cursor() as cur:
         cur.execute(insert("images",
-                           ['repository', 'tag', 'image_hash', 'published',
+                           ['namespace', 'repository', 'tag', 'image_hash', 'published',
                              'provenance', 'readme', 'schemata', 'previews'],
-                           REGISTRY_META_SCHEMA), (repository, tag, image_hash, published, Json(provenance),
+                           REGISTRY_META_SCHEMA), (namespace, repository, tag, image_hash, published, Json(provenance),
                                                    readme, Json(schemata), Json(previews)))
 
 
-def get_published_info(conn, repository, tag):
+def get_published_info(conn, repository, tag, namespace=''):
     with conn.cursor() as cur:
         cur.execute(select("images",
                             'image_hash,published,provenance,readme,schemata,previews',
-                            "repository = %s AND tag = %s",
-                           REGISTRY_META_SCHEMA), (repository, tag))
+                            "namespace = %s AND repository = %s AND tag = %s",
+                           REGISTRY_META_SCHEMA), (namespace, repository, tag))
         return cur.fetchone()
 
 
-def unpublish_repository(conn, repository):
+def unpublish_repository(conn, repository, namespace=''):
     with conn.cursor() as cur:
-        cur.execute(SQL("DELETE FROM {}.{} WHERE repository = %s").format(Identifier(REGISTRY_META_SCHEMA),
-                                                                          Identifier("images")), (repository,))
+        cur.execute(SQL("DELETE FROM {}.{} WHERE namespace = %s AND repository = %s").format(Identifier(REGISTRY_META_SCHEMA),
+                                                                          Identifier("images")), (namespace, repository))

--- a/splitgraph/sgfile/execution.py
+++ b/splitgraph/sgfile/execution.py
@@ -6,7 +6,7 @@ from splitgraph.commands import checkout, init, unmount, clone, import_tables, c
 from splitgraph.commands.mount_handlers import get_mount_handler
 from splitgraph.commands.push_pull import local_clone, pull
 from splitgraph.config.repo_lookups import lookup_repo
-from splitgraph.constants import SplitGraphException, serialize_connection_string, Color, to_repository
+from splitgraph.constants import SplitGraphException, serialize_connection_string, Color, to_repository, Repository
 from splitgraph.meta_handler.misc import repository_exists
 from splitgraph.meta_handler.provenance import store_import_provenance, store_sql_provenance, store_mount_provenance, \
     store_from_provenance
@@ -199,7 +199,7 @@ def _execute_db_import(conn, conn_string, fdw_name, fdw_params, table_names, tar
 def _execute_repo_import(conn, repository, table_names, tag_or_hash, target_repository, table_aliases, table_queries):
     # Don't use the actual routine here as we want more control: clone the remote repo in order to turn
     # the tag into an actual hash
-    tmp_repo = to_repository(repository.repository + '_clone_tmp')
+    tmp_repo = Repository(repository.namespace, repository.repository + '_clone_tmp')
     try:
         # Calculate the hash of the new layer by combining the hash of the previous layer,
         # the hash of the source and all the table names/aliases getting imported.

--- a/test/resources/external_sql.sgfile
+++ b/test/resources/external_sql.sgfile
@@ -1,3 +1,3 @@
-FROM test_pg_mount:latest IMPORT fruits AS my_fruits, vegetables
+FROM test/pg_mount:latest IMPORT fruits AS my_fruits, vegetables
 
 SQL FILE ${EXTERNAL_SQL_FILE}

--- a/test/resources/from_local.sgfile
+++ b/test/resources/from_local.sgfile
@@ -1,4 +1,4 @@
-FROM test_pg_mount:latest
+FROM test/pg_mount:latest
 # Same idea as from_remote but here we clone the _local_ repo into the output and create the join table.
 
 SQL CREATE TABLE join_table AS SELECT fruit_id AS id, fruits.name AS fruit, vegetables.name AS vegetable \

--- a/test/resources/from_remote.sgfile
+++ b/test/resources/from_remote.sgfile
@@ -1,5 +1,5 @@
-FROM test_pg_mount:${TAG}
-# This is supposed to import the remote test_pg_mount repo locally as output and base derivations off of it.
+FROM test/pg_mount:${TAG}
+# This is supposed to import the remote test/pg_mount repo locally as output and base derivations off of it.
 
 SQL CREATE TABLE join_table AS SELECT fruit_id AS id, fruits.name AS fruit, vegetables.name AS vegetable \
                                 FROM fruits JOIN vegetables\

--- a/test/resources/from_remote_multistage.sgfile
+++ b/test/resources/from_remote_multistage.sgfile
@@ -1,6 +1,6 @@
 # Stage 1: get both tables from the remote and join them
 
-FROM test_pg_mount:${TAG} AS output
+FROM test/pg_mount:${TAG} AS output
 
 SQL CREATE TABLE join_table AS SELECT fruit_id AS id, fruits.name AS fruit, vegetables.name AS vegetable \
                                 FROM fruits JOIN vegetables\

--- a/test/resources/import_and_update.sgfile
+++ b/test/resources/import_and_update.sgfile
@@ -1,4 +1,4 @@
-FROM test_pg_mount IMPORT fruits AS my_fruits, vegetables
+FROM test/pg_mount IMPORT fruits AS my_fruits, vegetables
 
 SQL INSERT INTO my_fruits VALUES (3, 'mayonnaise')
 

--- a/test/resources/import_local.sgfile
+++ b/test/resources/import_local.sgfile
@@ -1,2 +1,2 @@
 # We don't allow SOURCE any more -- all tables have to be imported.
-FROM test_pg_mount IMPORT fruits AS my_fruits
+FROM test/pg_mount IMPORT fruits AS my_fruits

--- a/test/resources/import_local_multiple_with_queries.sgfile
+++ b/test/resources/import_local_multiple_with_queries.sgfile
@@ -1,4 +1,4 @@
-FROM test_pg_mount IMPORT fruits AS my_fruits, vegetables
+FROM test/pg_mount IMPORT fruits AS my_fruits, vegetables
 
 SQL DELETE FROM my_fruits WHERE fruit_id = 1
 

--- a/test/resources/import_remote_multiple.sgfile
+++ b/test/resources/import_remote_multiple.sgfile
@@ -2,7 +2,7 @@
 # everywhere, even in the comments).
 # Escaping $ works too: \${ESCAPED} doesn't get changed.
 
-FROM test_pg_mount:${TAG} IMPORT fruits AS my_fruits, vegetables
+FROM test/pg_mount:${TAG} IMPORT fruits AS my_fruits, vegetables
 
 SQL CREATE TABLE join_table AS SELECT fruit_id AS id, my_fruits.name AS fruit, vegetables.name AS vegetable \
                                 FROM my_fruits JOIN vegetables\

--- a/test/resources/import_with_custom_query.sgfile
+++ b/test/resources/import_with_custom_query.sgfile
@@ -1,4 +1,4 @@
-FROM test_pg_mount IMPORT {SELECT * FROM fruits WHERE name = 'orange'} AS my_fruits,
+FROM test/pg_mount IMPORT {SELECT * FROM fruits WHERE name = 'orange'} AS my_fruits,
                           {SELECT * FROM vegetables WHERE name LIKE '%o'} AS o_vegetables,
                           vegetables,
                           fruits AS all_fruits

--- a/test/resources/import_with_custom_query_and_sql.sgfile
+++ b/test/resources/import_with_custom_query_and_sql.sgfile
@@ -1,4 +1,4 @@
-FROM test_pg_mount:${TAG} IMPORT {SELECT * FROM fruits WHERE name = 'orange'} AS my_fruits,
+FROM test/pg_mount:${TAG} IMPORT {SELECT * FROM fruits WHERE name = 'orange'} AS my_fruits,
                           {SELECT * FROM vegetables WHERE name LIKE '%o'} AS o_vegetables,
                           vegetables,
                           fruits AS all_fruits

--- a/test/resources/schema_changes.sgfile
+++ b/test/resources/schema_changes.sgfile
@@ -1,4 +1,4 @@
-FROM test_pg_mount IMPORT fruits
+FROM test/pg_mount IMPORT fruits
 FROM test_mg_mount IMPORT stuff
 
 SQL CREATE TABLE spirit_fruits AS SELECT fruits.fruit_id, stuff.name, fruits.name AS spirit_fruit\

--- a/test/splitgraph/commands/test_diff_packing.py
+++ b/test/splitgraph/commands/test_diff_packing.py
@@ -9,43 +9,43 @@ from test.splitgraph.conftest import PG_MNT
 
 CASES = [
     [  # Insert + update changed into a single insert
-        ("""INSERT INTO test_pg_mount.fruits VALUES (3, 'mayonnaise');
-        UPDATE test_pg_mount.fruits SET name = 'mustard' WHERE fruit_id = 3""",
+        ("""INSERT INTO "test/pg_mount".fruits VALUES (3, 'mayonnaise');
+        UPDATE "test/pg_mount".fruits SET name = 'mustard' WHERE fruit_id = 3""",
          [((3, 'mustard'), 0, {'c': [], 'v': []})]),
         # Insert + update + delete did nothing (todo what about sequences)
-        ("""INSERT INTO test_pg_mount.fruits VALUES (4, 'kumquat');
-        UPDATE test_pg_mount.fruits SET name = 'mustard' WHERE fruit_id = 4;
-        DELETE FROM test_pg_mount.fruits WHERE fruit_id = 4""",
+        ("""INSERT INTO "test/pg_mount".fruits VALUES (4, 'kumquat');
+        UPDATE "test/pg_mount".fruits SET name = 'mustard' WHERE fruit_id = 4;
+        DELETE FROM "test/pg_mount".fruits WHERE fruit_id = 4""",
          []),
         # delete + reinsert same results in nothing
-        ("""DELETE FROM test_pg_mount.fruits WHERE fruit_id = 1;
-        INSERT INTO test_pg_mount.fruits VALUES (1, 'apple')""",
+        ("""DELETE FROM "test/pg_mount".fruits WHERE fruit_id = 1;
+        INSERT INTO "test/pg_mount".fruits VALUES (1, 'apple')""",
          []),
         # Two updates, but the PK changed back to the original one -- no diff.
-        ("""UPDATE test_pg_mount.fruits SET name = 'pineapple' WHERE fruit_id = 1;
-        UPDATE test_pg_mount.fruits SET name = 'apple' WHERE fruit_id = 1""",
+        ("""UPDATE "test/pg_mount".fruits SET name = 'pineapple' WHERE fruit_id = 1;
+        UPDATE "test/pg_mount".fruits SET name = 'apple' WHERE fruit_id = 1""",
          [])
     ],
     [# Now test this whole thing works with primary keys
-        ("""ALTER TABLE test_pg_mount.fruits ADD PRIMARY KEY (fruit_id)""",
+        ("""ALTER TABLE "test/pg_mount".fruits ADD PRIMARY KEY (fruit_id)""",
          []),
         # Insert + update changed into a single insert (same pk, different value)
-        ("""INSERT INTO test_pg_mount.fruits VALUES (3, 'mayonnaise');
-            UPDATE test_pg_mount.fruits SET name = 'mustard' WHERE fruit_id = 3""",
+        ("""INSERT INTO "test/pg_mount".fruits VALUES (3, 'mayonnaise');
+            UPDATE "test/pg_mount".fruits SET name = 'mustard' WHERE fruit_id = 3""",
             [((3,), 0, {'c': ['name'], 'v': ['mustard']})]),
         # Insert + update + delete did nothing
-        ("""INSERT INTO test_pg_mount.fruits VALUES (4, 'kumquat');
-            UPDATE test_pg_mount.fruits SET name = 'mustard' WHERE fruit_id = 4;
-            DELETE FROM test_pg_mount.fruits WHERE fruit_id = 4""",
+        ("""INSERT INTO "test/pg_mount".fruits VALUES (4, 'kumquat');
+            UPDATE "test/pg_mount".fruits SET name = 'mustard' WHERE fruit_id = 4;
+            DELETE FROM "test/pg_mount".fruits WHERE fruit_id = 4""",
          []),
         # delete + reinsert same
-        ("""DELETE FROM test_pg_mount.fruits WHERE fruit_id = 1;
-            INSERT INTO test_pg_mount.fruits VALUES (1, 'apple')""",
+        ("""DELETE FROM "test/pg_mount".fruits WHERE fruit_id = 1;
+            INSERT INTO "test/pg_mount".fruits VALUES (1, 'apple')""",
          # Currently the packer isn't aware that we rewrote the same value
          [((1,), 2, {'c': ['name'], 'v': ['apple']})]),
         # Two updates
-        ("""UPDATE test_pg_mount.fruits SET name = 'pineapple' WHERE fruit_id = 1;
-            UPDATE test_pg_mount.fruits SET name = 'apple' WHERE fruit_id = 1""",
+        ("""UPDATE "test/pg_mount".fruits SET name = 'pineapple' WHERE fruit_id = 1;
+            UPDATE "test/pg_mount".fruits SET name = 'apple' WHERE fruit_id = 1""",
          # Same here
          [((1,), 2, {'c': ['name'], 'v': ['apple']})])
     ]

--- a/test/splitgraph/commands/test_diff_packing.py
+++ b/test/splitgraph/commands/test_diff_packing.py
@@ -1,7 +1,7 @@
 import pytest
 
 from splitgraph.commands import commit, diff
-from splitgraph.meta_handler.images import get_image_parent
+from splitgraph.meta_handler.images import get_image
 from test.splitgraph.conftest import PG_MNT
 
 # Test cases: ops are a list of operations (with commit after each set);
@@ -61,4 +61,4 @@ def test_diff_conflation_on_commit(sg_pg_conn, test_case):
             cur.execute(operation)
         sg_pg_conn.commit()
         head = commit(sg_pg_conn, PG_MNT)
-        assert diff(sg_pg_conn, PG_MNT, 'fruits', get_image_parent(sg_pg_conn, PG_MNT, head), head) == expected_diff
+        assert diff(sg_pg_conn, PG_MNT, 'fruits', get_image(sg_pg_conn, PG_MNT, head).parent_id, head) == expected_diff

--- a/test/splitgraph/commands/test_import.py
+++ b/test/splitgraph/commands/test_import.py
@@ -3,11 +3,10 @@ from splitgraph.commands.diff import dump_pending_changes
 from splitgraph.commands.importing import import_table_from_unmounted
 from splitgraph.commands.misc import cleanup_objects
 from splitgraph.meta_handler.images import get_image_parent
-from splitgraph.meta_handler.misc import get_current_mountpoints_hashes
+from splitgraph.meta_handler.misc import get_current_repositories
 from splitgraph.meta_handler.objects import get_existing_objects, get_downloaded_objects
-from splitgraph.meta_handler.tables import get_all_tables
 from splitgraph.meta_handler.tags import get_current_head
-from splitgraph.pg_utils import pg_table_exists
+from splitgraph.pg_utils import pg_table_exists, get_all_tables
 from test.splitgraph.conftest import PG_MNT, REMOTE_CONN_STRING
 
 
@@ -107,7 +106,8 @@ def test_import_from_remote(empty_pg_conn, remote_driver_conn):
     assert get_all_tables(empty_pg_conn, 'output') == ['test']
 
     # Import the 'fruits' table from the origin.
-    import_table_from_unmounted(empty_pg_conn, REMOTE_CONN_STRING, PG_MNT, ['fruits'], get_current_head(remote_driver_conn, PG_MNT),
+    import_table_from_unmounted(empty_pg_conn, REMOTE_CONN_STRING, PG_MNT, ['fruits'],
+                                get_current_head(remote_driver_conn, PG_MNT),
                                 'output', target_tables=[])
     new_head = get_current_head(empty_pg_conn, 'output')
 
@@ -115,7 +115,7 @@ def test_import_from_remote(empty_pg_conn, remote_driver_conn):
     # Also clean up the unused objects to make sure that the newly cloned table is still recorded.
     assert sorted(get_all_tables(empty_pg_conn, 'output')) == ['fruits', 'test']
     cleanup_objects(empty_pg_conn)
-    assert len(get_current_mountpoints_hashes(empty_pg_conn)) == 1
+    assert len(get_current_repositories(empty_pg_conn)) == 1
     checkout(empty_pg_conn, 'output', head)
     assert pg_table_exists(empty_pg_conn, 'output', 'test')
     assert not pg_table_exists(empty_pg_conn, 'output', 'fruits')
@@ -137,7 +137,8 @@ def test_import_and_update(empty_pg_conn, remote_driver_conn):
     init(empty_pg_conn, 'output')
     head = get_current_head(empty_pg_conn, 'output')
     # Import the 'fruits' table from the origin.
-    import_table_from_unmounted(empty_pg_conn, REMOTE_CONN_STRING, PG_MNT, ['fruits'], get_current_head(remote_driver_conn, PG_MNT),
+    import_table_from_unmounted(empty_pg_conn, REMOTE_CONN_STRING, PG_MNT, ['fruits'],
+                                get_current_head(remote_driver_conn, PG_MNT),
                                 'output', target_tables=[])
     new_head = get_current_head(empty_pg_conn, 'output')
 

--- a/test/splitgraph/commands/test_import.py
+++ b/test/splitgraph/commands/test_import.py
@@ -1,20 +1,20 @@
 from splitgraph.commands import checkout, commit, init, import_tables
 from splitgraph.commands.diff import dump_pending_changes
-from splitgraph.commands.importing import import_table_from_unmounted
+from splitgraph.commands.importing import import_table_from_remote
 from splitgraph.commands.misc import cleanup_objects
-from splitgraph.meta_handler.images import get_image_parent
+from splitgraph.meta_handler.images import get_image
 from splitgraph.meta_handler.misc import get_current_repositories
 from splitgraph.meta_handler.objects import get_existing_objects, get_downloaded_objects
 from splitgraph.meta_handler.tags import get_current_head
 from splitgraph.pg_utils import pg_table_exists, get_all_tables
-from test.splitgraph.conftest import PG_MNT, REMOTE_CONN_STRING
+from test.splitgraph.conftest import PG_MNT, REMOTE_CONN_STRING, OUTPUT
 
 
 def test_import_basic(sg_pg_conn):
     # Create a new schema and import 'fruits' from the mounted PG table.
-    init(sg_pg_conn, 'output')
-    head = get_current_head(sg_pg_conn, 'output')
-    import_tables(sg_pg_conn, mountpoint=PG_MNT, tables=['fruits'], target_mountpoint='output',
+    init(sg_pg_conn, OUTPUT)
+    head = get_current_head(sg_pg_conn, OUTPUT)
+    import_tables(sg_pg_conn, repository=PG_MNT, tables=['fruits'], target_repository=OUTPUT,
                   target_tables=['imported_fruits'])
 
     with sg_pg_conn.cursor() as cur:
@@ -23,59 +23,59 @@ def test_import_basic(sg_pg_conn):
         cur.execute("""SELECT * FROM test_pg_mount.fruits""")
         input = cur.fetchall()
         assert input == output
-    new_head = get_current_head(sg_pg_conn, 'output')
+    new_head = get_current_head(sg_pg_conn, OUTPUT)
 
     assert new_head != head
-    assert get_image_parent(sg_pg_conn, 'output', new_head) == head
+    assert get_image(sg_pg_conn, OUTPUT, new_head).parent_id == head
 
 
 def test_import_preserves_existing_tables(sg_pg_conn):
     # Create a new schema and import 'fruits' from the mounted PG table.
-    init(sg_pg_conn, 'output')
+    init(sg_pg_conn, OUTPUT)
     with sg_pg_conn.cursor() as cur:
         cur.execute("""CREATE TABLE output.test (id integer, name varchar)""")
         cur.execute("""INSERT INTO output.test VALUES (1, 'test')""")
-    commit(sg_pg_conn, 'output')
+    commit(sg_pg_conn, OUTPUT)
     with sg_pg_conn.cursor() as cur:
         cur.execute("""INSERT INTO output.test VALUES (2, 'test2')""")
-    head = commit(sg_pg_conn, 'output')
+    head = commit(sg_pg_conn, OUTPUT)
 
-    import_tables(sg_pg_conn, mountpoint=PG_MNT, tables=['fruits'], target_mountpoint='output',
+    import_tables(sg_pg_conn, repository=PG_MNT, tables=['fruits'], target_repository=OUTPUT,
                   target_tables=['imported_fruits'])
 
-    new_head = get_current_head(sg_pg_conn, 'output')
+    new_head = get_current_head(sg_pg_conn, OUTPUT)
 
-    checkout(sg_pg_conn, 'output', head)
-    assert pg_table_exists(sg_pg_conn, 'output', 'test')
-    assert not pg_table_exists(sg_pg_conn, 'output', 'imported_fruits')
+    checkout(sg_pg_conn, OUTPUT, head)
+    assert pg_table_exists(sg_pg_conn, OUTPUT.to_schema(), 'test')
+    assert not pg_table_exists(sg_pg_conn, OUTPUT.to_schema(), 'imported_fruits')
 
-    checkout(sg_pg_conn, 'output', new_head)
-    assert pg_table_exists(sg_pg_conn, 'output', 'test')
-    assert pg_table_exists(sg_pg_conn, 'output', 'imported_fruits')
+    checkout(sg_pg_conn, OUTPUT, new_head)
+    assert pg_table_exists(sg_pg_conn, OUTPUT.to_schema(), 'test')
+    assert pg_table_exists(sg_pg_conn, OUTPUT.to_schema(), 'imported_fruits')
 
 
 def test_import_preserves_pending_changes(sg_pg_conn):
-    init(sg_pg_conn, 'output')
+    init(sg_pg_conn, OUTPUT)
     with sg_pg_conn.cursor() as cur:
         cur.execute("""CREATE TABLE output.test (id integer, name varchar)""")
         cur.execute("""INSERT INTO output.test VALUES (1, 'test')""")
-    head = commit(sg_pg_conn, 'output')
+    head = commit(sg_pg_conn, OUTPUT)
     with sg_pg_conn.cursor() as cur:
         cur.execute("""INSERT INTO output.test VALUES (2, 'test2')""")
-    changes = dump_pending_changes(sg_pg_conn, 'output', 'test')
+    changes = dump_pending_changes(sg_pg_conn, OUTPUT.to_schema(), 'test')
 
-    import_tables(sg_pg_conn, mountpoint=PG_MNT, tables=['fruits'], target_mountpoint='output',
+    import_tables(sg_pg_conn, repository=PG_MNT, tables=['fruits'], target_repository=OUTPUT,
                   target_tables=['imported_fruits'])
-    new_head = get_current_head(sg_pg_conn, 'output')
+    new_head = get_current_head(sg_pg_conn, OUTPUT)
 
-    assert get_image_parent(sg_pg_conn, 'output', new_head) == head
-    assert changes == dump_pending_changes(sg_pg_conn, 'output', 'test')
+    assert get_image(sg_pg_conn, OUTPUT, new_head).parent_id == head
+    assert changes == dump_pending_changes(sg_pg_conn, OUTPUT.to_schema(), 'test')
 
 
 def test_import_multiple_tables(sg_pg_conn):
-    init(sg_pg_conn, 'output')
-    head = get_current_head(sg_pg_conn, 'output')
-    import_tables(sg_pg_conn, mountpoint=PG_MNT, tables=[], target_mountpoint='output', target_tables=[])
+    init(sg_pg_conn, OUTPUT)
+    head = get_current_head(sg_pg_conn, OUTPUT)
+    import_tables(sg_pg_conn, repository=PG_MNT, tables=[], target_repository=OUTPUT, target_tables=[])
 
     for table_name in ['fruits', 'vegetables']:
         with sg_pg_conn.cursor() as cur:
@@ -85,44 +85,43 @@ def test_import_multiple_tables(sg_pg_conn):
             input = cur.fetchall()
             assert input == output
 
-    new_head = get_current_head(sg_pg_conn, 'output')
+    new_head = get_current_head(sg_pg_conn, OUTPUT)
     assert new_head != head
-    assert get_image_parent(sg_pg_conn, 'output', new_head) == head
+    assert get_image(sg_pg_conn, OUTPUT, new_head).parent_id == head
 
 
 def test_import_from_remote(empty_pg_conn, remote_driver_conn):
     # Start with a clean repo -- add a table to output to see if it's preserved.
-    init(empty_pg_conn, 'output')
+    init(empty_pg_conn, OUTPUT)
     with empty_pg_conn.cursor() as cur:
         cur.execute("""CREATE TABLE output.test (id integer, name varchar)""")
         cur.execute("""INSERT INTO output.test VALUES (1, 'test')""")
-    commit(empty_pg_conn, 'output')
+    commit(empty_pg_conn, OUTPUT)
     with empty_pg_conn.cursor() as cur:
         cur.execute("""INSERT INTO output.test VALUES (2, 'test2')""")
-    head = commit(empty_pg_conn, 'output')
+    head = commit(empty_pg_conn, OUTPUT)
 
     assert len(get_downloaded_objects(empty_pg_conn)) == 2
     assert len(get_existing_objects(empty_pg_conn)) == 2
-    assert get_all_tables(empty_pg_conn, 'output') == ['test']
+    assert get_all_tables(empty_pg_conn, OUTPUT.to_schema()) == ['test']
 
     # Import the 'fruits' table from the origin.
-    import_table_from_unmounted(empty_pg_conn, REMOTE_CONN_STRING, PG_MNT, ['fruits'],
-                                get_current_head(remote_driver_conn, PG_MNT),
-                                'output', target_tables=[])
-    new_head = get_current_head(empty_pg_conn, 'output')
+    import_table_from_remote(empty_pg_conn, REMOTE_CONN_STRING, PG_MNT, ['fruits'],
+                             get_current_head(remote_driver_conn, PG_MNT), OUTPUT, target_tables=[])
+    new_head = get_current_head(empty_pg_conn, OUTPUT)
 
     # Check that the table now exists in the output, is committed and there's no trace of the cloned repo.
     # Also clean up the unused objects to make sure that the newly cloned table is still recorded.
-    assert sorted(get_all_tables(empty_pg_conn, 'output')) == ['fruits', 'test']
+    assert sorted(get_all_tables(empty_pg_conn, OUTPUT.to_schema())) == ['fruits', 'test']
     cleanup_objects(empty_pg_conn)
     assert len(get_current_repositories(empty_pg_conn)) == 1
-    checkout(empty_pg_conn, 'output', head)
-    assert pg_table_exists(empty_pg_conn, 'output', 'test')
-    assert not pg_table_exists(empty_pg_conn, 'output', 'fruits')
+    checkout(empty_pg_conn, OUTPUT, head)
+    assert pg_table_exists(empty_pg_conn, OUTPUT.to_schema(), 'test')
+    assert not pg_table_exists(empty_pg_conn, OUTPUT.to_schema(), 'fruits')
 
-    checkout(empty_pg_conn, 'output', new_head)
-    assert pg_table_exists(empty_pg_conn, 'output', 'test')
-    assert pg_table_exists(empty_pg_conn, 'output', 'fruits')
+    checkout(empty_pg_conn, OUTPUT, new_head)
+    assert pg_table_exists(empty_pg_conn, OUTPUT.to_schema(), 'test')
+    assert pg_table_exists(empty_pg_conn, OUTPUT.to_schema(), 'fruits')
 
     with empty_pg_conn.cursor() as cur:
         cur.execute("""SELECT * FROM output.fruits""")
@@ -134,27 +133,26 @@ def test_import_from_remote(empty_pg_conn, remote_driver_conn):
 
 
 def test_import_and_update(empty_pg_conn, remote_driver_conn):
-    init(empty_pg_conn, 'output')
-    head = get_current_head(empty_pg_conn, 'output')
+    init(empty_pg_conn, OUTPUT)
+    head = get_current_head(empty_pg_conn, OUTPUT)
     # Import the 'fruits' table from the origin.
-    import_table_from_unmounted(empty_pg_conn, REMOTE_CONN_STRING, PG_MNT, ['fruits'],
-                                get_current_head(remote_driver_conn, PG_MNT),
-                                'output', target_tables=[])
-    new_head = get_current_head(empty_pg_conn, 'output')
+    import_table_from_remote(empty_pg_conn, REMOTE_CONN_STRING, PG_MNT, ['fruits'],
+                             get_current_head(remote_driver_conn, PG_MNT), OUTPUT, target_tables=[])
+    new_head = get_current_head(empty_pg_conn, OUTPUT)
 
     with empty_pg_conn.cursor() as cur:
         cur.execute("INSERT INTO output.fruits VALUES (3, 'mayonnaise')")
-    new_head_2 = commit(empty_pg_conn, 'output')
+    new_head_2 = commit(empty_pg_conn, OUTPUT)
 
-    checkout(empty_pg_conn, 'output', head)
-    assert not pg_table_exists(empty_pg_conn, 'output', 'fruits')
+    checkout(empty_pg_conn, OUTPUT, head)
+    assert not pg_table_exists(empty_pg_conn, OUTPUT.to_schema(), 'fruits')
 
-    checkout(empty_pg_conn, 'output', new_head)
+    checkout(empty_pg_conn, OUTPUT, new_head)
     with empty_pg_conn.cursor() as cur:
         cur.execute("SELECT * FROM output.fruits")
         assert cur.fetchall() == [(1, 'apple'), (2, 'orange')]
 
-    checkout(empty_pg_conn, 'output', new_head_2)
+    checkout(empty_pg_conn, OUTPUT, new_head_2)
     with empty_pg_conn.cursor() as cur:
         cur.execute("SELECT * FROM output.fruits")
         assert cur.fetchall() == [(1, 'apple'), (2, 'orange'), (3, 'mayonnaise')]

--- a/test/splitgraph/commands/test_import.py
+++ b/test/splitgraph/commands/test_import.py
@@ -20,7 +20,7 @@ def test_import_basic(sg_pg_conn):
     with sg_pg_conn.cursor() as cur:
         cur.execute("""SELECT * FROM output.imported_fruits""")
         output = cur.fetchall()
-        cur.execute("""SELECT * FROM test_pg_mount.fruits""")
+        cur.execute("""SELECT * FROM "test/pg_mount".fruits""")
         input = cur.fetchall()
         assert input == output
     new_head = get_current_head(sg_pg_conn, OUTPUT)
@@ -81,7 +81,7 @@ def test_import_multiple_tables(sg_pg_conn):
         with sg_pg_conn.cursor() as cur:
             cur.execute("""SELECT * FROM output.%s""" % table_name)
             output = cur.fetchall()
-            cur.execute("""SELECT * FROM test_pg_mount.%s""" % table_name)
+            cur.execute("""SELECT * FROM "test/pg_mount".%s""" % table_name)
             input = cur.fetchall()
             assert input == output
 
@@ -127,7 +127,7 @@ def test_import_from_remote(empty_pg_conn, remote_driver_conn):
         cur.execute("""SELECT * FROM output.fruits""")
         output = cur.fetchall()
     with remote_driver_conn.cursor() as cur:
-        cur.execute("""SELECT * FROM test_pg_mount.fruits""")
+        cur.execute("""SELECT * FROM "test/pg_mount".fruits""")
         input = cur.fetchall()
     assert input == output
 

--- a/test/splitgraph/commands/test_misc.py
+++ b/test/splitgraph/commands/test_misc.py
@@ -50,17 +50,17 @@ def test_table_changes(include_snap, sg_pg_conn):
     head_1 = commit(sg_pg_conn, PG_MNT, include_snap=include_snap)
     # Checkout the old head and make sure the table doesn't exist in it
     checkout(sg_pg_conn, PG_MNT, head)
-    assert not pg_table_exists(sg_pg_conn, PG_MNT, 'fruits_copy')
+    assert not pg_table_exists(sg_pg_conn, PG_MNT.to_schema(), 'fruits_copy')
 
     # Make sure the table is reflected in the diff even if we're on a different commit
     assert diff(sg_pg_conn, PG_MNT, 'fruits_copy', image_1=head, image_2=head_1) is True
 
     # Go back and now delete a table
     checkout(sg_pg_conn, PG_MNT, head_1)
-    assert pg_table_exists(sg_pg_conn, PG_MNT, 'fruits_copy')
+    assert pg_table_exists(sg_pg_conn, PG_MNT.to_schema(), 'fruits_copy')
     with sg_pg_conn.cursor() as cur:
         cur.execute("""DROP TABLE test_pg_mount.fruits""")
-    assert not pg_table_exists(sg_pg_conn, PG_MNT, 'fruits')
+    assert not pg_table_exists(sg_pg_conn, PG_MNT.to_schema(), 'fruits')
 
     # Make sure the diff shows it's been removed and commit it
     assert diff(sg_pg_conn, PG_MNT, 'fruits', image_1=head_1, image_2=None) is False
@@ -68,11 +68,11 @@ def test_table_changes(include_snap, sg_pg_conn):
 
     # Go through the 3 commits and ensure the table existence is maintained
     checkout(sg_pg_conn, PG_MNT, head)
-    assert pg_table_exists(sg_pg_conn, PG_MNT, 'fruits')
+    assert pg_table_exists(sg_pg_conn, PG_MNT.to_schema(), 'fruits')
     checkout(sg_pg_conn, PG_MNT, head_1)
-    assert pg_table_exists(sg_pg_conn, PG_MNT, 'fruits')
+    assert pg_table_exists(sg_pg_conn, PG_MNT.to_schema(), 'fruits')
     checkout(sg_pg_conn, PG_MNT, head_2)
-    assert not pg_table_exists(sg_pg_conn, PG_MNT, 'fruits')
+    assert not pg_table_exists(sg_pg_conn, PG_MNT.to_schema(), 'fruits')
 
 
 def test_tagging(sg_pg_conn):

--- a/test/splitgraph/commands/test_misc.py
+++ b/test/splitgraph/commands/test_misc.py
@@ -9,13 +9,13 @@ from test.splitgraph.conftest import PG_MNT
 @pytest.mark.parametrize("include_snap", [True, False])
 def test_log_checkout(include_snap, sg_pg_conn):
     with sg_pg_conn.cursor() as cur:
-        cur.execute("""INSERT INTO test_pg_mount.fruits VALUES (3, 'mayonnaise')""")
+        cur.execute("""INSERT INTO "test/pg_mount".fruits VALUES (3, 'mayonnaise')""")
 
     head = get_current_head(sg_pg_conn, PG_MNT)
     head_1 = commit(sg_pg_conn, PG_MNT, include_snap=include_snap)
 
     with sg_pg_conn.cursor() as cur:
-        cur.execute("""DELETE FROM test_pg_mount.fruits WHERE name = 'apple'""")
+        cur.execute("""DELETE FROM "test/pg_mount".fruits WHERE name = 'apple'""")
 
     head_2 = commit(sg_pg_conn, PG_MNT, include_snap=include_snap)
 
@@ -24,24 +24,24 @@ def test_log_checkout(include_snap, sg_pg_conn):
 
     checkout(sg_pg_conn, PG_MNT, head)
     with sg_pg_conn.cursor() as cur:
-        cur.execute("""SELECT * FROM test_pg_mount.fruits""")
+        cur.execute("""SELECT * FROM "test/pg_mount".fruits""")
         assert list(cur.fetchall()) == [(1, 'apple'), (2, 'orange')]
 
     checkout(sg_pg_conn, PG_MNT, head_1)
     with sg_pg_conn.cursor() as cur:
-        cur.execute("""SELECT * FROM test_pg_mount.fruits""")
+        cur.execute("""SELECT * FROM "test/pg_mount".fruits""")
         assert list(cur.fetchall()) == [(1, 'apple'), (2, 'orange'), (3, 'mayonnaise')]
 
     checkout(sg_pg_conn, PG_MNT, head_2)
     with sg_pg_conn.cursor() as cur:
-        cur.execute("""SELECT * FROM test_pg_mount.fruits""")
+        cur.execute("""SELECT * FROM "test/pg_mount".fruits""")
         assert list(cur.fetchall()) == [(2, 'orange'), (3, 'mayonnaise')]
 
 
 @pytest.mark.parametrize("include_snap", [True, False])
 def test_table_changes(include_snap, sg_pg_conn):
     with sg_pg_conn.cursor() as cur:
-        cur.execute("""CREATE TABLE test_pg_mount.fruits_copy AS SELECT * FROM test_pg_mount.fruits""")
+        cur.execute("""CREATE TABLE "test/pg_mount".fruits_copy AS SELECT * FROM "test/pg_mount".fruits""")
 
     head = get_current_head(sg_pg_conn, PG_MNT)
     # Check that table addition has been detected
@@ -59,7 +59,7 @@ def test_table_changes(include_snap, sg_pg_conn):
     checkout(sg_pg_conn, PG_MNT, head_1)
     assert pg_table_exists(sg_pg_conn, PG_MNT.to_schema(), 'fruits_copy')
     with sg_pg_conn.cursor() as cur:
-        cur.execute("""DROP TABLE test_pg_mount.fruits""")
+        cur.execute("""DROP TABLE "test/pg_mount".fruits""")
     assert not pg_table_exists(sg_pg_conn, PG_MNT.to_schema(), 'fruits')
 
     # Make sure the diff shows it's been removed and commit it
@@ -78,12 +78,12 @@ def test_table_changes(include_snap, sg_pg_conn):
 def test_tagging(sg_pg_conn):
     head = get_current_head(sg_pg_conn, PG_MNT)
     with sg_pg_conn.cursor() as cur:
-        cur.execute("""INSERT INTO test_pg_mount.fruits VALUES (3, 'mayonnaise')""")
+        cur.execute("""INSERT INTO "test/pg_mount".fruits VALUES (3, 'mayonnaise')""")
     commit(sg_pg_conn, PG_MNT)
 
     checkout(sg_pg_conn, PG_MNT, head)
     with sg_pg_conn.cursor() as cur:
-        cur.execute("""INSERT INTO test_pg_mount.fruits VALUES (3, 'mustard')""")
+        cur.execute("""INSERT INTO "test/pg_mount".fruits VALUES (3, 'mustard')""")
     right = commit(sg_pg_conn, PG_MNT)
 
     set_tag(sg_pg_conn, PG_MNT, head, 'base')

--- a/test/splitgraph/commands/test_mounting.py
+++ b/test/splitgraph/commands/test_mounting.py
@@ -9,7 +9,7 @@ def test_mount_unmount():
     unmount(conn, PG_MNT)
     _mount_postgres(conn, PG_MNT)
     with conn.cursor() as cur:
-        cur.execute("""SELECT * FROM test_pg_mount.fruits""")
+        cur.execute("""SELECT * FROM "test/pg_mount".fruits""")
         assert (1, 'apple') in list(cur.fetchall())
     unmount(conn, PG_MNT)
     with conn.cursor() as cur:
@@ -19,10 +19,10 @@ def test_mount_unmount():
 
 def test_cross_joins(sg_pg_mg_conn):
     with sg_pg_mg_conn.cursor() as cur:
-        cur.execute("""SELECT test_pg_mount.fruits.fruit_id,
+        cur.execute("""SELECT "test/pg_mount".fruits.fruit_id,
                              test_mg_mount.stuff.name,
-                             test_pg_mount.fruits.name as spirit_fruit
-                      FROM test_pg_mount.fruits 
+                             "test/pg_mount".fruits.name as spirit_fruit
+                      FROM "test/pg_mount".fruits 
                              JOIN test_mg_mount.stuff 
-                             ON test_pg_mount.fruits.fruit_id = test_mg_mount.stuff.duration""")
+                             ON "test/pg_mount".fruits.fruit_id = test_mg_mount.stuff.duration""")
         assert cur.fetchall() == [(2, 'James', 'orange')]

--- a/test/splitgraph/commands/test_mounting.py
+++ b/test/splitgraph/commands/test_mounting.py
@@ -13,7 +13,7 @@ def test_mount_unmount():
         assert (1, 'apple') in list(cur.fetchall())
     unmount(conn, PG_MNT)
     with conn.cursor() as cur:
-        cur.execute("""SELECT * FROM information_schema.schemata where schema_name = '%s'""" % PG_MNT)
+        cur.execute("""SELECT * FROM information_schema.schemata where schema_name = '%s'""" % PG_MNT.to_schema())
         assert cur.fetchone() is None
 
 

--- a/test/splitgraph/commands/test_provenance.py
+++ b/test/splitgraph/commands/test_provenance.py
@@ -31,7 +31,7 @@ def test_sgfile_recreate(empty_pg_conn, remote_driver_conn):
     recreated_commands = image_hash_to_sgfile(empty_pg_conn, OUTPUT, get_current_head(empty_pg_conn, OUTPUT),
                                               err_on_end=False)
 
-    assert recreated_commands == ["FROM test_pg_mount:%s IMPORT {SELECT * FROM fruits WHERE name = 'orange'} AS " \
+    assert recreated_commands == ["FROM test/pg_mount:%s IMPORT {SELECT * FROM fruits WHERE name = 'orange'} AS " \
                                   % get_tagged_id(remote_driver_conn, PG_MNT, 'v1') +
                                   "my_fruits, {SELECT * FROM vegetables WHERE name LIKE '%o'} AS o_vegetables, "
                                   "vegetables AS vegetables, fruits AS all_fruits",
@@ -45,7 +45,7 @@ def test_sgfile_recreate_custom_from(empty_pg_conn, remote_driver_conn):
                                               err_on_end=False)
 
     # Parser strips newlines in sql but not the whitespace, so we have to reproduce the query here verbatim.
-    assert recreated_commands == ["FROM test_pg_mount:%s" % get_tagged_id(remote_driver_conn, PG_MNT, 'v1'),
+    assert recreated_commands == ["FROM test/pg_mount:%s" % get_tagged_id(remote_driver_conn, PG_MNT, 'v1'),
                                   "SQL CREATE TABLE join_table AS SELECT fruit_id AS id, fruits.name AS fruit, "
                                   "vegetables.name AS vegetable                                 FROM fruits "
                                   "JOIN vegetables                                ON fruit_id = vegetable_id"]
@@ -90,7 +90,7 @@ def test_rerun_with_new_version(empty_pg_conn, remote_driver_conn):
     ov2_log = get_log(empty_pg_conn, OUTPUT, output_v2)
 
     # ov1_log: CREATE TABLE commit, then FROM v1
-    # ov2_log: CREATE TABLE commit, then FROM v2 which is based on FROM v1 (since we cloned both from test_pg_mount),
+    # ov2_log: CREATE TABLE commit, then FROM v2 which is based on FROM v1 (since we cloned both from test/pg_mount),
     # then as previously.
     assert ov1_log[1:] == ov2_log[2:]
 

--- a/test/splitgraph/commands/test_provenance.py
+++ b/test/splitgraph/commands/test_provenance.py
@@ -3,35 +3,36 @@ from splitgraph.commands.provenance import provenance, image_hash_to_sgfile
 from splitgraph.meta_handler.tags import get_current_head, get_tagged_id
 from splitgraph.sgfile import execute_commands
 from splitgraph.sgfile.execution import rerun_image_with_replacement
+from test.splitgraph.conftest import OUTPUT, PG_MNT
 from test.splitgraph.test_sgfile import _load_sgfile, _add_multitag_dataset_to_remote_driver
 
 
 def test_provenance(empty_pg_conn, remote_driver_conn):
     new_head = _add_multitag_dataset_to_remote_driver(remote_driver_conn)
     execute_commands(empty_pg_conn, _load_sgfile('import_remote_multiple.sgfile'), params={'TAG': 'v1'},
-                     output='output')
-    dependencies = provenance(empty_pg_conn, 'output', get_current_head(empty_pg_conn, 'output'))
+                     output=OUTPUT)
+    dependencies = provenance(empty_pg_conn, OUTPUT, get_current_head(empty_pg_conn, OUTPUT))
 
-    assert dependencies == [('test_pg_mount', get_tagged_id(remote_driver_conn, 'test_pg_mount', 'v1'))]
+    assert dependencies == [(PG_MNT, get_tagged_id(remote_driver_conn, PG_MNT, 'v1'))]
 
 
 def test_provenance_with_from(empty_pg_conn, remote_driver_conn):
     new_head = _add_multitag_dataset_to_remote_driver(remote_driver_conn)
-    execute_commands(empty_pg_conn, _load_sgfile('from_remote.sgfile'), params={'TAG': 'v1'}, output='output')
-    dependencies = provenance(empty_pg_conn, 'output', get_current_head(empty_pg_conn, 'output'))
+    execute_commands(empty_pg_conn, _load_sgfile('from_remote.sgfile'), params={'TAG': 'v1'}, output=OUTPUT)
+    dependencies = provenance(empty_pg_conn, OUTPUT, get_current_head(empty_pg_conn, OUTPUT))
 
-    assert dependencies == [('test_pg_mount', get_tagged_id(remote_driver_conn, 'test_pg_mount', 'v1'))]
+    assert dependencies == [(PG_MNT, get_tagged_id(remote_driver_conn, PG_MNT, 'v1'))]
 
 
 def test_sgfile_recreate(empty_pg_conn, remote_driver_conn):
     new_head = _add_multitag_dataset_to_remote_driver(remote_driver_conn)
     execute_commands(empty_pg_conn, _load_sgfile('import_with_custom_query_and_sql.sgfile'), params={'TAG': 'v1'},
-                     output='output')
-    recreated_commands = image_hash_to_sgfile(empty_pg_conn, 'output', get_current_head(empty_pg_conn, 'output'),
+                     output=OUTPUT)
+    recreated_commands = image_hash_to_sgfile(empty_pg_conn, OUTPUT, get_current_head(empty_pg_conn, OUTPUT),
                                               err_on_end=False)
 
     assert recreated_commands == ["FROM test_pg_mount:%s IMPORT {SELECT * FROM fruits WHERE name = 'orange'} AS " \
-                                  % get_tagged_id(remote_driver_conn, 'test_pg_mount', 'v1') +
+                                  % get_tagged_id(remote_driver_conn, PG_MNT, 'v1') +
                                   "my_fruits, {SELECT * FROM vegetables WHERE name LIKE '%o'} AS o_vegetables, "
                                   "vegetables AS vegetables, fruits AS all_fruits",
                                   "SQL CREATE TABLE test_table AS SELECT * FROM all_fruits"]
@@ -39,12 +40,12 @@ def test_sgfile_recreate(empty_pg_conn, remote_driver_conn):
 
 def test_sgfile_recreate_custom_from(empty_pg_conn, remote_driver_conn):
     _add_multitag_dataset_to_remote_driver(remote_driver_conn)
-    execute_commands(empty_pg_conn, _load_sgfile('from_remote.sgfile'), params={'TAG': 'v1'}, output='output')
-    recreated_commands = image_hash_to_sgfile(empty_pg_conn, 'output',
-                                              get_current_head(empty_pg_conn, 'output'), err_on_end=False)
+    execute_commands(empty_pg_conn, _load_sgfile('from_remote.sgfile'), params={'TAG': 'v1'}, output=OUTPUT)
+    recreated_commands = image_hash_to_sgfile(empty_pg_conn, OUTPUT, get_current_head(empty_pg_conn, OUTPUT),
+                                              err_on_end=False)
 
     # Parser strips newlines in sql but not the whitespace, so we have to reproduce the query here verbatim.
-    assert recreated_commands == ["FROM test_pg_mount:%s" % get_tagged_id(remote_driver_conn, 'test_pg_mount', 'v1'),
+    assert recreated_commands == ["FROM test_pg_mount:%s" % get_tagged_id(remote_driver_conn, PG_MNT, 'v1'),
                                   "SQL CREATE TABLE join_table AS SELECT fruit_id AS id, fruits.name AS fruit, "
                                   "vegetables.name AS vegetable                                 FROM fruits "
                                   "JOIN vegetables                                ON fruit_id = vegetable_id"]
@@ -55,10 +56,10 @@ def test_sgfile_incomplete_provenance(empty_pg_conn, remote_driver_conn):
     # on the image created by MOUNT and not regenerate the MOUNT command.
     _add_multitag_dataset_to_remote_driver(remote_driver_conn)
     execute_commands(empty_pg_conn, _load_sgfile('import_from_mounted_db_with_sql.sgfile'),
-                     params={'TAG': 'v1'}, output='output')
-    head = get_current_head(empty_pg_conn, 'output')
-    image_with_mount = get_log(empty_pg_conn, 'output', head)[-2]
-    recreated_commands = image_hash_to_sgfile(empty_pg_conn, 'output', head, err_on_end=False)
+                     params={'TAG': 'v1'}, output=OUTPUT)
+    head = get_current_head(empty_pg_conn, OUTPUT)
+    image_with_mount = get_log(empty_pg_conn, OUTPUT, head)[-2]
+    recreated_commands = image_hash_to_sgfile(empty_pg_conn, OUTPUT, head, err_on_end=False)
 
     assert recreated_commands == ["FROM output:%s" % image_with_mount,
                                   "SQL CREATE TABLE new_table AS SELECT * FROM all_fruits"]
@@ -67,26 +68,26 @@ def test_sgfile_incomplete_provenance(empty_pg_conn, remote_driver_conn):
 def test_rerun_with_new_version(empty_pg_conn, remote_driver_conn):
     _add_multitag_dataset_to_remote_driver(remote_driver_conn)
     # Test running commands that base new datasets on a remote repository.
-    execute_commands(empty_pg_conn, _load_sgfile('from_remote.sgfile'), output='output', params={'TAG': 'v1'})
+    execute_commands(empty_pg_conn, _load_sgfile('from_remote.sgfile'), output=OUTPUT, params={'TAG': 'v1'})
 
-    output_v1 = get_current_head(empty_pg_conn, 'output')
+    output_v1 = get_current_head(empty_pg_conn, OUTPUT)
     # Do a logical rebase of the newly created image on the V2 of the remote repository
 
-    rerun_image_with_replacement(empty_pg_conn, 'output', output_v1, {'test_pg_mount': 'v2'})
-    output_v2 = get_current_head(empty_pg_conn, 'output')
+    rerun_image_with_replacement(empty_pg_conn, OUTPUT, output_v1, {PG_MNT: 'v2'})
+    output_v2 = get_current_head(empty_pg_conn, OUTPUT)
     with empty_pg_conn.cursor() as cur:
         cur.execute("SELECT * FROM output.join_table")
         assert cur.fetchall() == [(2, 'orange', 'carrot')]
 
     # Do some checks on the structure of the final output repo. In particular, make sure that the two derived versions
     # still exist and depend only on the respective tags of the source.
-    assert provenance(empty_pg_conn, 'output', output_v1) == \
-        [('test_pg_mount', get_tagged_id(remote_driver_conn, 'test_pg_mount', 'v1'))]
-    assert provenance(empty_pg_conn, 'output', output_v2) == \
-        [('test_pg_mount', get_tagged_id(remote_driver_conn, 'test_pg_mount', 'v2'))]
+    assert provenance(empty_pg_conn, OUTPUT, output_v1) == \
+           [(PG_MNT, get_tagged_id(remote_driver_conn, PG_MNT, 'v1'))]
+    assert provenance(empty_pg_conn, OUTPUT, output_v2) == \
+           [(PG_MNT, get_tagged_id(remote_driver_conn, PG_MNT, 'v2'))]
 
-    ov1_log = get_log(empty_pg_conn, 'output', output_v1)
-    ov2_log = get_log(empty_pg_conn, 'output', output_v2)
+    ov1_log = get_log(empty_pg_conn, OUTPUT, output_v1)
+    ov2_log = get_log(empty_pg_conn, OUTPUT, output_v2)
 
     # ov1_log: CREATE TABLE commit, then FROM v1
     # ov2_log: CREATE TABLE commit, then FROM v2 which is based on FROM v1 (since we cloned both from test_pg_mount),
@@ -96,23 +97,23 @@ def test_rerun_with_new_version(empty_pg_conn, remote_driver_conn):
 
 def test_rerun_with_from_import(empty_pg_conn, remote_driver_conn):
     _add_multitag_dataset_to_remote_driver(remote_driver_conn)
-    execute_commands(empty_pg_conn, _load_sgfile('import_remote_multiple.sgfile'), output='output', params={'TAG': 'v1'})
+    execute_commands(empty_pg_conn, _load_sgfile('import_remote_multiple.sgfile'), output=OUTPUT, params={'TAG': 'v1'})
 
-    output_v1 = get_current_head(empty_pg_conn, 'output')
+    output_v1 = get_current_head(empty_pg_conn, OUTPUT)
     # Do a logical rebase of the newly created image on the V2 of the remote repository
 
-    rerun_image_with_replacement(empty_pg_conn, 'output', output_v1, {'test_pg_mount': 'v2'})
-    output_v2 = get_current_head(empty_pg_conn, 'output')
+    rerun_image_with_replacement(empty_pg_conn, OUTPUT, output_v1, {PG_MNT: 'v2'})
+    output_v2 = get_current_head(empty_pg_conn, OUTPUT)
 
     # Do some checks on the structure of the final output repo. In particular, make sure that the two derived versions
     # still exist and depend only on the respective tags of the source.
-    assert provenance(empty_pg_conn, 'output', output_v1) == \
-        [('test_pg_mount', get_tagged_id(remote_driver_conn, 'test_pg_mount', 'v1'))]
-    assert provenance(empty_pg_conn, 'output', output_v2) == \
-        [('test_pg_mount', get_tagged_id(remote_driver_conn, 'test_pg_mount', 'v2'))]
+    assert provenance(empty_pg_conn, OUTPUT, output_v1) == \
+           [(PG_MNT, get_tagged_id(remote_driver_conn, PG_MNT, 'v1'))]
+    assert provenance(empty_pg_conn, OUTPUT, output_v2) == \
+           [(PG_MNT, get_tagged_id(remote_driver_conn, PG_MNT, 'v2'))]
 
-    ov1_log = get_log(empty_pg_conn, 'output', output_v1)
-    ov2_log = get_log(empty_pg_conn, 'output', output_v2)
+    ov1_log = get_log(empty_pg_conn, OUTPUT, output_v1)
+    ov2_log = get_log(empty_pg_conn, OUTPUT, output_v2)
 
     # ov1_log: CREATE TABLE commit, then IMPORT from v1, then the 00000 commit
     # ov2_log: CREATE TABLE commit, then FROM v1, then the 00000.. commit

--- a/test/splitgraph/commands/test_publish.py
+++ b/test/splitgraph/commands/test_publish.py
@@ -20,7 +20,7 @@ def test_publish(empty_pg_conn, remote_driver_conn, extra_info):
     publish(empty_pg_conn, OUTPUT, 'v1', readme="A test repo.",
             include_provenance=extra_info, include_table_previews=extra_info)
 
-    # Base the derivation on v2 of test_pg_mount and publish that too.
+    # Base the derivation on v2 of test/pg_mount and publish that too.
     execute_commands(empty_pg_conn, _load_sgfile('import_remote_multiple.sgfile'), params={'TAG': 'v2'},
                      output=OUTPUT)
     set_tag(empty_pg_conn, OUTPUT, get_current_head(empty_pg_conn, OUTPUT), 'v2')
@@ -41,7 +41,7 @@ def test_publish(empty_pg_conn, remote_driver_conn, extra_info):
 
     assert schemata == expected_schemata
     if extra_info:
-        assert provenance == [[['', 'test_pg_mount'], get_tagged_id(remote_driver_conn, PG_MNT, 'v1')]]
+        assert provenance == [[['test', 'pg_mount'], get_tagged_id(remote_driver_conn, PG_MNT, 'v1')]]
         assert previews == {'join_table': [[1, 'apple', 'potato'], [2, 'orange', 'carrot']],
                             'my_fruits': [[1, 'apple'], [2, 'orange']],
                             'vegetables': [[1, 'potato'], [2, 'carrot']]}
@@ -55,7 +55,7 @@ def test_publish(empty_pg_conn, remote_driver_conn, extra_info):
     assert readme == "Based on v2."
     assert schemata == expected_schemata
     if extra_info:
-        assert provenance == [[['', 'test_pg_mount'], get_tagged_id(remote_driver_conn, PG_MNT, 'v2')]]
+        assert provenance == [[['test', 'pg_mount'], get_tagged_id(remote_driver_conn, PG_MNT, 'v2')]]
         assert previews == {'join_table': [[2, 'orange', 'carrot']],
                             'my_fruits': [[2, 'orange']],
                             'vegetables': [[1, 'potato'], [2, 'carrot']]}

--- a/test/splitgraph/commands/test_publish.py
+++ b/test/splitgraph/commands/test_publish.py
@@ -5,7 +5,7 @@ from splitgraph.commands.publish import publish
 from splitgraph.meta_handler.tags import get_current_head, get_tagged_id, set_tag
 from splitgraph.registry_meta_handler import get_published_info
 from splitgraph.sgfile import execute_commands
-from test.splitgraph.conftest import REMOTE_CONN_STRING
+from test.splitgraph.conftest import REMOTE_CONN_STRING, OUTPUT, PG_MNT
 from test.splitgraph.test_sgfile import _add_multitag_dataset_to_remote_driver, _load_sgfile
 
 
@@ -14,22 +14,22 @@ def test_publish(empty_pg_conn, remote_driver_conn, extra_info):
     # Run some sgfile commands to create a dataset and push it
     new_head = _add_multitag_dataset_to_remote_driver(remote_driver_conn)
     execute_commands(empty_pg_conn, _load_sgfile('import_remote_multiple.sgfile'), params={'TAG': 'v1'},
-                     output='output')
-    set_tag(empty_pg_conn, 'output', get_current_head(empty_pg_conn, 'output'), 'v1')
-    push(empty_pg_conn, 'output', remote_conn_string=REMOTE_CONN_STRING)
-    publish(empty_pg_conn, 'output', 'v1', readme="A test repo.",
+                     output=OUTPUT)
+    set_tag(empty_pg_conn, OUTPUT, get_current_head(empty_pg_conn, OUTPUT), 'v1')
+    push(empty_pg_conn, OUTPUT, remote_conn_string=REMOTE_CONN_STRING)
+    publish(empty_pg_conn, OUTPUT, 'v1', readme="A test repo.",
             include_provenance=extra_info, include_table_previews=extra_info)
 
     # Base the derivation on v2 of test_pg_mount and publish that too.
     execute_commands(empty_pg_conn, _load_sgfile('import_remote_multiple.sgfile'), params={'TAG': 'v2'},
-                     output='output')
-    set_tag(empty_pg_conn, 'output', get_current_head(empty_pg_conn, 'output'), 'v2')
-    push(empty_pg_conn, 'output', remote_conn_string=REMOTE_CONN_STRING)
-    publish(empty_pg_conn, 'output', 'v2', readme="Based on v2.",
+                     output=OUTPUT)
+    set_tag(empty_pg_conn, OUTPUT, get_current_head(empty_pg_conn, OUTPUT), 'v2')
+    push(empty_pg_conn, OUTPUT, remote_conn_string=REMOTE_CONN_STRING)
+    publish(empty_pg_conn, OUTPUT, 'v2', readme="Based on v2.",
             include_provenance=extra_info, include_table_previews=extra_info)
 
-    image_hash, published_dt, provenance, readme, schemata, previews = get_published_info(remote_driver_conn, 'output', 'v1')
-    assert image_hash == get_tagged_id(empty_pg_conn, 'output', 'v1')
+    image_hash, published_dt, provenance, readme, schemata, previews = get_published_info(remote_driver_conn, OUTPUT, 'v1')
+    assert image_hash == get_tagged_id(empty_pg_conn, OUTPUT, 'v1')
     assert readme == "A test repo."
     expected_schemata = {'join_table': [['id', 'integer', False],
                                         ['fruit', 'character varying', False],
@@ -41,7 +41,7 @@ def test_publish(empty_pg_conn, remote_driver_conn, extra_info):
 
     assert schemata == expected_schemata
     if extra_info:
-        assert provenance == [["test_pg_mount", get_tagged_id(remote_driver_conn, 'test_pg_mount', 'v1')]]
+        assert provenance == [[['', 'test_pg_mount'], get_tagged_id(remote_driver_conn, PG_MNT, 'v1')]]
         assert previews == {'join_table': [[1, 'apple', 'potato'], [2, 'orange', 'carrot']],
                             'my_fruits': [[1, 'apple'], [2, 'orange']],
                             'vegetables': [[1, 'potato'], [2, 'carrot']]}
@@ -50,12 +50,12 @@ def test_publish(empty_pg_conn, remote_driver_conn, extra_info):
         assert provenance is None
         assert previews is None
 
-    image_hash, published_dt, provenance, readme, schemata, previews = get_published_info(remote_driver_conn, 'output', 'v2')
-    assert image_hash == get_tagged_id(empty_pg_conn, 'output', 'v2')
+    image_hash, published_dt, provenance, readme, schemata, previews = get_published_info(remote_driver_conn, OUTPUT, 'v2')
+    assert image_hash == get_tagged_id(empty_pg_conn, OUTPUT, 'v2')
     assert readme == "Based on v2."
     assert schemata == expected_schemata
     if extra_info:
-        assert provenance == [["test_pg_mount", get_tagged_id(remote_driver_conn, 'test_pg_mount', 'v2')]]
+        assert provenance == [[['', 'test_pg_mount'], get_tagged_id(remote_driver_conn, PG_MNT, 'v2')]]
         assert previews == {'join_table': [[2, 'orange', 'carrot']],
                             'my_fruits': [[2, 'orange']],
                             'vegetables': [[1, 'potato'], [2, 'carrot']]}

--- a/test/splitgraph/commands/test_push_pull.py
+++ b/test/splitgraph/commands/test_push_pull.py
@@ -4,10 +4,13 @@ import pytest
 
 from splitgraph.commands import clone, checkout, commit, pull, push, unmount
 from splitgraph.commands.misc import cleanup_objects
+from splitgraph.constants import Repository
 from splitgraph.meta_handler.images import get_all_images_parents
 from splitgraph.meta_handler.objects import get_existing_objects, get_downloaded_objects, get_external_object_locations
 from splitgraph.meta_handler.tags import get_current_head
 from test.splitgraph.conftest import PG_MNT
+
+PG_MNT_PULL = Repository(PG_MNT.namespace, PG_MNT.repository + '_pull')
 
 
 @pytest.mark.parametrize("download_all", [True, False])
@@ -16,8 +19,8 @@ def test_pull(sg_pg_conn, remote_driver_conn, download_all):
     # Here, it's the pg on cachedb that connects to the remote driver, so we can use the actual hostname
     # (as opposed to the one exposed to us). However, the clone procedure also uses that connection string to talk to
     # the remote. Hence, there's an /etc/hosts indirection on the host mapping the remote driver to localhost.
-    clone(sg_pg_conn, PG_MNT, local_mountpoint=PG_MNT + '_pull', download_all=download_all)
-    checkout(sg_pg_conn, PG_MNT + '_pull', get_current_head(remote_driver_conn, PG_MNT))
+    clone(sg_pg_conn, PG_MNT, local_repository=PG_MNT_PULL, download_all=download_all)
+    checkout(sg_pg_conn, PG_MNT_PULL, get_current_head(remote_driver_conn, PG_MNT))
 
     # Do something to fruits on the remote
     with remote_driver_conn.cursor() as cur:
@@ -34,30 +37,30 @@ def test_pull(sg_pg_conn, remote_driver_conn, download_all):
         cur.execute("""SELECT * FROM test_pg_mount_pull.fruits""")
         assert list(cur.fetchall()) == [(1, 'apple'), (2, 'orange')]
     assert head_1 not in [snapdata[0] for snapdata in
-                          get_all_images_parents(sg_pg_conn, PG_MNT + '_pull')]
+                          get_all_images_parents(sg_pg_conn, PG_MNT_PULL)]
 
     # Since the pull procedure initializes a new connection, we have to commit our changes
     # in order to see them.
     remote_driver_conn.commit()
 
-    pull(sg_pg_conn, PG_MNT + '_pull', remote='origin')
+    pull(sg_pg_conn, PG_MNT_PULL, remote='origin')
 
     # Check out the newly-pulled commit and verify it has the same data.
-    checkout(sg_pg_conn, PG_MNT + '_pull', head_1)
+    checkout(sg_pg_conn, PG_MNT_PULL, head_1)
 
     with sg_pg_conn.cursor() as cur:
         cur.execute("""SELECT * FROM test_pg_mount_pull.fruits""")
         assert list(cur.fetchall()) == [(1, 'apple'), (2, 'orange'), (3, 'mayonnaise')]
-    assert get_current_head(sg_pg_conn, PG_MNT + '_pull') == head_1
+    assert get_current_head(sg_pg_conn, PG_MNT_PULL) == head_1
 
 
 @pytest.mark.parametrize("keep_downloaded", [True, False])
 def test_pulls_with_lazy_object_downloads(empty_pg_conn, remote_driver_conn, keep_downloaded):
-    clone(empty_pg_conn, PG_MNT, local_mountpoint=PG_MNT + '_pull', download_all=False)
+    clone(empty_pg_conn, PG_MNT, local_repository=PG_MNT_PULL, download_all=False)
     # Make sure we haven't downloaded anything until checkout
     assert not get_downloaded_objects(empty_pg_conn)
 
-    checkout(empty_pg_conn, PG_MNT + '_pull', get_current_head(remote_driver_conn, PG_MNT),
+    checkout(empty_pg_conn, PG_MNT_PULL, get_current_head(remote_driver_conn, PG_MNT),
              keep_downloaded_objects=keep_downloaded)
     if keep_downloaded:
         assert len(get_downloaded_objects(empty_pg_conn)) == 2  # Original fruits and vegetables tables.
@@ -78,7 +81,7 @@ def test_pulls_with_lazy_object_downloads(empty_pg_conn, remote_driver_conn, kee
     right = commit(remote_driver_conn, PG_MNT)
 
     # Pull from origin.
-    pull(empty_pg_conn, PG_MNT + '_pull', remote='origin', download_all=False)
+    pull(empty_pg_conn, PG_MNT_PULL, remote='origin', download_all=False)
     # Make sure we have the pointers to the three versions of the fruits table + the original vegetables
     assert len(get_existing_objects(empty_pg_conn)) == 4
 
@@ -87,14 +90,14 @@ def test_pulls_with_lazy_object_downloads(empty_pg_conn, remote_driver_conn, kee
         assert len(get_downloaded_objects(empty_pg_conn)) == 2
 
     # Check out left commit: since it only depends on the root, we should download just the new version of fruits.
-    checkout(empty_pg_conn, PG_MNT + '_pull', left, keep_downloaded_objects=keep_downloaded)
+    checkout(empty_pg_conn, PG_MNT_PULL, left, keep_downloaded_objects=keep_downloaded)
 
     if keep_downloaded:
         assert len(get_downloaded_objects(empty_pg_conn)) == 3  # now have 2 versions of fruits + 1 vegetables
     else:
         assert not get_downloaded_objects(empty_pg_conn)
 
-    checkout(empty_pg_conn, PG_MNT + '_pull', right, keep_downloaded_objects=keep_downloaded)
+    checkout(empty_pg_conn, PG_MNT_PULL, right, keep_downloaded_objects=keep_downloaded)
     if keep_downloaded:
         assert len(get_downloaded_objects(empty_pg_conn)) == 4  # now have 2 versions of fruits + 1 vegetables
         assert get_downloaded_objects(empty_pg_conn) == get_existing_objects(empty_pg_conn)
@@ -104,17 +107,17 @@ def test_pulls_with_lazy_object_downloads(empty_pg_conn, remote_driver_conn, kee
 
 def test_push(empty_pg_conn, remote_driver_conn):
     # Clone from the remote driver like in the previous test.
-    clone(empty_pg_conn, PG_MNT, local_mountpoint=PG_MNT + '_pull')
+    clone(empty_pg_conn, PG_MNT, local_repository=PG_MNT_PULL)
     head = get_current_head(remote_driver_conn, PG_MNT)
-    checkout(empty_pg_conn, PG_MNT + '_pull', head)
+    checkout(empty_pg_conn, PG_MNT_PULL, head)
 
     # Then, change our copy and commit.
     with empty_pg_conn.cursor() as cur:
         cur.execute("""INSERT INTO test_pg_mount_pull.fruits VALUES (3, 'mayonnaise')""")
-    head_1 = commit(empty_pg_conn, PG_MNT + '_pull')
+    head_1 = commit(empty_pg_conn, PG_MNT_PULL)
 
     # Now, push to remote.
-    push(empty_pg_conn, PG_MNT + '_pull', remote_mountpoint=PG_MNT)
+    push(empty_pg_conn, PG_MNT_PULL, remote_repository=PG_MNT)
 
     # See if the original mountpoint got updated.
     checkout(remote_driver_conn, PG_MNT, head_1)
@@ -127,21 +130,21 @@ def test_http_push_pull(empty_pg_conn, remote_driver_conn):
     # Test pushing/pulling when the objects are uploaded to a remote storage instead of to the actual remote DB.
     # "Uploading" to a file for now because I can't seem to get uploading on an HTTP fixture working.
 
-    clone(empty_pg_conn, PG_MNT, local_mountpoint=PG_MNT + '_pull', download_all=False)
+    clone(empty_pg_conn, PG_MNT, local_repository=PG_MNT_PULL, download_all=False)
     # Add a couple of commits, this time on the cloned copy.
     head = get_current_head(remote_driver_conn, PG_MNT)
-    checkout(empty_pg_conn, PG_MNT + '_pull', head)
+    checkout(empty_pg_conn, PG_MNT_PULL, head)
     with empty_pg_conn.cursor() as cur:
         cur.execute("""INSERT INTO test_pg_mount_pull.fruits VALUES (3, 'mayonnaise')""")
-    left = commit(empty_pg_conn, PG_MNT + '_pull')
-    checkout(empty_pg_conn, PG_MNT + '_pull', head)
+    left = commit(empty_pg_conn, PG_MNT_PULL)
+    checkout(empty_pg_conn, PG_MNT_PULL, head)
     with empty_pg_conn.cursor() as cur:
         cur.execute("""INSERT INTO test_pg_mount_pull.fruits VALUES (3, 'mustard')""")
-    right = commit(empty_pg_conn, PG_MNT + '_pull')
+    right = commit(empty_pg_conn, PG_MNT_PULL)
 
     with tempfile.TemporaryDirectory() as tmpdir:
         # Push to origin, but this time upload the actual objects instead.
-        push(empty_pg_conn, PG_MNT + '_pull', remote_mountpoint=PG_MNT, handler='FILE',
+        push(empty_pg_conn, PG_MNT_PULL, remote_repository=PG_MNT, handler='FILE',
              handler_options={'path': tmpdir})
 
         # Check that the actual objects don't exist on the remote but are instead registered with an URL.
@@ -157,23 +160,23 @@ def test_http_push_pull(empty_pg_conn, remote_driver_conn):
 
         # Destroy the pulled mountpoint and recreate it again.
         assert len(get_downloaded_objects(empty_pg_conn)) == 4
-        unmount(empty_pg_conn, PG_MNT + '_pull')
+        unmount(empty_pg_conn, PG_MNT_PULL)
         # Make sure we don't have any leftover physical objects.
         cleanup_objects(empty_pg_conn)
         assert len(get_downloaded_objects(empty_pg_conn)) == 0
 
-        clone(empty_pg_conn, PG_MNT, local_mountpoint=PG_MNT + '_pull', download_all=False)
+        clone(empty_pg_conn, PG_MNT, local_repository=PG_MNT_PULL, download_all=False)
 
         # Proceed as per the lazy checkout tests to make sure we don't download more than required.
         # Make sure we still haven't downloaded anything.
         assert len(get_downloaded_objects(empty_pg_conn)) == 0
 
         # Check out left commit: since it only depends on the root, we should download just the new version of fruits.
-        checkout(empty_pg_conn, PG_MNT + '_pull', left)
+        checkout(empty_pg_conn, PG_MNT_PULL, left)
         assert len(
             get_downloaded_objects(empty_pg_conn)) == 3  # now have 2 versions of fruits + 1 vegetables
 
-        checkout(empty_pg_conn, PG_MNT + '_pull', right)
+        checkout(empty_pg_conn, PG_MNT_PULL, right)
         assert len(get_downloaded_objects(empty_pg_conn)) == 4
         # Only now we actually have all the objects materialized.
         assert get_downloaded_objects(empty_pg_conn) == get_existing_objects(empty_pg_conn)

--- a/test/splitgraph/commands/test_push_pull.py
+++ b/test/splitgraph/commands/test_push_pull.py
@@ -4,13 +4,10 @@ import pytest
 
 from splitgraph.commands import clone, checkout, commit, pull, push, unmount
 from splitgraph.commands.misc import cleanup_objects
-from splitgraph.constants import Repository
 from splitgraph.meta_handler.images import get_all_images_parents
 from splitgraph.meta_handler.objects import get_existing_objects, get_downloaded_objects, get_external_object_locations
 from splitgraph.meta_handler.tags import get_current_head
-from test.splitgraph.conftest import PG_MNT
-
-PG_MNT_PULL = Repository(PG_MNT.namespace, PG_MNT.repository + '_pull')
+from test.splitgraph.conftest import PG_MNT, PG_MNT_PULL
 
 
 @pytest.mark.parametrize("download_all", [True, False])
@@ -24,12 +21,12 @@ def test_pull(sg_pg_conn, remote_driver_conn, download_all):
 
     # Do something to fruits on the remote
     with remote_driver_conn.cursor() as cur:
-        cur.execute("""INSERT INTO test_pg_mount.fruits VALUES (3, 'mayonnaise')""")
+        cur.execute("""INSERT INTO "test/pg_mount".fruits VALUES (3, 'mayonnaise')""")
     head_1 = commit(remote_driver_conn, PG_MNT)
 
     # Check that the fruits table changed on the original mount
     with remote_driver_conn.cursor() as cur:
-        cur.execute("""SELECT * FROM test_pg_mount.fruits""")
+        cur.execute("""SELECT * FROM "test/pg_mount".fruits""")
         assert list(cur.fetchall()) == [(1, 'apple'), (2, 'orange'), (3, 'mayonnaise')]
 
     # ...and check it's unchanged on the pulled one.
@@ -72,12 +69,12 @@ def test_pulls_with_lazy_object_downloads(empty_pg_conn, remote_driver_conn, kee
     # In the meantime, make two branches off of origin (a total of 3 commits)
     head = get_current_head(remote_driver_conn, PG_MNT)
     with remote_driver_conn.cursor() as cur:
-        cur.execute("""INSERT INTO test_pg_mount.fruits VALUES (3, 'mayonnaise')""")
+        cur.execute("""INSERT INTO "test/pg_mount".fruits VALUES (3, 'mayonnaise')""")
     left = commit(remote_driver_conn, PG_MNT)
 
     checkout(remote_driver_conn, PG_MNT, head)
     with remote_driver_conn.cursor() as cur:
-        cur.execute("""INSERT INTO test_pg_mount.fruits VALUES (3, 'mustard')""")
+        cur.execute("""INSERT INTO "test/pg_mount".fruits VALUES (3, 'mustard')""")
     right = commit(remote_driver_conn, PG_MNT)
 
     # Pull from origin.
@@ -122,7 +119,7 @@ def test_push(empty_pg_conn, remote_driver_conn):
     # See if the original mountpoint got updated.
     checkout(remote_driver_conn, PG_MNT, head_1)
     with remote_driver_conn.cursor() as cur:
-        cur.execute("""SELECT * FROM test_pg_mount.fruits""")
+        cur.execute("""SELECT * FROM "test/pg_mount".fruits""")
         assert list(cur.fetchall()) == [(1, 'apple'), (2, 'orange'), (3, 'mayonnaise')]
 
 

--- a/test/splitgraph/commands/test_schema_changes.py
+++ b/test/splitgraph/commands/test_schema_changes.py
@@ -8,17 +8,17 @@ from splitgraph.pg_utils import get_full_table_schema, get_primary_keys
 from test.splitgraph.conftest import PG_MNT
 
 TEST_CASES = [
-    ("ALTER TABLE test_pg_mount.fruits DROP COLUMN name",
+    ("ALTER TABLE \"test/pg_mount\".fruits DROP COLUMN name",
      [(1, 'fruit_id', 'integer', False)]),
-    ("ALTER TABLE test_pg_mount.fruits ADD COLUMN test varchar",
+    ("ALTER TABLE \"test/pg_mount\".fruits ADD COLUMN test varchar",
      [(1, 'fruit_id', 'integer', False), (2, 'name', 'character varying', False),
       (3, 'test', 'character varying', False)]),
-    ("ALTER TABLE test_pg_mount.fruits ADD PRIMARY KEY (fruit_id)",
+    ("ALTER TABLE \"test/pg_mount\".fruits ADD PRIMARY KEY (fruit_id)",
      [(1, 'fruit_id', 'integer', True), (2, 'name', 'character varying', False)]),
 
-    ("""ALTER TABLE test_pg_mount.fruits ADD COLUMN test_1 varchar, ADD COLUMN test_2 integer,
+    ("""ALTER TABLE "test/pg_mount".fruits ADD COLUMN test_1 varchar, ADD COLUMN test_2 integer,
                                          DROP COLUMN name;
-        ALTER TABLE test_pg_mount.fruits ADD PRIMARY KEY (fruit_id)""",
+        ALTER TABLE "test/pg_mount".fruits ADD PRIMARY KEY (fruit_id)""",
      [(1, 'fruit_id', 'integer', True), (3, 'test_1', 'character varying', False),
       (4, 'test_2', 'integer', False)]),
 ]
@@ -60,7 +60,7 @@ def test_schema_changes(sg_pg_conn, test_case):
 def test_pk_preserved_on_checkout(sg_pg_conn):
     assert list(get_primary_keys(sg_pg_conn, PG_MNT.to_schema(), 'fruits')) == []
     with sg_pg_conn.cursor() as cur:
-        cur.execute("""ALTER TABLE test_pg_mount.fruits ADD PRIMARY KEY (fruit_id)""")
+        cur.execute("""ALTER TABLE "test/pg_mount".fruits ADD PRIMARY KEY (fruit_id)""")
     assert list(get_primary_keys(sg_pg_conn, PG_MNT.to_schema(), 'fruits')) == [('fruit_id', 'integer')]
     head = get_current_head(sg_pg_conn, PG_MNT)
     new_head = commit(sg_pg_conn, PG_MNT)

--- a/test/splitgraph/commands/test_schema_changes.py
+++ b/test/splitgraph/commands/test_schema_changes.py
@@ -2,7 +2,7 @@ import pytest
 
 from splitgraph.commands import commit, checkout
 from splitgraph.constants import SPLITGRAPH_META_SCHEMA
-from splitgraph.meta_handler.tables import get_table_with_format
+from splitgraph.meta_handler.tables import get_object_for_table
 from splitgraph.meta_handler.tags import get_current_head
 from splitgraph.pg_utils import get_full_table_schema, get_primary_keys
 from test.splitgraph.conftest import PG_MNT
@@ -45,8 +45,8 @@ def test_schema_changes(sg_pg_conn, test_case):
     new_head = commit(sg_pg_conn, PG_MNT)
 
     # Test that the new image only has a snap and the object storing the snap has the expected new schema
-    assert get_table_with_format(sg_pg_conn, PG_MNT, 'fruits', new_head, 'DIFF') is None
-    new_snap = get_table_with_format(sg_pg_conn, PG_MNT, 'fruits', new_head, 'SNAP')
+    assert get_object_for_table(sg_pg_conn, PG_MNT, 'fruits', new_head, 'DIFF', '') is None
+    new_snap = get_object_for_table(sg_pg_conn, PG_MNT, 'fruits', new_head, 'SNAP', '')
     assert new_snap is not None
     assert get_full_table_schema(sg_pg_conn, SPLITGRAPH_META_SCHEMA, new_snap) == _reassign_ordinals(expected_new_schema)
 

--- a/test/splitgraph/commands/test_schema_changes.py
+++ b/test/splitgraph/commands/test_schema_changes.py
@@ -35,38 +35,38 @@ def _reassign_ordinals(schema):
 def test_schema_changes(sg_pg_conn, test_case):
     action, expected_new_schema = test_case
 
-    assert get_full_table_schema(sg_pg_conn, PG_MNT, 'fruits') == OLD_SCHEMA
+    assert get_full_table_schema(sg_pg_conn, PG_MNT.to_schema(), 'fruits') == OLD_SCHEMA
     with sg_pg_conn.cursor() as cur:
         cur.execute(action)
     sg_pg_conn.commit()
-    assert get_full_table_schema(sg_pg_conn, PG_MNT, 'fruits') == expected_new_schema
+    assert get_full_table_schema(sg_pg_conn, PG_MNT.to_schema(), 'fruits') == expected_new_schema
 
     head = get_current_head(sg_pg_conn, PG_MNT)
     new_head = commit(sg_pg_conn, PG_MNT)
 
     # Test that the new image only has a snap and the object storing the snap has the expected new schema
-    assert get_object_for_table(sg_pg_conn, PG_MNT, 'fruits', new_head, 'DIFF', '') is None
-    new_snap = get_object_for_table(sg_pg_conn, PG_MNT, 'fruits', new_head, 'SNAP', '')
+    assert get_object_for_table(sg_pg_conn, PG_MNT, 'fruits', new_head, 'DIFF') is None
+    new_snap = get_object_for_table(sg_pg_conn, PG_MNT, 'fruits', new_head, 'SNAP')
     assert new_snap is not None
     assert get_full_table_schema(sg_pg_conn, SPLITGRAPH_META_SCHEMA, new_snap) == _reassign_ordinals(expected_new_schema)
 
     checkout(sg_pg_conn, PG_MNT, head)
-    assert get_full_table_schema(sg_pg_conn, PG_MNT, 'fruits') == OLD_SCHEMA
+    assert get_full_table_schema(sg_pg_conn, PG_MNT.to_schema(), 'fruits') == OLD_SCHEMA
     checkout(sg_pg_conn, PG_MNT, new_head)
 
-    assert get_full_table_schema(sg_pg_conn, PG_MNT, 'fruits') == _reassign_ordinals(expected_new_schema)
+    assert get_full_table_schema(sg_pg_conn, PG_MNT.to_schema(), 'fruits') == _reassign_ordinals(expected_new_schema)
 
 
 def test_pk_preserved_on_checkout(sg_pg_conn):
-    assert list(get_primary_keys(sg_pg_conn, PG_MNT, 'fruits')) == []
+    assert list(get_primary_keys(sg_pg_conn, PG_MNT.to_schema(), 'fruits')) == []
     with sg_pg_conn.cursor() as cur:
         cur.execute("""ALTER TABLE test_pg_mount.fruits ADD PRIMARY KEY (fruit_id)""")
-    assert list(get_primary_keys(sg_pg_conn, PG_MNT, 'fruits')) == [('fruit_id', 'integer')]
+    assert list(get_primary_keys(sg_pg_conn, PG_MNT.to_schema(), 'fruits')) == [('fruit_id', 'integer')]
     head = get_current_head(sg_pg_conn, PG_MNT)
     new_head = commit(sg_pg_conn, PG_MNT)
-    assert list(get_primary_keys(sg_pg_conn, PG_MNT, 'fruits')) == [('fruit_id', 'integer')]
+    assert list(get_primary_keys(sg_pg_conn, PG_MNT.to_schema(), 'fruits')) == [('fruit_id', 'integer')]
 
     checkout(sg_pg_conn, PG_MNT, head)
-    assert list(get_primary_keys(sg_pg_conn, PG_MNT, 'fruits')) == []
+    assert list(get_primary_keys(sg_pg_conn, PG_MNT.to_schema(), 'fruits')) == []
     checkout(sg_pg_conn, PG_MNT, new_head)
-    assert list(get_primary_keys(sg_pg_conn, PG_MNT, 'fruits')) == [('fruit_id', 'integer')]
+    assert list(get_primary_keys(sg_pg_conn, PG_MNT.to_schema(), 'fruits')) == [('fruit_id', 'integer')]

--- a/test/splitgraph/conftest.py
+++ b/test/splitgraph/conftest.py
@@ -54,7 +54,7 @@ def healthcheck():
     _mount_postgres(conn, PG_MNT)
     _mount_mongo(conn, MG_MNT)
     with conn.cursor() as cur:
-        cur.execute('SELECT COUNT(*) FROM "test_pg_mount".fruits')
+        cur.execute('SELECT COUNT(*) FROM "test/pg_mount".fruits')
         assert cur.fetchone()[0] > 0
         cur.execute('SELECT COUNT(*) FROM "test_mg_mount".stuff')
         assert cur.fetchone()[0] > 0

--- a/test/splitgraph/conftest.py
+++ b/test/splitgraph/conftest.py
@@ -9,8 +9,10 @@ from splitgraph.meta_handler.misc import get_current_repositories
 from splitgraph.pg_utils import get_all_foreign_tables
 from splitgraph.registry_meta_handler import ensure_registry_schema, unpublish_repository
 
-PG_MNT = R('test_pg_mount')
+PG_MNT = R('test/pg_mount')
+PG_MNT_PULL = R('test_pg_mount_pull')
 MG_MNT = R('test_mg_mount')
+OUTPUT = R('output')
 
 
 def _mount_postgres(conn, repository):
@@ -38,7 +40,7 @@ def _mount_mongo(conn, repository):
     unmount(conn, R('tmp'))
 
 
-TEST_MOUNTPOINTS = [PG_MNT, R('test_pg_mount_pull'), R('output'), MG_MNT, R('output_stage_2')]
+TEST_MOUNTPOINTS = [PG_MNT, PG_MNT_PULL, OUTPUT, MG_MNT, R('output_stage_2')]
 
 
 def healthcheck():
@@ -100,8 +102,8 @@ def remote_driver_conn():
     # Mount and snapshot the two origin DBs (mongo/pg) with the test data.
     conn = make_conn(REMOTE_HOST, REMOTE_PORT, PG_USER, PG_PWD, PG_DB)
     ensure_registry_schema(conn)
-    unpublish_repository(conn, R('output'))
-    unpublish_repository(conn, R('test_pg_mount'))
+    unpublish_repository(conn, OUTPUT)
+    unpublish_repository(conn, PG_MNT)
     for mountpoint in TEST_MOUNTPOINTS:
         unmount(conn, mountpoint)
     cleanup_objects(conn)
@@ -133,4 +135,3 @@ def empty_pg_conn():
 
 
 REMOTE_CONN_STRING = serialize_connection_string(REMOTE_HOST, REMOTE_PORT, PG_USER, PG_PWD, PG_DB)
-OUTPUT = R('output')

--- a/test/splitgraph/conftest.py
+++ b/test/splitgraph/conftest.py
@@ -5,7 +5,8 @@ from splitgraph.commands import *
 from splitgraph.commands import unmount
 from splitgraph.commands.misc import make_conn, cleanup_objects
 from splitgraph.constants import PG_USER, PG_PWD, PG_DB, serialize_connection_string
-from splitgraph.meta_handler.misc import get_current_mountpoints_hashes, get_all_foreign_tables
+from splitgraph.meta_handler.misc import get_current_repositories
+from splitgraph.pg_utils import get_all_foreign_tables
 from splitgraph.registry_meta_handler import ensure_registry_schema, unpublish_repository
 
 PG_MNT = 'test_pg_mount'
@@ -119,12 +120,12 @@ def remote_driver_conn():
 def empty_pg_conn():
     # A connection to the local driver that has nothing mounted on it.
     conn = _conn()
-    for mountpoint, _ in get_current_mountpoints_hashes(conn):
+    for mountpoint, _ in get_current_repositories(conn):
         unmount(conn, mountpoint)
     cleanup_objects(conn)
     conn.commit()
     yield conn
-    for mountpoint, _ in get_current_mountpoints_hashes(conn):
+    for mountpoint, _ in get_current_repositories(conn):
         unmount(conn, mountpoint)
     cleanup_objects(conn)
     conn.commit()

--- a/test/splitgraph/test_commandline.py
+++ b/test/splitgraph/test_commandline.py
@@ -7,12 +7,13 @@ from splitgraph.commandline import status_c, sql_c, diff_c, commit_c, log_c, sho
 from splitgraph.commands import commit, checkout
 from splitgraph.commands.misc import table_exists_at, unmount
 from splitgraph.commands.provenance import provenance
+from splitgraph.constants import to_repository
 from splitgraph.meta_handler.images import get_all_images_parents, get_image
 from splitgraph.meta_handler.misc import repository_exists
 from splitgraph.meta_handler.tables import get_table
 from splitgraph.meta_handler.tags import get_current_head, get_tagged_id, set_tag
 from splitgraph.registry_meta_handler import get_published_info
-from test.splitgraph.conftest import PG_MNT, MG_MNT
+from test.splitgraph.conftest import PG_MNT, MG_MNT, OUTPUT
 from test.splitgraph.test_sgfile import SGFILE_ROOT, _add_multitag_dataset_to_remote_driver
 
 
@@ -36,12 +37,12 @@ def test_commandline_basics(sg_pg_mg_conn):
     assert "(1, 'apple')" not in result.output
 
     def check_diff(args):
-        result = runner.invoke(diff_c, args)
+        result = runner.invoke(diff_c, [str(a) for a in args])
         assert "added 1 rows" in result.output
         assert "removed 1 rows" in result.output
         assert "vegetables: table removed"
         assert "mushrooms: table added"
-        result = runner.invoke(diff_c, args + ['-v'])
+        result = runner.invoke(diff_c, [str(a) for a in args] + ['-v'])
         assert "(3, 'mayonnaise'): +" in result.output
         assert "(1, 'apple'): -" in result.output
 
@@ -49,10 +50,10 @@ def test_commandline_basics(sg_pg_mg_conn):
     check_diff([PG_MNT])
 
     # sgr commit (with an extra snapshot
-    result = runner.invoke(commit_c, [PG_MNT, '-m', 'Test commit', '-s'])
+    result = runner.invoke(commit_c, [str(PG_MNT), '-m', 'Test commit', '-s'])
     new_head = get_current_head(sg_pg_mg_conn, PG_MNT)
     assert new_head != old_head
-    assert get_image(sg_pg_mg_conn, PG_MNT, new_head).parent == old_head
+    assert get_image(sg_pg_mg_conn, PG_MNT, new_head).parent_id == old_head
     assert new_head[:10] in result.output
 
     # sgr diff, old head -> new head (2-param), truncated hashes
@@ -70,24 +71,24 @@ def test_commandline_basics(sg_pg_mg_conn):
     # check_diff([PG_MNT, new_head[:20], old_head[:20]])
 
     # sgr status with the new commit
-    result = runner.invoke(status_c, [PG_MNT])
+    result = runner.invoke(status_c, [str(PG_MNT)])
     assert 'test_pg_mount' in result.output
     assert 'Parent: ' + old_head in result.output
     assert new_head in result.output
 
     # sgr log
-    result = runner.invoke(log_c, [PG_MNT])
+    result = runner.invoke(log_c, [str(PG_MNT)])
     assert old_head in result.output
     assert new_head in result.output
     assert "Test commit" in result.output
 
     # sgr log (tree)
-    result = runner.invoke(log_c, [PG_MNT, '-t'])
+    result = runner.invoke(log_c, [str(PG_MNT), '-t'])
     assert old_head[:5] in result.output
     assert new_head[:5] in result.output
 
     # sgr show the new commit
-    result = runner.invoke(show_c, [PG_MNT, new_head[:20], '-v'])
+    result = runner.invoke(show_c, [str(PG_MNT), new_head[:20], '-v'])
     assert "Test commit" in result.output
     assert "Parent: " + old_head in result.output
     fruit_objs = get_table(sg_pg_mg_conn, PG_MNT, 'fruits', new_head[:20])
@@ -107,38 +108,38 @@ def test_commandline_tag_checkout(sg_pg_mg_conn):
     runner.invoke(sql_c, ["DROP TABLE test_pg_mount.vegetables"])
     runner.invoke(sql_c, ["DELETE FROM test_pg_mount.fruits WHERE fruit_id = 1"])
     runner.invoke(sql_c, ["SELECT * FROM test_pg_mount.fruits"])
-    runner.invoke(commit_c, [PG_MNT, '-m', 'Test commit'])
+    runner.invoke(commit_c, [str(PG_MNT), '-m', 'Test commit'])
     new_head = get_current_head(sg_pg_mg_conn, PG_MNT)
 
     # sgr tag <mountpoint> <tag>: tags the current HEAD
-    runner.invoke(tag_c, [PG_MNT, 'v2'])
+    runner.invoke(tag_c, [str(PG_MNT), 'v2'])
     assert get_tagged_id(sg_pg_mg_conn, PG_MNT, 'v2') == new_head
 
     # sgr tag <mountpoint> <tag> -i (imagehash):
-    runner.invoke(tag_c, [PG_MNT, 'v1', '-i', old_head[:10]])
+    runner.invoke(tag_c, [str(PG_MNT), 'v1', '-i', old_head[:10]])
     assert get_tagged_id(sg_pg_mg_conn, PG_MNT, 'v1') == old_head
 
     # sgr tag <mountpoint> with the same tag -- expect an error
-    result = runner.invoke(tag_c, [PG_MNT, 'v1'])
+    result = runner.invoke(tag_c, [str(PG_MNT), 'v1'])
     assert result.exit_code != 0
     assert 'Tag v1 already exists' in str(result.exc_info)
 
     # list tags
-    result = runner.invoke(tag_c, [PG_MNT])
+    result = runner.invoke(tag_c, [str(PG_MNT)])
     assert old_head[:12] + ': v1' in result.output
     assert new_head[:12] + ': HEAD, v2' in result.output
 
     # List tags on a single image
-    result = runner.invoke(tag_c, [PG_MNT, '-i', old_head[:20]])
+    result = runner.invoke(tag_c, [str(PG_MNT), '-i', old_head[:20]])
     assert 'v1' in result.output
     assert 'HEAD, v2' not in result.output
 
     # Checkout by tag
-    runner.invoke(checkout_c, [PG_MNT, 'v1'])
+    runner.invoke(checkout_c, [str(PG_MNT), 'v1'])
     assert get_current_head(sg_pg_mg_conn, PG_MNT) == old_head
 
     # Checkout by hash
-    runner.invoke(checkout_c, [PG_MNT, new_head[:20]])
+    runner.invoke(checkout_c, [str(PG_MNT), new_head[:20]])
     assert get_current_head(sg_pg_mg_conn, PG_MNT) == new_head
 
 
@@ -146,11 +147,11 @@ def test_misc_mountpoint_management(sg_pg_mg_conn):
     runner = CliRunner()
 
     result = runner.invoke(status_c)
-    assert PG_MNT in result.output
-    assert MG_MNT in result.output
+    assert str(PG_MNT) in result.output
+    assert str(MG_MNT) in result.output
 
     # sgr unmount
-    result = runner.invoke(unmount_c, [MG_MNT])
+    result = runner.invoke(unmount_c, [str(MG_MNT)])
     assert result.exit_code == 0
     assert not repository_exists(sg_pg_mg_conn, MG_MNT)
 
@@ -160,11 +161,11 @@ def test_misc_mountpoint_management(sg_pg_mg_conn):
 
     # sgr init
     result = runner.invoke(init_c, ['output'])
-    assert "Initialized empty mountpoint output" in result.output
-    assert repository_exists(sg_pg_mg_conn, 'output')
+    assert "Initialized empty repository output" in result.output
+    assert repository_exists(sg_pg_mg_conn, OUTPUT)
 
     # sgr mount
-    result = runner.invoke(mount_c, [MG_MNT, '-c', 'originro:originpass@mongoorigin:27017',
+    result = runner.invoke(mount_c, [str(MG_MNT), '-c', 'originro:originpass@mongoorigin:27017',
                                      '-h', 'mongo_fdw', '-o', json.dumps({"stuff": {
             "db": "origindb",
             "coll": "stuff",
@@ -184,14 +185,14 @@ def test_import(sg_pg_mg_conn):
     head = get_current_head(sg_pg_mg_conn, PG_MNT)
 
     # sgr import mountpoint, table, target_mountpoint (3-arg)
-    result = runner.invoke(import_c, [MG_MNT, 'stuff', PG_MNT])
+    result = runner.invoke(import_c, [str(MG_MNT), 'stuff', str(PG_MNT)])
     assert result.exit_code == 0
     new_head = get_current_head(sg_pg_mg_conn, PG_MNT)
     assert table_exists_at(sg_pg_mg_conn, PG_MNT, 'stuff', new_head)
     assert not table_exists_at(sg_pg_mg_conn, PG_MNT, 'stuff', head)
 
     # sgr import with alias
-    result = runner.invoke(import_c, [MG_MNT, 'stuff', PG_MNT, 'stuff_copy'])
+    result = runner.invoke(import_c, [str(MG_MNT), 'stuff', str(PG_MNT), 'stuff_copy'])
     assert result.exit_code == 0
     new_new_head = get_current_head(sg_pg_mg_conn, PG_MNT)
     assert table_exists_at(sg_pg_mg_conn, PG_MNT, 'stuff_copy', new_new_head)
@@ -202,7 +203,7 @@ def test_import(sg_pg_mg_conn):
         cur.execute("DELETE FROM test_mg_mount.stuff")
     new_mg_head = commit(sg_pg_mg_conn, MG_MNT)
 
-    result = runner.invoke(import_c, [MG_MNT, 'stuff', PG_MNT, 'stuff_empty', new_mg_head])
+    result = runner.invoke(import_c, [str(MG_MNT), 'stuff', str(PG_MNT), 'stuff_empty', new_mg_head])
     assert result.exit_code == 0
     new_new_new_head = get_current_head(sg_pg_mg_conn, PG_MNT)
     assert table_exists_at(sg_pg_mg_conn, PG_MNT, 'stuff_empty', new_new_new_head)
@@ -215,7 +216,7 @@ def test_import(sg_pg_mg_conn):
 def test_pull_push(empty_pg_conn, remote_driver_conn):
     runner = CliRunner()
 
-    result = runner.invoke(clone_c, [PG_MNT])
+    result = runner.invoke(clone_c, [str(PG_MNT)])
     assert result.exit_code == 0
     assert repository_exists(empty_pg_conn, PG_MNT)
 
@@ -223,7 +224,7 @@ def test_pull_push(empty_pg_conn, remote_driver_conn):
         cur.execute("INSERT INTO test_pg_mount.fruits VALUES (3, 'mayonnaise')")
     remote_driver_head = commit(remote_driver_conn, PG_MNT)
 
-    result = runner.invoke(pull_c, [PG_MNT, 'origin'])
+    result = runner.invoke(pull_c, [str(PG_MNT), 'origin'])
     assert result.exit_code == 0
     checkout(empty_pg_conn, PG_MNT, remote_driver_head)
 
@@ -232,13 +233,13 @@ def test_pull_push(empty_pg_conn, remote_driver_conn):
     local_head = commit(empty_pg_conn, PG_MNT)
 
     assert not table_exists_at(remote_driver_conn, PG_MNT, 'fruits', local_head)
-    result = runner.invoke(push_c, [PG_MNT, 'origin', '-h', 'DB'])
+    result = runner.invoke(push_c, [str(PG_MNT), 'origin', '-h', 'DB'])
     assert result.exit_code == 0
     assert table_exists_at(remote_driver_conn, PG_MNT, 'fruits', local_head)
 
     set_tag(empty_pg_conn, PG_MNT, local_head, 'v1')
     empty_pg_conn.commit()
-    result = runner.invoke(publish_c, [PG_MNT, 'v1', '-r', SGFILE_ROOT + 'README.md'])
+    result = runner.invoke(publish_c, [str(PG_MNT), 'v1', '-r', SGFILE_ROOT + 'README.md'])
     assert result.exit_code == 0
     image_hash, published_dt, deps, readme, schemata, previews = get_published_info(remote_driver_conn, PG_MNT, 'v1')
     assert image_hash == local_head
@@ -264,11 +265,11 @@ def test_sgfile(empty_pg_conn, remote_driver_conn):
 
     # Test the sgr provenance command. First, just list the dependencies of the new image.
     result = runner.invoke(provenance_c, ['output', 'latest'])
-    assert 'test_pg_mount:%s' % get_tagged_id(remote_driver_conn, 'test_pg_mount', 'latest') in result.output
+    assert 'test_pg_mount:%s' % get_tagged_id(remote_driver_conn, PG_MNT, 'latest') in result.output
 
     # Second, output the full sgfile (-f)
     result = runner.invoke(provenance_c, ['output', 'latest', '-f'])
-    assert 'FROM test_pg_mount:%s IMPORT' % get_tagged_id(remote_driver_conn, 'test_pg_mount', 'latest') in result.output
+    assert 'FROM test_pg_mount:%s IMPORT' % get_tagged_id(remote_driver_conn, PG_MNT, 'latest') in result.output
     assert 'SQL CREATE TABLE join_table AS SELECT' in result.output
 
 
@@ -282,19 +283,18 @@ def test_sgfile_rerun_update(empty_pg_conn, remote_driver_conn):
 
     # Rerun the output:latest against v2 of the test_pg_mount
     result = runner.invoke(rerun_c, ['output', 'latest', '-i', 'test_pg_mount', 'v2'])
-    output_v2 = get_current_head(empty_pg_conn, 'output')
+    output_v2 = get_current_head(empty_pg_conn, OUTPUT)
     assert result.exit_code == 0
-    assert provenance(empty_pg_conn, 'output', output_v2) == \
-           [('test_pg_mount', get_tagged_id(remote_driver_conn, 'test_pg_mount', 'v2'))]
+    assert provenance(empty_pg_conn, OUTPUT, output_v2) == [(PG_MNT, get_tagged_id(remote_driver_conn, PG_MNT, 'v2'))]
 
     # Now rerun the output:latest against the latest version of everything.
     # In this case, this should all resolve to the same version of test_pg_mount (v2) and not produce
     # any extra commits.
-    curr_commits = get_all_images_parents(empty_pg_conn, 'output')
+    curr_commits = get_all_images_parents(empty_pg_conn, OUTPUT)
     result = runner.invoke(rerun_c, ['output', 'latest', '-u'])
     assert result.exit_code == 0
-    assert output_v2 == get_current_head(empty_pg_conn, 'output')
-    assert get_all_images_parents(empty_pg_conn, 'output') == curr_commits
+    assert output_v2 == get_current_head(empty_pg_conn, OUTPUT)
+    assert get_all_images_parents(empty_pg_conn, OUTPUT) == curr_commits
 
 
 def test_mount_and_import(empty_pg_conn):
@@ -312,13 +312,13 @@ def test_mount_and_import(empty_pg_conn):
                 }}})])
         assert result.exit_code == 0
 
-        result = runner.invoke(import_c, ['tmp', 'stuff', MG_MNT, '-f'])
+        result = runner.invoke(import_c, ['tmp', 'stuff', str(MG_MNT), '-f'])
         assert result.exit_code == 0
         assert table_exists_at(empty_pg_conn, MG_MNT, 'stuff', get_current_head(empty_pg_conn, MG_MNT))
 
-        result = runner.invoke(import_c, ['tmp', 'SELECT * FROM stuff WHERE duration > 10', MG_MNT,
+        result = runner.invoke(import_c, ['tmp', 'SELECT * FROM stuff WHERE duration > 10', str(MG_MNT),
                                           'stuff_query', '-f', '-q'])
         assert result.exit_code == 0
         assert table_exists_at(empty_pg_conn, MG_MNT, 'stuff_query', get_current_head(empty_pg_conn, MG_MNT))
     finally:
-        unmount(empty_pg_conn, 'tmp')
+        unmount(empty_pg_conn, to_repository('tmp'))

--- a/test/splitgraph/test_commandline.py
+++ b/test/splitgraph/test_commandline.py
@@ -28,11 +28,11 @@ def test_commandline_basics(sg_pg_mg_conn):
     assert old_head in result.output
 
     # sgr sql
-    runner.invoke(sql_c, ["INSERT INTO test_pg_mount.fruits VALUES (3, 'mayonnaise')"])
-    runner.invoke(sql_c, ["CREATE TABLE test_pg_mount.mushrooms (mushroom_id integer, name varchar)"])
-    runner.invoke(sql_c, ["DROP TABLE test_pg_mount.vegetables"])
-    runner.invoke(sql_c, ["DELETE FROM test_pg_mount.fruits WHERE fruit_id = 1"])
-    result = runner.invoke(sql_c, ["SELECT * FROM test_pg_mount.fruits"])
+    runner.invoke(sql_c, ["INSERT INTO \"test/pg_mount\".fruits VALUES (3, 'mayonnaise')"])
+    runner.invoke(sql_c, ["CREATE TABLE \"test/pg_mount\".mushrooms (mushroom_id integer, name varchar)"])
+    runner.invoke(sql_c, ["DROP TABLE \"test/pg_mount\".vegetables"])
+    runner.invoke(sql_c, ["DELETE FROM \"test/pg_mount\".fruits WHERE fruit_id = 1"])
+    result = runner.invoke(sql_c, ["SELECT * FROM \"test/pg_mount\".fruits"])
     assert "(3, 'mayonnaise')" in result.output
     assert "(1, 'apple')" not in result.output
 
@@ -72,7 +72,7 @@ def test_commandline_basics(sg_pg_mg_conn):
 
     # sgr status with the new commit
     result = runner.invoke(status_c, [str(PG_MNT)])
-    assert 'test_pg_mount' in result.output
+    assert 'test/pg_mount' in result.output
     assert 'Parent: ' + old_head in result.output
     assert new_head in result.output
 
@@ -103,11 +103,11 @@ def test_commandline_tag_checkout(sg_pg_mg_conn):
     runner = CliRunner()
     # Do the quick setting up with the same commit structure
     old_head = get_current_head(sg_pg_mg_conn, PG_MNT)
-    runner.invoke(sql_c, ["INSERT INTO test_pg_mount.fruits VALUES (3, 'mayonnaise')"])
-    runner.invoke(sql_c, ["CREATE TABLE test_pg_mount.mushrooms (mushroom_id integer, name varchar)"])
-    runner.invoke(sql_c, ["DROP TABLE test_pg_mount.vegetables"])
-    runner.invoke(sql_c, ["DELETE FROM test_pg_mount.fruits WHERE fruit_id = 1"])
-    runner.invoke(sql_c, ["SELECT * FROM test_pg_mount.fruits"])
+    runner.invoke(sql_c, ["INSERT INTO \"test/pg_mount\".fruits VALUES (3, 'mayonnaise')"])
+    runner.invoke(sql_c, ["CREATE TABLE \"test/pg_mount\".mushrooms (mushroom_id integer, name varchar)"])
+    runner.invoke(sql_c, ["DROP TABLE \"test/pg_mount\".vegetables"])
+    runner.invoke(sql_c, ["DELETE FROM \"test/pg_mount\".fruits WHERE fruit_id = 1"])
+    runner.invoke(sql_c, ["SELECT * FROM \"test/pg_mount\".fruits"])
     runner.invoke(commit_c, [str(PG_MNT), '-m', 'Test commit'])
     new_head = get_current_head(sg_pg_mg_conn, PG_MNT)
 
@@ -209,7 +209,7 @@ def test_import(sg_pg_mg_conn):
     assert table_exists_at(sg_pg_mg_conn, PG_MNT, 'stuff_empty', new_new_new_head)
     assert not table_exists_at(sg_pg_mg_conn, PG_MNT, 'stuff_empty', new_new_head)
     with sg_pg_mg_conn.cursor() as cur:
-        cur.execute("SELECT * FROM test_pg_mount.stuff_empty")
+        cur.execute("SELECT * FROM \"test/pg_mount\".stuff_empty")
         assert cur.fetchall() == []
 
 
@@ -221,7 +221,7 @@ def test_pull_push(empty_pg_conn, remote_driver_conn):
     assert repository_exists(empty_pg_conn, PG_MNT)
 
     with remote_driver_conn.cursor() as cur:
-        cur.execute("INSERT INTO test_pg_mount.fruits VALUES (3, 'mayonnaise')")
+        cur.execute("INSERT INTO \"test/pg_mount\".fruits VALUES (3, 'mayonnaise')")
     remote_driver_head = commit(remote_driver_conn, PG_MNT)
 
     result = runner.invoke(pull_c, [str(PG_MNT), 'origin'])
@@ -229,7 +229,7 @@ def test_pull_push(empty_pg_conn, remote_driver_conn):
     checkout(empty_pg_conn, PG_MNT, remote_driver_head)
 
     with empty_pg_conn.cursor() as cur:
-        cur.execute("INSERT INTO test_pg_mount.fruits VALUES (4, 'mustard')")
+        cur.execute("INSERT INTO \"test/pg_mount\".fruits VALUES (4, 'mustard')")
     local_head = commit(empty_pg_conn, PG_MNT)
 
     assert not table_exists_at(remote_driver_conn, PG_MNT, 'fruits', local_head)
@@ -265,11 +265,11 @@ def test_sgfile(empty_pg_conn, remote_driver_conn):
 
     # Test the sgr provenance command. First, just list the dependencies of the new image.
     result = runner.invoke(provenance_c, ['output', 'latest'])
-    assert 'test_pg_mount:%s' % get_tagged_id(remote_driver_conn, PG_MNT, 'latest') in result.output
+    assert 'test/pg_mount:%s' % get_tagged_id(remote_driver_conn, PG_MNT, 'latest') in result.output
 
     # Second, output the full sgfile (-f)
     result = runner.invoke(provenance_c, ['output', 'latest', '-f'])
-    assert 'FROM test_pg_mount:%s IMPORT' % get_tagged_id(remote_driver_conn, PG_MNT, 'latest') in result.output
+    assert 'FROM test/pg_mount:%s IMPORT' % get_tagged_id(remote_driver_conn, PG_MNT, 'latest') in result.output
     assert 'SQL CREATE TABLE join_table AS SELECT' in result.output
 
 
@@ -281,14 +281,14 @@ def test_sgfile_rerun_update(empty_pg_conn, remote_driver_conn):
                                     '-a', 'TAG', 'v1', '-o', 'output'])
     assert result.exit_code == 0
 
-    # Rerun the output:latest against v2 of the test_pg_mount
-    result = runner.invoke(rerun_c, ['output', 'latest', '-i', 'test_pg_mount', 'v2'])
+    # Rerun the output:latest against v2 of the test/pg_mount
+    result = runner.invoke(rerun_c, ['output', 'latest', '-i', 'test/pg_mount', 'v2'])
     output_v2 = get_current_head(empty_pg_conn, OUTPUT)
     assert result.exit_code == 0
     assert provenance(empty_pg_conn, OUTPUT, output_v2) == [(PG_MNT, get_tagged_id(remote_driver_conn, PG_MNT, 'v2'))]
 
     # Now rerun the output:latest against the latest version of everything.
-    # In this case, this should all resolve to the same version of test_pg_mount (v2) and not produce
+    # In this case, this should all resolve to the same version of test/pg_mount (v2) and not produce
     # any extra commits.
     curr_commits = get_all_images_parents(empty_pg_conn, OUTPUT)
     result = runner.invoke(rerun_c, ['output', 'latest', '-u'])

--- a/test/splitgraph/test_commandline.py
+++ b/test/splitgraph/test_commandline.py
@@ -7,7 +7,7 @@ from splitgraph.commandline import status_c, sql_c, diff_c, commit_c, log_c, sho
 from splitgraph.commands import commit, checkout
 from splitgraph.commands.misc import table_exists_at, unmount
 from splitgraph.commands.provenance import provenance
-from splitgraph.meta_handler.images import get_image_parent, get_all_images_parents
+from splitgraph.meta_handler.images import get_all_images_parents, get_image
 from splitgraph.meta_handler.misc import repository_exists
 from splitgraph.meta_handler.tables import get_table
 from splitgraph.meta_handler.tags import get_current_head, get_tagged_id, set_tag
@@ -21,8 +21,8 @@ def test_commandline_basics(sg_pg_mg_conn):
 
     # sgr status
     result = runner.invoke(status_c, [])
-    assert PG_MNT in result.output
-    assert MG_MNT in result.output
+    assert PG_MNT.to_schema() in result.output
+    assert MG_MNT.to_schema() in result.output
     old_head = get_current_head(sg_pg_mg_conn, PG_MNT)
     assert old_head in result.output
 
@@ -52,7 +52,7 @@ def test_commandline_basics(sg_pg_mg_conn):
     result = runner.invoke(commit_c, [PG_MNT, '-m', 'Test commit', '-s'])
     new_head = get_current_head(sg_pg_mg_conn, PG_MNT)
     assert new_head != old_head
-    assert get_image_parent(sg_pg_mg_conn, PG_MNT, new_head) == old_head
+    assert get_image(sg_pg_mg_conn, PG_MNT, new_head).parent == old_head
     assert new_head[:10] in result.output
 
     # sgr diff, old head -> new head (2-param), truncated hashes

--- a/test/splitgraph/test_commandline.py
+++ b/test/splitgraph/test_commandline.py
@@ -8,7 +8,7 @@ from splitgraph.commands import commit, checkout
 from splitgraph.commands.misc import table_exists_at, unmount
 from splitgraph.commands.provenance import provenance
 from splitgraph.meta_handler.images import get_image_parent, get_all_images_parents
-from splitgraph.meta_handler.misc import mountpoint_exists
+from splitgraph.meta_handler.misc import repository_exists
 from splitgraph.meta_handler.tables import get_table
 from splitgraph.meta_handler.tags import get_current_head, get_tagged_id, set_tag
 from splitgraph.registry_meta_handler import get_published_info
@@ -152,7 +152,7 @@ def test_misc_mountpoint_management(sg_pg_mg_conn):
     # sgr unmount
     result = runner.invoke(unmount_c, [MG_MNT])
     assert result.exit_code == 0
-    assert not mountpoint_exists(sg_pg_mg_conn, MG_MNT)
+    assert not repository_exists(sg_pg_mg_conn, MG_MNT)
 
     # sgr cleanup
     result = runner.invoke(cleanup_c)
@@ -161,7 +161,7 @@ def test_misc_mountpoint_management(sg_pg_mg_conn):
     # sgr init
     result = runner.invoke(init_c, ['output'])
     assert "Initialized empty mountpoint output" in result.output
-    assert mountpoint_exists(sg_pg_mg_conn, 'output')
+    assert repository_exists(sg_pg_mg_conn, 'output')
 
     # sgr mount
     result = runner.invoke(mount_c, [MG_MNT, '-c', 'originro:originpass@mongoorigin:27017',
@@ -217,7 +217,7 @@ def test_pull_push(empty_pg_conn, remote_driver_conn):
 
     result = runner.invoke(clone_c, [PG_MNT])
     assert result.exit_code == 0
-    assert mountpoint_exists(empty_pg_conn, PG_MNT)
+    assert repository_exists(empty_pg_conn, PG_MNT)
 
     with remote_driver_conn.cursor() as cur:
         cur.execute("INSERT INTO test_pg_mount.fruits VALUES (3, 'mayonnaise')")

--- a/test/splitgraph/test_drawing.py
+++ b/test/splitgraph/test_drawing.py
@@ -1,9 +1,10 @@
 from splitgraph.drawing import render_tree
 from splitgraph.sgfile.execution import execute_commands
+from test.splitgraph.conftest import OUTPUT
 from test.splitgraph.test_sgfile import _load_sgfile
 
 
 def test_drawing(sg_pg_mg_conn):
     # Doesn't really check anything, mostly used to make sure the tree drawing code doesn't throw.
-    execute_commands(sg_pg_mg_conn, _load_sgfile('import_local.sgfile'), output='output')
-    render_tree(sg_pg_mg_conn, 'output')
+    execute_commands(sg_pg_mg_conn, _load_sgfile('import_local.sgfile'), output=OUTPUT)
+    render_tree(sg_pg_mg_conn, OUTPUT)

--- a/test/splitgraph/test_sgfile.py
+++ b/test/splitgraph/test_sgfile.py
@@ -5,8 +5,8 @@ import pytest
 
 from splitgraph.commands import checkout, commit, push, unmount, clone, get_log
 from splitgraph.commands.misc import cleanup_objects
-from splitgraph.constants import SPLITGRAPH_META_SCHEMA, SplitGraphException
-from splitgraph.meta_handler.images import get_image_parent
+from splitgraph.constants import SplitGraphException, to_repository as R
+from splitgraph.meta_handler.images import get_image, get_all_images_parents
 from splitgraph.meta_handler.misc import get_current_repositories
 from splitgraph.meta_handler.objects import get_existing_objects, get_downloaded_objects, get_external_object_locations
 from splitgraph.meta_handler.tables import get_tables_at, get_object_for_table
@@ -14,7 +14,7 @@ from splitgraph.meta_handler.tags import get_current_head, set_tag
 from splitgraph.pg_utils import pg_table_exists
 from splitgraph.sgfile.execution import execute_commands
 from splitgraph.sgfile.parsing import preprocess
-from test.splitgraph.conftest import REMOTE_CONN_STRING
+from test.splitgraph.conftest import REMOTE_CONN_STRING, OUTPUT, PG_MNT
 
 SGFILE_ROOT = os.path.join(os.path.dirname(__file__), '../resources/')
 
@@ -45,20 +45,20 @@ def test_sgfile_preprocessor_escaping():
 
 
 def test_basic_sgfile(sg_pg_mg_conn):
-    execute_commands(sg_pg_mg_conn, _load_sgfile('create_table.sgfile'), output='output')
-    log = list(reversed(get_log(sg_pg_mg_conn, 'output', get_current_head(sg_pg_mg_conn, 'output'))))
+    execute_commands(sg_pg_mg_conn, _load_sgfile('create_table.sgfile'), output=OUTPUT)
+    log = list(reversed(get_log(sg_pg_mg_conn, OUTPUT, get_current_head(sg_pg_mg_conn, OUTPUT))))
 
-    checkout(sg_pg_mg_conn, 'output', log[1])
+    checkout(sg_pg_mg_conn, OUTPUT, log[1])
     with sg_pg_mg_conn.cursor() as cur:
         cur.execute("""SELECT * FROM output.my_fruits""")
         assert cur.fetchall() == []
 
-    checkout(sg_pg_mg_conn, 'output', log[2])
+    checkout(sg_pg_mg_conn, OUTPUT, log[2])
     with sg_pg_mg_conn.cursor() as cur:
         cur.execute("""SELECT * FROM output.my_fruits""")
         assert cur.fetchall() == [(1, 'pineapple')]
 
-    checkout(sg_pg_mg_conn, 'output', log[3])
+    checkout(sg_pg_mg_conn, OUTPUT, log[3])
     with sg_pg_mg_conn.cursor() as cur:
         cur.execute("""SELECT * FROM output.my_fruits""")
         assert cur.fetchall() == [(1, 'pineapple'), (2, 'banana')]
@@ -67,47 +67,47 @@ def test_basic_sgfile(sg_pg_mg_conn):
 def test_update_without_import_sgfile(sg_pg_mg_conn):
     # Test that correct commits are produced by executing an sgfile (both against newly created and already
     # existing tables on an existing mountpoint)
-    execute_commands(sg_pg_mg_conn, _load_sgfile('update_without_import.sgfile'), output='output')
-    log = get_log(sg_pg_mg_conn, 'output', get_current_head(sg_pg_mg_conn, 'output'))
+    execute_commands(sg_pg_mg_conn, _load_sgfile('update_without_import.sgfile'), output=OUTPUT)
+    log = get_log(sg_pg_mg_conn, OUTPUT, get_current_head(sg_pg_mg_conn, OUTPUT))
 
-    checkout(sg_pg_mg_conn, 'output', log[1])
+    checkout(sg_pg_mg_conn, OUTPUT, log[1])
     with sg_pg_mg_conn.cursor() as cur:
         cur.execute("""SELECT * FROM output.my_fruits""")
         assert cur.fetchall() == []
 
-    checkout(sg_pg_mg_conn, 'output', log[0])
+    checkout(sg_pg_mg_conn, OUTPUT, log[0])
     with sg_pg_mg_conn.cursor() as cur:
         cur.execute("""SELECT * FROM output.my_fruits""")
         assert cur.fetchall() == [(1, 'pineapple')]
 
 
 def test_local_import_sgfile(sg_pg_mg_conn):
-    execute_commands(sg_pg_mg_conn, _load_sgfile('import_local.sgfile'), output='output')
-    head = get_current_head(sg_pg_mg_conn, 'output')
-    old_head = get_image_parent(sg_pg_mg_conn, 'output', head)
+    execute_commands(sg_pg_mg_conn, _load_sgfile('import_local.sgfile'), output=OUTPUT)
+    head = get_current_head(sg_pg_mg_conn, OUTPUT)
+    old_head = get_image(sg_pg_mg_conn, OUTPUT, head).parent_id
 
-    checkout(sg_pg_mg_conn, 'output', old_head)
-    assert not pg_table_exists(sg_pg_mg_conn, 'output', 'my_fruits')
-    assert not pg_table_exists(sg_pg_mg_conn, 'output', 'fruits')
+    checkout(sg_pg_mg_conn, OUTPUT, old_head)
+    assert not pg_table_exists(sg_pg_mg_conn, OUTPUT.to_schema(), 'my_fruits')
+    assert not pg_table_exists(sg_pg_mg_conn, OUTPUT.to_schema(), 'fruits')
 
-    checkout(sg_pg_mg_conn, 'output', head)
-    assert pg_table_exists(sg_pg_mg_conn, 'output', 'my_fruits')
-    assert not pg_table_exists(sg_pg_mg_conn, 'output', 'fruits')
+    checkout(sg_pg_mg_conn, OUTPUT, head)
+    assert pg_table_exists(sg_pg_mg_conn, OUTPUT.to_schema(), 'my_fruits')
+    assert not pg_table_exists(sg_pg_mg_conn, OUTPUT.to_schema(), 'fruits')
 
 
 def test_advanced_sgfile(sg_pg_mg_conn):
-    execute_commands(sg_pg_mg_conn, _load_sgfile('import_local_multiple_with_queries.sgfile'), output='output')
-    head = get_current_head(sg_pg_mg_conn, 'output')
+    execute_commands(sg_pg_mg_conn, _load_sgfile('import_local_multiple_with_queries.sgfile'), output=OUTPUT)
+    head = get_current_head(sg_pg_mg_conn, OUTPUT)
 
-    assert pg_table_exists(sg_pg_mg_conn, 'output', 'my_fruits')
-    assert pg_table_exists(sg_pg_mg_conn, 'output', 'vegetables')
-    assert not pg_table_exists(sg_pg_mg_conn, 'output', 'fruits')
-    assert pg_table_exists(sg_pg_mg_conn, 'output', 'join_table')
+    assert pg_table_exists(sg_pg_mg_conn, OUTPUT.to_schema(), 'my_fruits')
+    assert pg_table_exists(sg_pg_mg_conn, OUTPUT.to_schema(), 'vegetables')
+    assert not pg_table_exists(sg_pg_mg_conn, OUTPUT.to_schema(), 'fruits')
+    assert pg_table_exists(sg_pg_mg_conn, OUTPUT.to_schema(), 'join_table')
 
-    old_head = get_image_parent(sg_pg_mg_conn, 'output', head)
-    checkout(sg_pg_mg_conn, 'output', old_head)
-    assert not pg_table_exists(sg_pg_mg_conn, 'output', 'join_table')
-    checkout(sg_pg_mg_conn, 'output', head)
+    old_head = get_image(sg_pg_mg_conn, OUTPUT, head).parent_id
+    checkout(sg_pg_mg_conn, OUTPUT, old_head)
+    assert not pg_table_exists(sg_pg_mg_conn, OUTPUT.to_schema(), 'join_table')
+    checkout(sg_pg_mg_conn, OUTPUT, head)
     with sg_pg_mg_conn.cursor() as cur:
         cur.execute("""SELECT id, fruit, vegetable FROM output.join_table""")
         assert cur.fetchall() == [(2, 'orange', 'carrot')]
@@ -118,25 +118,21 @@ def test_advanced_sgfile(sg_pg_mg_conn):
 
 def test_sgfile_cached(sg_pg_mg_conn):
     # Check that no new commits/snaps are created if we rerun the same sgfile
-    execute_commands(sg_pg_mg_conn, _load_sgfile('import_local_multiple_with_queries.sgfile'), output='output')
-    with sg_pg_mg_conn.cursor() as cur:
-        cur.execute("""SELECT image_hash FROM %s.images WHERE mountpoint = 'output'""" % SPLITGRAPH_META_SCHEMA)
-        commits = [c[0] for c in cur.fetchall()]
-    assert len(commits) == 4
+    execute_commands(sg_pg_mg_conn, _load_sgfile('import_local_multiple_with_queries.sgfile'), output=OUTPUT)
+    images = get_all_images_parents(sg_pg_mg_conn, OUTPUT)
+    assert len(images) == 4
 
-    execute_commands(sg_pg_mg_conn, _load_sgfile('import_local_multiple_with_queries.sgfile'), output='output')
-    with sg_pg_mg_conn.cursor() as cur:
-        cur.execute("""SELECT image_hash FROM %s.images WHERE mountpoint = 'output'""" % SPLITGRAPH_META_SCHEMA)
-        new_commits = [c[0] for c in cur.fetchall()]
-    assert new_commits == commits
+    execute_commands(sg_pg_mg_conn, _load_sgfile('import_local_multiple_with_queries.sgfile'), output=OUTPUT)
+    new_images = get_all_images_parents(sg_pg_mg_conn, OUTPUT)
+    assert new_images == images
 
 
 def _add_multitag_dataset_to_remote_driver(remote_driver_conn):
-    set_tag(remote_driver_conn, 'test_pg_mount', get_current_head(remote_driver_conn, 'test_pg_mount'), 'v1')
+    set_tag(remote_driver_conn, PG_MNT, get_current_head(remote_driver_conn, PG_MNT), 'v1')
     with remote_driver_conn.cursor() as cur:
         cur.execute("DELETE FROM test_pg_mount.fruits WHERE fruit_id = 1")
-    new_head = commit(remote_driver_conn, 'test_pg_mount')
-    set_tag(remote_driver_conn, 'test_pg_mount', new_head, 'v2')
+    new_head = commit(remote_driver_conn, PG_MNT)
+    set_tag(remote_driver_conn, PG_MNT, new_head, 'v2')
     remote_driver_conn.commit()
     return new_head
 
@@ -146,44 +142,44 @@ def test_sgfile_remote(empty_pg_conn, remote_driver_conn):
 
     # We use the v1 tag when importing from the remote, so fruit_id = 1 still exists there.
     execute_commands(empty_pg_conn, _load_sgfile('import_remote_multiple.sgfile'), params={'TAG': 'v1'},
-                     output='output')
+                     output=OUTPUT)
     with empty_pg_conn.cursor() as cur:
         cur.execute("""SELECT id, fruit, vegetable FROM output.join_table""")
         assert cur.fetchall() == [(1, 'apple', 'potato'), (2, 'orange', 'carrot')]
 
     # Now run the commands against v2 and make sure the fruit_id = 1 has disappeared from the output.
     execute_commands(empty_pg_conn, _load_sgfile('import_remote_multiple.sgfile'), params={'TAG': 'v2'},
-                     output='output')
+                     output=OUTPUT)
     with empty_pg_conn.cursor() as cur:
         cur.execute("""SELECT id, fruit, vegetable FROM output.join_table""")
         assert cur.fetchall() == [(2, 'orange', 'carrot')]
 
 
 def test_sgfile_remote_hash(empty_pg_conn, remote_driver_conn):
-    head = get_current_head(remote_driver_conn, 'test_pg_mount')
+    head = get_current_head(remote_driver_conn, PG_MNT)
     execute_commands(empty_pg_conn, _load_sgfile('import_remote_multiple.sgfile'), params={'TAG': head[:10]},
-                     output='output')
+                     output=OUTPUT)
     with empty_pg_conn.cursor() as cur:
         cur.execute("""SELECT id, fruit, vegetable FROM output.join_table""")
         assert cur.fetchall() == [(1, 'apple', 'potato'), (2, 'orange', 'carrot')]
 
 
 def test_import_updating_sgfile_with_uploading(empty_pg_conn, remote_driver_conn):
-    execute_commands(empty_pg_conn, _load_sgfile('import_and_update.sgfile'), output='output')
-    head = get_current_head(empty_pg_conn, 'output')
+    execute_commands(empty_pg_conn, _load_sgfile('import_and_update.sgfile'), output=OUTPUT)
+    head = get_current_head(empty_pg_conn, OUTPUT)
 
     assert len(get_existing_objects(empty_pg_conn)) == 4  # Two original tables + two updates
 
     with tempfile.TemporaryDirectory() as tmpdir:
         # Push with upload. Have to specify the remote connection string since we are pushing a new repository.
-        push(empty_pg_conn, 'output', remote_conn_string=REMOTE_CONN_STRING, handler='FILE',
+        push(empty_pg_conn, OUTPUT, remote_conn_string=REMOTE_CONN_STRING, handler='FILE',
              handler_options={'path': tmpdir})
         # Unmount everything locally and cleanup
-        unmount(empty_pg_conn, 'output')
+        unmount(empty_pg_conn, OUTPUT)
         cleanup_objects(empty_pg_conn)
         assert not get_existing_objects(empty_pg_conn)
 
-        clone(empty_pg_conn, 'output', download_all=False)
+        clone(empty_pg_conn, OUTPUT, download_all=False)
 
         assert not get_downloaded_objects(empty_pg_conn)
         existing_objects = list(get_existing_objects(empty_pg_conn))
@@ -191,7 +187,7 @@ def test_import_updating_sgfile_with_uploading(empty_pg_conn, remote_driver_conn
         # Only 2 objects are stored externally (the other two have been on the remote the whole time)
         assert len(get_external_object_locations(empty_pg_conn, existing_objects)) == 2
 
-        checkout(empty_pg_conn, 'output', head)
+        checkout(empty_pg_conn, OUTPUT, head)
         with empty_pg_conn.cursor() as cur:
             cur.execute("""SELECT fruit_id, name FROM output.my_fruits""")
             assert cur.fetchall() == [(1, 'apple'), (2, 'orange'), (3, 'mayonnaise')]
@@ -211,11 +207,11 @@ def test_sgfile_end_to_end_with_uploading(empty_pg_conn, remote_driver_conn):
     # Do the same setting up first and run the sgfile against the remote data.
     new_head = _add_multitag_dataset_to_remote_driver(remote_driver_conn)
     execute_commands(empty_pg_conn, _load_sgfile('import_remote_multiple.sgfile'), params={'TAG': 'v1'},
-                     output='output')
+                     output=OUTPUT)
 
     with tempfile.TemporaryDirectory() as tmpdir:
         # Push with upload
-        push(empty_pg_conn, 'output', remote_conn_string=REMOTE_CONN_STRING, handler='FILE',
+        push(empty_pg_conn, OUTPUT, remote_conn_string=REMOTE_CONN_STRING, handler='FILE',
              handler_options={'path': tmpdir})
         # Unmount everything locally and cleanup
         for mountpoint, _ in get_current_repositories(empty_pg_conn):
@@ -223,7 +219,7 @@ def test_sgfile_end_to_end_with_uploading(empty_pg_conn, remote_driver_conn):
         cleanup_objects(empty_pg_conn)
 
         execute_commands(empty_pg_conn, _load_sgfile('import_from_preuploaded_remote.sgfile'),
-                         output='output_stage_2')
+                         output=R('output_stage_2'))
 
         with empty_pg_conn.cursor() as cur:
             cur.execute("""SELECT id, name, fruit, vegetable FROM output_stage_2.diet""")
@@ -231,22 +227,22 @@ def test_sgfile_end_to_end_with_uploading(empty_pg_conn, remote_driver_conn):
 
 
 def test_sgfile_schema_changes(sg_pg_mg_conn):
-    execute_commands(sg_pg_mg_conn, _load_sgfile('schema_changes.sgfile'), output='output')
-    old_output_head = get_current_head(sg_pg_mg_conn, 'output')
+    execute_commands(sg_pg_mg_conn, _load_sgfile('schema_changes.sgfile'), output=OUTPUT)
+    old_output_head = get_current_head(sg_pg_mg_conn, OUTPUT)
 
     # Then, alter the dataset and rerun the sgfile.
     with sg_pg_mg_conn.cursor() as cur:
         cur.execute("""INSERT INTO test_pg_mount.fruits VALUES (12, 'mayonnaise')""")
-    commit(sg_pg_mg_conn, 'test_pg_mount')
-    execute_commands(sg_pg_mg_conn, _load_sgfile('schema_changes.sgfile'), output='output')
-    new_output_head = get_current_head(sg_pg_mg_conn, 'output')
+    commit(sg_pg_mg_conn, PG_MNT)
+    execute_commands(sg_pg_mg_conn, _load_sgfile('schema_changes.sgfile'), output=OUTPUT)
+    new_output_head = get_current_head(sg_pg_mg_conn, OUTPUT)
 
-    checkout(sg_pg_mg_conn, 'output', old_output_head)
+    checkout(sg_pg_mg_conn, OUTPUT, old_output_head)
     with sg_pg_mg_conn.cursor() as cur:
         cur.execute("""SELECT * FROM output.spirit_fruits""")
         assert cur.fetchall() == [('James', 'orange', 12)]
 
-    checkout(sg_pg_mg_conn, 'output', new_output_head)
+    checkout(sg_pg_mg_conn, OUTPUT, new_output_head)
     with sg_pg_mg_conn.cursor() as cur:
         cur.execute("""SELECT * FROM output.spirit_fruits""")
         # Mayonnaise joined with Alex, ID 12 + 10 = 22.
@@ -259,11 +255,11 @@ def test_import_with_custom_query(sg_pg_mg_conn):
     with sg_pg_mg_conn.cursor() as cur:
         cur.execute("INSERT INTO test_pg_mount.fruits VALUES (3, 'mayonnaise')")
         cur.execute("INSERT INTO test_pg_mount.vegetables VALUES (3, 'oregano')")
-    commit(sg_pg_mg_conn, 'test_pg_mount')
+    commit(sg_pg_mg_conn, PG_MNT)
 
-    execute_commands(sg_pg_mg_conn, _load_sgfile('import_with_custom_query.sgfile'), output='output')
-    head = get_current_head(sg_pg_mg_conn, 'output')
-    old_head = get_image_parent(sg_pg_mg_conn, 'output', head)
+    execute_commands(sg_pg_mg_conn, _load_sgfile('import_with_custom_query.sgfile'), output=OUTPUT)
+    head = get_current_head(sg_pg_mg_conn, OUTPUT)
+    old_head = get_image(sg_pg_mg_conn, OUTPUT, head).parent_id
 
     # First two tables imported as snaps since they had a custom query, the other two are diffs (basically a commit
     # pointing to the same object as test_pg_mount has).
@@ -271,11 +267,11 @@ def test_import_with_custom_query(sg_pg_mg_conn):
     contents = [[(2, 'orange')], [(1, 'potato'), (3, 'oregano')],
                 [(1, 'potato'), (2, 'carrot'), (3, 'oregano')], [(1, 'apple'), (2, 'orange'), (3, 'mayonnaise')]]
 
-    checkout(sg_pg_mg_conn, 'output', old_head)
+    checkout(sg_pg_mg_conn, OUTPUT, old_head)
     for t in tables:
-        assert not pg_table_exists(sg_pg_mg_conn, 'output', t)
+        assert not pg_table_exists(sg_pg_mg_conn, OUTPUT.to_schema(), t)
 
-    checkout(sg_pg_mg_conn, 'output', head)
+    checkout(sg_pg_mg_conn, OUTPUT, head)
     with sg_pg_mg_conn.cursor() as cur:
         for t, c in zip(tables, contents):
             cur.execute("""SELECT * FROM output.%s""" % t)
@@ -284,26 +280,26 @@ def test_import_with_custom_query(sg_pg_mg_conn):
     for t in tables:
         # Tables with queries stored as snaps, actually imported tables share objects with test_pg_mount.
         if t in ['my_fruits', 'o_vegetables']:
-            assert get_object_for_table(sg_pg_mg_conn, 'output', t, head, 'SNAP', '') is not None
-            assert get_object_for_table(sg_pg_mg_conn, 'output', t, head, 'DIFF', '') is None
+            assert get_object_for_table(sg_pg_mg_conn, OUTPUT, t, head, 'SNAP') is not None
+            assert get_object_for_table(sg_pg_mg_conn, OUTPUT, t, head, 'DIFF') is None
         else:
-            assert get_object_for_table(sg_pg_mg_conn, 'output', t, head, 'SNAP', '') is None
-            assert get_object_for_table(sg_pg_mg_conn, 'output', t, head, 'DIFF', '') is not None
+            assert get_object_for_table(sg_pg_mg_conn, OUTPUT, t, head, 'SNAP') is None
+            assert get_object_for_table(sg_pg_mg_conn, OUTPUT, t, head, 'DIFF') is not None
 
 
 def test_import_mount(empty_pg_conn):
-    execute_commands(empty_pg_conn, _load_sgfile('import_from_mounted_db.sgfile'), output='output')
+    execute_commands(empty_pg_conn, _load_sgfile('import_from_mounted_db.sgfile'), output=OUTPUT)
 
-    head = get_current_head(empty_pg_conn, 'output')
-    old_head = get_image_parent(empty_pg_conn, 'output', head)
+    head = get_current_head(empty_pg_conn, OUTPUT)
+    old_head = get_image(empty_pg_conn, OUTPUT, head).parent_id
 
-    checkout(empty_pg_conn, 'output', old_head)
+    checkout(empty_pg_conn, OUTPUT, old_head)
     tables = ['my_fruits', 'o_vegetables', 'vegetables', 'all_fruits']
     contents = [[(2, 'orange')], [(1, 'potato')], [(1, 'potato'), (2, 'carrot')], [(1, 'apple'), (2, 'orange')]]
     for t in tables:
-        assert not pg_table_exists(empty_pg_conn, 'output', t)
+        assert not pg_table_exists(empty_pg_conn, OUTPUT.to_schema(), t)
 
-    checkout(empty_pg_conn, 'output', head)
+    checkout(empty_pg_conn, OUTPUT, head)
     with empty_pg_conn.cursor() as cur:
         for t, c in zip(tables, contents):
             cur.execute("""SELECT * FROM output.%s""" % t)
@@ -311,23 +307,23 @@ def test_import_mount(empty_pg_conn):
 
     # All imported tables stored as snapshots
     for t in tables:
-        assert get_object_for_table(empty_pg_conn, 'output', t, head, 'SNAP', '') is not None
-        assert get_object_for_table(empty_pg_conn, 'output', t, head, 'DIFF', '') is None
+        assert get_object_for_table(empty_pg_conn, OUTPUT, t, head, 'SNAP') is not None
+        assert get_object_for_table(empty_pg_conn, OUTPUT, t, head, 'DIFF') is None
 
 
 def test_import_all(empty_pg_conn):
-    execute_commands(empty_pg_conn, _load_sgfile('import_all_from_mounted.sgfile'), output='output')
+    execute_commands(empty_pg_conn, _load_sgfile('import_all_from_mounted.sgfile'), output=OUTPUT)
 
-    head = get_current_head(empty_pg_conn, 'output')
-    old_head = get_image_parent(empty_pg_conn, 'output', head)
+    head = get_current_head(empty_pg_conn, OUTPUT)
+    old_head = get_image(empty_pg_conn, OUTPUT, head).parent_id
 
-    checkout(empty_pg_conn, 'output', old_head)
+    checkout(empty_pg_conn, OUTPUT, old_head)
     tables = ['vegetables', 'fruits']
     contents = [[(1, 'potato'), (2, 'carrot')], [(1, 'apple'), (2, 'orange')]]
     for t in tables:
-        assert not pg_table_exists(empty_pg_conn, 'output', t)
+        assert not pg_table_exists(empty_pg_conn, OUTPUT.to_schema(), t)
 
-    checkout(empty_pg_conn, 'output', head)
+    checkout(empty_pg_conn, OUTPUT, head)
     with empty_pg_conn.cursor() as cur:
         for t, c in zip(tables, contents):
             cur.execute("""SELECT * FROM output.%s""" % t)
@@ -337,19 +333,19 @@ def test_import_all(empty_pg_conn):
 def test_from_remote(empty_pg_conn, remote_driver_conn):
     _add_multitag_dataset_to_remote_driver(remote_driver_conn)
     # Test running commands that base new datasets on a remote repository.
-    execute_commands(empty_pg_conn, _load_sgfile('from_remote.sgfile'), output='output',
+    execute_commands(empty_pg_conn, _load_sgfile('from_remote.sgfile'), output=OUTPUT,
                      params={'TAG': 'v1'})
 
-    new_head = get_current_head(empty_pg_conn, 'output')
+    new_head = get_current_head(empty_pg_conn, OUTPUT)
     # Go back to the parent: the two source tables should exist there
-    checkout(empty_pg_conn, 'output', get_image_parent(empty_pg_conn, 'output', new_head))
-    assert pg_table_exists(empty_pg_conn, 'output', 'fruits')
-    assert pg_table_exists(empty_pg_conn, 'output', 'vegetables')
-    assert not pg_table_exists(empty_pg_conn, 'output', 'join_table')
+    checkout(empty_pg_conn, OUTPUT, get_image(empty_pg_conn, OUTPUT, new_head).parent_id)
+    assert pg_table_exists(empty_pg_conn, OUTPUT.to_schema(), 'fruits')
+    assert pg_table_exists(empty_pg_conn, OUTPUT.to_schema(), 'vegetables')
+    assert not pg_table_exists(empty_pg_conn, OUTPUT.to_schema(), 'join_table')
 
-    checkout(empty_pg_conn, 'output', new_head)
-    assert pg_table_exists(empty_pg_conn, 'output', 'fruits')
-    assert pg_table_exists(empty_pg_conn, 'output', 'vegetables')
+    checkout(empty_pg_conn, OUTPUT, new_head)
+    assert pg_table_exists(empty_pg_conn, OUTPUT.to_schema(), 'fruits')
+    assert pg_table_exists(empty_pg_conn, OUTPUT.to_schema(), 'vegetables')
     with empty_pg_conn.cursor() as cur:
         cur.execute("SELECT * FROM output.join_table")
         assert cur.fetchall() == [(1, 'apple', 'potato'), (2, 'orange', 'carrot')]
@@ -357,8 +353,8 @@ def test_from_remote(empty_pg_conn, remote_driver_conn):
     # Now run the same sgfile but from the v2 of the remote (where row 1 has been removed from the fruits table)
     # First, remove the output mountpoint (the executor tries to fetch the commit 0000 from it otherwise which
     # doesn't exist).
-    unmount(empty_pg_conn, 'output')
-    execute_commands(empty_pg_conn, _load_sgfile('from_remote.sgfile'), output='output', params={'TAG': 'v2'})
+    unmount(empty_pg_conn, OUTPUT)
+    execute_commands(empty_pg_conn, _load_sgfile('from_remote.sgfile'), output=OUTPUT, params={'TAG': 'v2'})
 
     with empty_pg_conn.cursor() as cur:
         cur.execute("SELECT * FROM output.join_table")
@@ -366,12 +362,12 @@ def test_from_remote(empty_pg_conn, remote_driver_conn):
 
 
 def test_from_remote_hash(empty_pg_conn, remote_driver_conn):
-    head = get_current_head(remote_driver_conn, 'test_pg_mount')
+    head = get_current_head(remote_driver_conn, PG_MNT)
     # Test running commands that base new datasets on a remote repository.
-    execute_commands(empty_pg_conn, _load_sgfile('from_remote.sgfile'), output='output', params={'TAG': head[:10]})
+    execute_commands(empty_pg_conn, _load_sgfile('from_remote.sgfile'), output=OUTPUT, params={'TAG': head[:10]})
 
-    assert pg_table_exists(empty_pg_conn, 'output', 'fruits')
-    assert pg_table_exists(empty_pg_conn, 'output', 'vegetables')
+    assert pg_table_exists(empty_pg_conn, OUTPUT.to_schema(), 'fruits')
+    assert pg_table_exists(empty_pg_conn, OUTPUT.to_schema(), 'vegetables')
     with empty_pg_conn.cursor() as cur:
         cur.execute("SELECT * FROM output.join_table")
         assert cur.fetchall() == [(1, 'apple', 'potato'), (2, 'orange', 'carrot')]
@@ -379,36 +375,37 @@ def test_from_remote_hash(empty_pg_conn, remote_driver_conn):
 
 def test_from_multistage(empty_pg_conn, remote_driver_conn):
     _add_multitag_dataset_to_remote_driver(remote_driver_conn)
+    OUTPUT_STAGE_2 = R('output_stage_2')
 
-    # Produces two mountpoints: output and output_stage_2
+    # Produces two repositories: output and output_stage_2
     execute_commands(empty_pg_conn, _load_sgfile('from_remote_multistage.sgfile'), params={'TAG': 'v1'})
 
-    # Check the final output ('output_stage_2': it should only have one single table object (a SNAP with the join_table
-    # from the first stage, 'output'.
+    # Check the final output ('output_stage_2'): it should only have one single table object (a SNAP with the join_table
+    # from the first stage, OUTPUT.
     with empty_pg_conn.cursor() as cur:
         cur.execute("SELECT * FROM output_stage_2.balanced_diet")
         assert cur.fetchall() == [(1, 'apple', 'potato'), (2, 'orange', 'carrot')]
-    head = get_current_head(empty_pg_conn, 'output_stage_2')
+    head = get_current_head(empty_pg_conn, OUTPUT_STAGE_2)
     # Check the commit is based on the original empty image.
-    assert get_image_parent(empty_pg_conn, 'output_stage_2', head) == '0' * 64
-    assert get_tables_at(empty_pg_conn, 'output_stage_2', head) == ['balanced_diet']
-    assert get_object_for_table(empty_pg_conn, 'output_stage_2', 'balanced_diet', head, 'SNAP', '') is not None
-    assert get_object_for_table(empty_pg_conn, 'output_stage_2', 'balanced_diet', head, 'DIFF', '') is None
+    assert get_image(empty_pg_conn, OUTPUT_STAGE_2, head).parent_id == '0' * 64
+    assert get_tables_at(empty_pg_conn, OUTPUT_STAGE_2, head) == ['balanced_diet']
+    assert get_object_for_table(empty_pg_conn, OUTPUT_STAGE_2, 'balanced_diet', head, 'SNAP') is not None
+    assert get_object_for_table(empty_pg_conn, OUTPUT_STAGE_2, 'balanced_diet', head, 'DIFF') is None
 
 
 def test_from_local(sg_pg_mg_conn):
-    execute_commands(sg_pg_mg_conn, _load_sgfile('from_local.sgfile'), output='output')
+    execute_commands(sg_pg_mg_conn, _load_sgfile('from_local.sgfile'), output=OUTPUT)
 
-    new_head = get_current_head(sg_pg_mg_conn, 'output')
+    new_head = get_current_head(sg_pg_mg_conn, OUTPUT)
     # Go back to the parent: the two source tables should exist there
-    checkout(sg_pg_mg_conn, 'output', get_image_parent(sg_pg_mg_conn, 'output', new_head))
-    assert pg_table_exists(sg_pg_mg_conn, 'output', 'fruits')
-    assert pg_table_exists(sg_pg_mg_conn, 'output', 'vegetables')
-    assert not pg_table_exists(sg_pg_mg_conn, 'output', 'join_table')
+    checkout(sg_pg_mg_conn, OUTPUT, get_image(sg_pg_mg_conn, OUTPUT, new_head).parent_id)
+    assert pg_table_exists(sg_pg_mg_conn, OUTPUT.to_schema(), 'fruits')
+    assert pg_table_exists(sg_pg_mg_conn, OUTPUT.to_schema(), 'vegetables')
+    assert not pg_table_exists(sg_pg_mg_conn, OUTPUT.to_schema(), 'join_table')
 
-    checkout(sg_pg_mg_conn, 'output', new_head)
-    assert pg_table_exists(sg_pg_mg_conn, 'output', 'fruits')
-    assert pg_table_exists(sg_pg_mg_conn, 'output', 'vegetables')
+    checkout(sg_pg_mg_conn, OUTPUT, new_head)
+    assert pg_table_exists(sg_pg_mg_conn, OUTPUT.to_schema(), 'fruits')
+    assert pg_table_exists(sg_pg_mg_conn, OUTPUT.to_schema(), 'vegetables')
     with sg_pg_mg_conn.cursor() as cur:
         cur.execute("SELECT * FROM output.join_table")
         assert cur.fetchall() == [(1, 'apple', 'potato'), (2, 'orange', 'carrot')]
@@ -417,7 +414,7 @@ def test_from_local(sg_pg_mg_conn):
 def test_sgfile_with_external_sql(sg_pg_mg_conn, remote_driver_conn):
     # Tests are running from root so we pass in the path to the SQL manually to the sgfile.
     execute_commands(sg_pg_mg_conn, _load_sgfile('external_sql.sgfile'),
-                     params={'EXTERNAL_SQL_FILE': SGFILE_ROOT + 'external_sql.sql'}, output='output')
+                     params={'EXTERNAL_SQL_FILE': SGFILE_ROOT + 'external_sql.sql'}, output=OUTPUT)
     with sg_pg_mg_conn.cursor() as cur:
         cur.execute("""SELECT id, fruit, vegetable FROM output.join_table""")
         assert cur.fetchall() == [(1, 'apple', 'potato'), (2, 'orange', 'carrot')]

--- a/test/splitgraph/test_sgfile.py
+++ b/test/splitgraph/test_sgfile.py
@@ -7,9 +7,9 @@ from splitgraph.commands import checkout, commit, push, unmount, clone, get_log
 from splitgraph.commands.misc import cleanup_objects
 from splitgraph.constants import SPLITGRAPH_META_SCHEMA, SplitGraphException
 from splitgraph.meta_handler.images import get_image_parent
-from splitgraph.meta_handler.misc import get_current_mountpoints_hashes
+from splitgraph.meta_handler.misc import get_current_repositories
 from splitgraph.meta_handler.objects import get_existing_objects, get_downloaded_objects, get_external_object_locations
-from splitgraph.meta_handler.tables import get_tables_at, get_table_with_format
+from splitgraph.meta_handler.tables import get_tables_at, get_object_for_table
 from splitgraph.meta_handler.tags import get_current_head, set_tag
 from splitgraph.pg_utils import pg_table_exists
 from splitgraph.sgfile.execution import execute_commands
@@ -218,7 +218,7 @@ def test_sgfile_end_to_end_with_uploading(empty_pg_conn, remote_driver_conn):
         push(empty_pg_conn, 'output', remote_conn_string=REMOTE_CONN_STRING, handler='FILE',
              handler_options={'path': tmpdir})
         # Unmount everything locally and cleanup
-        for mountpoint, _ in get_current_mountpoints_hashes(empty_pg_conn):
+        for mountpoint, _ in get_current_repositories(empty_pg_conn):
             unmount(empty_pg_conn, mountpoint)
         cleanup_objects(empty_pg_conn)
 
@@ -284,11 +284,11 @@ def test_import_with_custom_query(sg_pg_mg_conn):
     for t in tables:
         # Tables with queries stored as snaps, actually imported tables share objects with test_pg_mount.
         if t in ['my_fruits', 'o_vegetables']:
-            assert get_table_with_format(sg_pg_mg_conn, 'output', t, head, 'SNAP') is not None
-            assert get_table_with_format(sg_pg_mg_conn, 'output', t, head, 'DIFF') is None
+            assert get_object_for_table(sg_pg_mg_conn, 'output', t, head, 'SNAP', '') is not None
+            assert get_object_for_table(sg_pg_mg_conn, 'output', t, head, 'DIFF', '') is None
         else:
-            assert get_table_with_format(sg_pg_mg_conn, 'output', t, head, 'SNAP') is None
-            assert get_table_with_format(sg_pg_mg_conn, 'output', t, head, 'DIFF') is not None
+            assert get_object_for_table(sg_pg_mg_conn, 'output', t, head, 'SNAP', '') is None
+            assert get_object_for_table(sg_pg_mg_conn, 'output', t, head, 'DIFF', '') is not None
 
 
 def test_import_mount(empty_pg_conn):
@@ -311,8 +311,8 @@ def test_import_mount(empty_pg_conn):
 
     # All imported tables stored as snapshots
     for t in tables:
-        assert get_table_with_format(empty_pg_conn, 'output', t, head, 'SNAP') is not None
-        assert get_table_with_format(empty_pg_conn, 'output', t, head, 'DIFF') is None
+        assert get_object_for_table(empty_pg_conn, 'output', t, head, 'SNAP', '') is not None
+        assert get_object_for_table(empty_pg_conn, 'output', t, head, 'DIFF', '') is None
 
 
 def test_import_all(empty_pg_conn):
@@ -392,8 +392,8 @@ def test_from_multistage(empty_pg_conn, remote_driver_conn):
     # Check the commit is based on the original empty image.
     assert get_image_parent(empty_pg_conn, 'output_stage_2', head) == '0' * 64
     assert get_tables_at(empty_pg_conn, 'output_stage_2', head) == ['balanced_diet']
-    assert get_table_with_format(empty_pg_conn, 'output_stage_2', 'balanced_diet', head, 'SNAP') is not None
-    assert get_table_with_format(empty_pg_conn, 'output_stage_2', 'balanced_diet', head, 'DIFF') is None
+    assert get_object_for_table(empty_pg_conn, 'output_stage_2', 'balanced_diet', head, 'SNAP', '') is not None
+    assert get_object_for_table(empty_pg_conn, 'output_stage_2', 'balanced_diet', head, 'DIFF', '') is None
 
 
 def test_from_local(sg_pg_mg_conn):

--- a/test/splitgraph/test_sgfile.py
+++ b/test/splitgraph/test_sgfile.py
@@ -130,7 +130,7 @@ def test_sgfile_cached(sg_pg_mg_conn):
 def _add_multitag_dataset_to_remote_driver(remote_driver_conn):
     set_tag(remote_driver_conn, PG_MNT, get_current_head(remote_driver_conn, PG_MNT), 'v1')
     with remote_driver_conn.cursor() as cur:
-        cur.execute("DELETE FROM test_pg_mount.fruits WHERE fruit_id = 1")
+        cur.execute("DELETE FROM \"test/pg_mount\".fruits WHERE fruit_id = 1")
     new_head = commit(remote_driver_conn, PG_MNT)
     set_tag(remote_driver_conn, PG_MNT, new_head, 'v2')
     remote_driver_conn.commit()
@@ -232,7 +232,7 @@ def test_sgfile_schema_changes(sg_pg_mg_conn):
 
     # Then, alter the dataset and rerun the sgfile.
     with sg_pg_mg_conn.cursor() as cur:
-        cur.execute("""INSERT INTO test_pg_mount.fruits VALUES (12, 'mayonnaise')""")
+        cur.execute("""INSERT INTO "test/pg_mount".fruits VALUES (12, 'mayonnaise')""")
     commit(sg_pg_mg_conn, PG_MNT)
     execute_commands(sg_pg_mg_conn, _load_sgfile('schema_changes.sgfile'), output=OUTPUT)
     new_output_head = get_current_head(sg_pg_mg_conn, OUTPUT)
@@ -253,8 +253,8 @@ def test_import_with_custom_query(sg_pg_mg_conn):
     # Mostly a lazy way for the test to distinguish between the importer storing the results of a query as a snap
     # and pointing the commit history to the diff for unchanged objects.
     with sg_pg_mg_conn.cursor() as cur:
-        cur.execute("INSERT INTO test_pg_mount.fruits VALUES (3, 'mayonnaise')")
-        cur.execute("INSERT INTO test_pg_mount.vegetables VALUES (3, 'oregano')")
+        cur.execute("INSERT INTO \"test/pg_mount\".fruits VALUES (3, 'mayonnaise')")
+        cur.execute("INSERT INTO \"test/pg_mount\".vegetables VALUES (3, 'oregano')")
     commit(sg_pg_mg_conn, PG_MNT)
 
     execute_commands(sg_pg_mg_conn, _load_sgfile('import_with_custom_query.sgfile'), output=OUTPUT)
@@ -262,7 +262,7 @@ def test_import_with_custom_query(sg_pg_mg_conn):
     old_head = get_image(sg_pg_mg_conn, OUTPUT, head).parent_id
 
     # First two tables imported as snaps since they had a custom query, the other two are diffs (basically a commit
-    # pointing to the same object as test_pg_mount has).
+    # pointing to the same object as test/pg_mount has).
     tables = ['my_fruits', 'o_vegetables', 'vegetables', 'all_fruits']
     contents = [[(2, 'orange')], [(1, 'potato'), (3, 'oregano')],
                 [(1, 'potato'), (2, 'carrot'), (3, 'oregano')], [(1, 'apple'), (2, 'orange'), (3, 'mayonnaise')]]
@@ -278,7 +278,7 @@ def test_import_with_custom_query(sg_pg_mg_conn):
             assert cur.fetchall() == c
 
     for t in tables:
-        # Tables with queries stored as snaps, actually imported tables share objects with test_pg_mount.
+        # Tables with queries stored as snaps, actually imported tables share objects with test/pg_mount.
         if t in ['my_fruits', 'o_vegetables']:
             assert get_object_for_table(sg_pg_mg_conn, OUTPUT, t, head, 'SNAP') is not None
             assert get_object_for_table(sg_pg_mg_conn, OUTPUT, t, head, 'DIFF') is None

--- a/test/splitgraph/test_sgfile.py
+++ b/test/splitgraph/test_sgfile.py
@@ -120,13 +120,13 @@ def test_sgfile_cached(sg_pg_mg_conn):
     # Check that no new commits/snaps are created if we rerun the same sgfile
     execute_commands(sg_pg_mg_conn, _load_sgfile('import_local_multiple_with_queries.sgfile'), output='output')
     with sg_pg_mg_conn.cursor() as cur:
-        cur.execute("""SELECT snap_id FROM %s.snap_tree WHERE mountpoint = 'output'""" % SPLITGRAPH_META_SCHEMA)
+        cur.execute("""SELECT image_hash FROM %s.images WHERE mountpoint = 'output'""" % SPLITGRAPH_META_SCHEMA)
         commits = [c[0] for c in cur.fetchall()]
     assert len(commits) == 4
 
     execute_commands(sg_pg_mg_conn, _load_sgfile('import_local_multiple_with_queries.sgfile'), output='output')
     with sg_pg_mg_conn.cursor() as cur:
-        cur.execute("""SELECT snap_id FROM %s.snap_tree WHERE mountpoint = 'output'""" % SPLITGRAPH_META_SCHEMA)
+        cur.execute("""SELECT image_hash FROM %s.images WHERE mountpoint = 'output'""" % SPLITGRAPH_META_SCHEMA)
         new_commits = [c[0] for c in cur.fetchall()]
     assert new_commits == commits
 


### PR DESCRIPTION
* "Mountpoint" is legacy terminology from the old prototype days where we'd actually mount a database via FDW into a schema and use version control on that. Instead of mountpoint, use either repository (an object with a namespace + repo name, e.g. noaa/climate) or schema throughout the code. PG utility functions (like getting all tables in a schema / getting the columns/PKs for a table) operate on the schema whereas SG functions (e.g. getting all tables in a repository) operate on the repo.
* Other renames: snap_id -> image_hash, snap_tree -> images (again legacy, SNAP is now a type of an object).
* Schema changes: add namespace to most tables in preparation for the addition of row-level security to the registry. 
* Misc refactoring: return a single Image object from one image-querying function (was several functions returning subsets of the columns in the `images` table)

Still some weirdness with naming temporary mountpoints (e.g. things we materialize remote tables into before querying/importing them) but this all works end-to-end with the commandline experience unchanged (things like noaa/climate in the commandline are now parsed into namespace=noaa, repository=climate).