### PR TITLE
Feature/registry rls phase 2

### DIFF
--- a/docs/commands.rst
+++ b/docs/commands.rst
@@ -99,7 +99,7 @@ See also :mod:`splitgraph.commands.mounting`.
 
 `sgr unmount`
     Destroys the local copy of a repository and all the metadata related to it in
-    `images`, `tables`, `remotes` and `snap_tags`. This command doesn't delete the actual physical objects in
+    `images`, `tables`, `remotes` and `tags`. This command doesn't delete the actual physical objects in
     `splitgraph_meta` or references to them in
     `objects` / `object_locations`. There's a separate function, `sgr cleanup`
     (or :func:`splitgraph.commands.misc.cleanup_objects`) that crawls the `splitgraph_meta` for objects not required

--- a/docs/internals.rst
+++ b/docs/internals.rst
@@ -26,7 +26,7 @@ Here's an overview of the tables in this schema:
     the object linked to the parent commit of a given object: if we're importing a table from a different repository,
     we would pull in its chain of DIFF objects without tying them to commits those objects were created in.
   * `remotes`: Currently, stores the connection string for the upstream repository a given repository was cloned from.
-  * `snap_tags`: maps images and their repositories to one or more tags. Tags (apart from HEAD) are pushed and pulled
+  * `tags`: maps images and their repositories to one or more tags. Tags (apart from HEAD) are pushed and pulled
     to/from upstream repositories and are immutable (this is weakly enforced by the push/pull code).
     HEAD is a special tag: it points out to the currently checked-out local image.
   * `object_locations`: If a given object is not stored in the remote, this table specifies where to find it (protocol
@@ -58,7 +58,7 @@ Implementation of various Splitgraph commands
     * All changes are conflated using a straightforward algorithm in `splitgraph.objects.utils.conflate_changes`.
   * The meta tables this touches are `objects` (to register the new objects and link them to their parents),
     `tables` (to link tables in the new commit to existing/new objects), `images` (to register the new commit) and
-    `snap_tags` (to move the HEAD pointer to the new commit).
+    `tags` (to move the HEAD pointer to the new commit).
 
 `checkout`
 ----------
@@ -75,7 +75,7 @@ Implementation of various Splitgraph commands
         * Currently, only `FILE` is supported: the object is dumped into a user-specified directory as an uncompressed
           SQL file.
       * Download the object from the upstream (by inspecting the `remotes` table).
-  * `snap_tags` is changed to update the HEAD pointer.
+  * `tags` is changed to update the HEAD pointer.
 
 `clone/push/pull`
 -----------------
@@ -83,7 +83,7 @@ Implementation of various Splitgraph commands
 `sgr clone` is implemented as follows:
 
   * First, it connect to the remote and inspect its `splitgraph_meta` table to gather the commits, tags and objects
-    (`images`, `snap_tags`, `objects`, `tables` and `object_locations`) that don't exist in the local
+    (`images`, `tags`, `objects`, `tables` and `object_locations`) that don't exist in the local
     `splitgraph_meta`. See `splitgraph.commands.push_pull._get_required_snaps_objects`.
   * As part of that, also crawl the remote `objects` to gather the list of all required objects
     and their dependencies.

--- a/splitgraph/commandline.py
+++ b/splitgraph/commandline.py
@@ -1,11 +1,11 @@
-import json
-import re
 import sys
 from collections import Counter, defaultdict
-from pprint import pprint
 
 import click
+import json
 import psycopg2
+import re
+from pprint import pprint
 from psycopg2 import ProgrammingError
 from splitgraph.commands import mount, unmount, commit, checkout, diff, get_log, init, get_parent_children, pull, \
     clone, push, import_tables
@@ -18,8 +18,8 @@ from splitgraph.drawing import render_tree
 from splitgraph.meta_handler.images import get_canonical_image_id, get_image
 from splitgraph.meta_handler.misc import get_current_repositories, get_remote_for
 from splitgraph.meta_handler.tables import get_tables_at, get_table
-from splitgraph.pg_utils import get_all_tables
 from splitgraph.meta_handler.tags import get_current_head, get_all_hashes_tags, set_tag, tag_or_hash_to_actual_hash
+from splitgraph.pg_utils import get_all_tables
 from splitgraph.sgfile.execution import execute_commands, rerun_image_with_replacement
 
 
@@ -440,7 +440,7 @@ def publish_c(repository, tag, readme, skip_provenance, skip_previews):
         readme = readme.read()
     else:
         readme = ""
-    publish(conn, repository, tag, readme, include_provenance=not skip_provenance,
+    publish(conn, repository, tag, readme=readme, include_provenance=not skip_provenance,
             include_table_previews=not skip_previews)
     conn.commit()
     conn.close()

--- a/splitgraph/commands/importing.py
+++ b/splitgraph/commands/importing.py
@@ -116,7 +116,7 @@ def _import_tables(conn, repository, image_hash, tables, target_repository, targ
 
 def _register_and_checkout_new_table(conn, do_checkout, object_id, target_hash, target_repository, target_table):
     # Might not be necessary if we don't actually want to materialize the snapshot (wastes space).
-    register_object(conn, object_id, 'SNAP', parent_object=None, original_namespace=target_repository.namespace)
+    register_object(conn, object_id, 'SNAP', parent_object=None, namespace=target_repository.namespace)
     register_table(conn, target_repository, target_table, target_hash, object_id)
     if do_checkout:
         copy_table(conn, SPLITGRAPH_META_SCHEMA, object_id, target_repository.to_schema(), target_table)

--- a/splitgraph/meta_handler/common.py
+++ b/splitgraph/meta_handler/common.py
@@ -200,16 +200,17 @@ def setup_registry_mode(conn):
         # whose location we're changing.
         cur.execute(SQL("ALTER TABLE {}.{} ENABLE ROW LEVEL SECURITY").format(Identifier(SPLITGRAPH_META_SCHEMA),
                                                                               Identifier('object_locations')))
-        test_query = SQL("""(SELECT true FROM {0}.object_locations
+        test_query = SQL("""((SELECT true as bool FROM {0}.object_locations
                             JOIN {0}.objects ON {0}.object_locations.object_id = {0}.objects.object_id
-                            WHERE {0}.objects.namespace = current_user)""".format(Identifier(SPLITGRAPH_META_SCHEMA)))
+                            WHERE {0}.objects.namespace = current_user) = true)""").format(
+            Identifier(SPLITGRAPH_META_SCHEMA))
 
         cur.execute(SQL("""CREATE POLICY object_locations_S ON {}.object_locations FOR SELECT USING (true)""")
                     .format(Identifier(SPLITGRAPH_META_SCHEMA)))
         cur.execute(SQL("""CREATE POLICY object_locations_I ON {}.object_locations FOR INSERT
                            WITH CHECK """).format(Identifier(SPLITGRAPH_META_SCHEMA)) + test_query)
         cur.execute(SQL("CREATE POLICY object_locations_U ON {}.object_locations FOR UPDATE USING ")
-                    .format(Identifier(SPLITGRAPH_META_SCHEMA)) + test_query + SQL(" CHECK ") + test_query)
+                    .format(Identifier(SPLITGRAPH_META_SCHEMA)) + test_query + SQL(" WITH CHECK ") + test_query)
         cur.execute(SQL("""CREATE POLICY object_locations_D ON {}.object_locations FOR DELETE
                            USING """).format(Identifier(SPLITGRAPH_META_SCHEMA)) + test_query)
 

--- a/splitgraph/meta_handler/objects.py
+++ b/splitgraph/meta_handler/objects.py
@@ -18,12 +18,12 @@ def get_object_format(conn, object_id):
         return None if result is None else result[0]
 
 
-def register_object(conn, object_id, object_format, original_namespace, parent_object=None):
+def register_object(conn, object_id, object_format, namespace, parent_object=None):
     if not parent_object and object_format != 'SNAP':
         raise ValueError("Non-SNAP objects can't have no parent!")
     with conn.cursor() as cur:
-        cur.execute(insert("objects", ("object_id", "format", "parent_id", "original_namespace")),
-                    (object_id, object_format, parent_object, original_namespace))
+        cur.execute(insert("objects", ("object_id", "format", "parent_id", "namespace")),
+                    (object_id, object_format, parent_object, namespace))
 
 
 def deregister_table_object(conn, object_id):
@@ -34,7 +34,7 @@ def deregister_table_object(conn, object_id):
 
 def register_objects(conn, object_meta):
     with conn.cursor() as cur:
-        execute_batch(cur, insert("objects", ("object_id", "format", "parent_id", "original_namespace")),
+        execute_batch(cur, insert("objects", ("object_id", "format", "parent_id", "namespace")),
                       object_meta, page_size=100)
 
 
@@ -86,7 +86,7 @@ def get_external_object_locations(conn, objects):
 
 def get_object_meta(conn, objects):
     with conn.cursor() as cur:
-        cur.execute(select("objects", "object_id, format, parent_id, original_namespace",
+        cur.execute(select("objects", "object_id, format, parent_id, namespace",
                            "object_id IN (" + ','.join('%s' for _ in objects) + ")"), objects)
         return cur.fetchall()
 

--- a/splitgraph/meta_handler/tables.py
+++ b/splitgraph/meta_handler/tables.py
@@ -16,7 +16,7 @@ def get_object_for_table(conn, repository, table_name, image, object_format):
     with conn.cursor() as cur:
         cur.execute(SQL("""SELECT {0}.tables.object_id FROM {0}.tables JOIN {0}.objects
                             ON {0}.objects.object_id = {0}.tables.object_id
-                            WHERE namespace = %s AND repository = %s AND image_hash = %s
+                            WHERE {0}.tables.namespace = %s AND repository = %s AND image_hash = %s
                             AND table_name = %s AND format = %s""").format(
             Identifier(SPLITGRAPH_META_SCHEMA)), (repository.namespace, repository.repository,
                                                   image, table_name, object_format))
@@ -29,6 +29,7 @@ def get_table(conn, repository, table_name, image):
     with conn.cursor() as cur:
         cur.execute(SQL("""SELECT {0}.tables.object_id, format FROM {0}.tables JOIN {0}.objects
                             ON {0}.objects.object_id = {0}.tables.object_id
-                            WHERE namespace = %s AND repository = %s AND image_hash = %s AND table_name = %s""").format(
+                            WHERE {0}.tables.namespace = %s AND repository = %s AND image_hash = %s
+                            AND table_name = %s""").format(
             Identifier(SPLITGRAPH_META_SCHEMA)), (repository.namespace, repository.repository, image, table_name))
         return cur.fetchall()

--- a/splitgraph/meta_handler/tags.py
+++ b/splitgraph/meta_handler/tags.py
@@ -26,7 +26,7 @@ def get_tagged_id(conn, repository, tag, raise_on_none=True):
             return result[0]
 
     with conn.cursor() as cur:
-        cur.execute(select("snap_tags", "image_hash", "namespace = %s AND repository = %s AND tag = %s"),
+        cur.execute(select("tags", "image_hash", "namespace = %s AND repository = %s AND tag = %s"),
                     (repository.namespace, repository.repository, tag))
         result = cur.fetchone()
         if result is None or result == (None,):
@@ -44,7 +44,7 @@ def get_tagged_id(conn, repository, tag, raise_on_none=True):
 
 def get_all_hashes_tags(conn, repository):
     with conn.cursor() as cur:
-        cur.execute(select("snap_tags", "image_hash, tag", "namespace = %s AND repository = %s"),
+        cur.execute(select("tags", "image_hash, tag", "namespace = %s AND repository = %s"),
                     (repository.namespace, repository.repository,))
         return cur.fetchall()
 
@@ -61,14 +61,14 @@ def set_head(conn, repository, image):
 
 def set_tag(conn, repository, image, tag, force=False):
     with conn.cursor() as cur:
-        cur.execute(select("snap_tags", "1", "namespace = %s AND repository = %s AND tag = %s"),
+        cur.execute(select("tags", "1", "namespace = %s AND repository = %s AND tag = %s"),
                     (repository.namespace, repository.repository, tag))
         if cur.fetchone() is None:
-            cur.execute(insert("snap_tags", ("image_hash", "namespace", "repository", "tag")),
+            cur.execute(insert("tags", ("image_hash", "namespace", "repository", "tag")),
                         (image, repository.namespace, repository.repository, tag))
         else:
             if force:
-                cur.execute(SQL("UPDATE {}.snap_tags SET image_hash = %s "
+                cur.execute(SQL("UPDATE {}.tags SET image_hash = %s "
                                 "WHERE namespace = %s AND repository = %s AND tag = %s").format(
                     Identifier(SPLITGRAPH_META_SCHEMA)),
                     (image, repository.namespace, repository.repository, tag))

--- a/splitgraph/objects/creation.py
+++ b/splitgraph/objects/creation.py
@@ -58,7 +58,7 @@ def record_table_as_diff(conn, repository, image_hash, table, table_info):
 
             for parent_id, _ in table_info:
                 register_object(conn, object_id, object_format='DIFF', parent_object=parent_id,
-                                original_namespace=repository.namespace)
+                                namespace=repository.namespace)
 
             register_table(conn, repository, table, image_hash, object_id)
         else:
@@ -90,8 +90,8 @@ def record_table_as_snap(conn, repository, image_hash, table, table_info):
         if table_info:
             for parent_id, _ in table_info:
                 register_object(conn, object_id, object_format='SNAP', parent_object=parent_id,
-                                original_namespace=repository.namespace)
+                                namespace=repository.namespace)
         else:
             register_object(conn, object_id, object_format='SNAP', parent_object=None,
-                            original_namespace=repository.namespace)
+                            namespace=repository.namespace)
         register_table(conn, repository, table, image_hash, object_id)

--- a/test/architecture/data/remote_driver/setup.sql
+++ b/test/architecture/data/remote_driver/setup.sql
@@ -1,0 +1,2 @@
+-- Add an unprivileged role that we can use to test RLS on the remote.
+CREATE ROLE testuser LOGIN PASSWORD 'testpassword';

--- a/test/architecture/docker-compose.yml
+++ b/test/architecture/docker-compose.yml
@@ -43,6 +43,8 @@ services:
       - POSTGRES_PASSWORD=supersecure
       - POSTGRES_DB=cachedb
       - PGPORT=5431
+    volumes:
+      - ./data/remote_driver/setup.sql:/docker-entrypoint-initdb.d/setup.sql
     expose:
       - 5431
   ci_pgorigin:

--- a/test/splitgraph/conftest.py
+++ b/test/splitgraph/conftest.py
@@ -4,7 +4,7 @@ from splitgraph.commandline import _conn
 from splitgraph.commands import *
 from splitgraph.commands import unmount
 from splitgraph.commands.misc import make_conn, cleanup_objects
-from splitgraph.constants import PG_USER, PG_PWD, PG_DB, serialize_connection_string, to_repository as R
+from splitgraph.constants import PG_USER, PG_PWD, PG_DB, serialize_connection_string, to_repository as R, Repository
 from splitgraph.meta_handler.common import setup_registry_mode, ensure_metadata_schema, toggle_registry_rls
 from splitgraph.meta_handler.misc import get_current_repositories
 from splitgraph.pg_utils import get_all_foreign_tables
@@ -108,6 +108,7 @@ def remote_driver_conn():
     toggle_registry_rls(conn, 'DISABLE')
     unpublish_repository(conn, OUTPUT)
     unpublish_repository(conn, PG_MNT)
+    unpublish_repository(conn, Repository('testuser', 'pg_mount'))
     for mountpoint in TEST_MOUNTPOINTS:
         unmount(conn, mountpoint)
     cleanup_objects(conn)
@@ -115,6 +116,7 @@ def remote_driver_conn():
     _mount_postgres(conn, PG_MNT)
     _mount_mongo(conn, MG_MNT)
     yield conn
+    conn.rollback()
     for mountpoint in TEST_MOUNTPOINTS:
         unmount(conn, mountpoint)
     cleanup_objects(conn)
@@ -131,6 +133,7 @@ def empty_pg_conn():
     cleanup_objects(conn)
     conn.commit()
     yield conn
+    conn.rollback()
     for mountpoint, _ in get_current_repositories(conn):
         unmount(conn, mountpoint)
     cleanup_objects(conn)

--- a/test/splitgraph/test_rls.py
+++ b/test/splitgraph/test_rls.py
@@ -1,0 +1,100 @@
+import tempfile
+
+import pytest
+from psycopg2._psycopg import ProgrammingError
+
+from splitgraph.commands import clone, push, commit, checkout, unmount
+from splitgraph.config.repo_lookups import get_remote_connection_params
+from splitgraph.constants import Repository, serialize_connection_string
+from splitgraph.meta_handler.common import toggle_registry_rls
+from splitgraph.meta_handler.images import get_all_images_parents
+from splitgraph.meta_handler.misc import unregister_repository
+from test.splitgraph.conftest import PG_MNT
+from test.splitgraph.test_sgfile import _add_multitag_dataset_to_remote_driver
+
+
+def _init_rls_test(remote_driver_conn):
+    _add_multitag_dataset_to_remote_driver(remote_driver_conn)
+    toggle_registry_rls(remote_driver_conn, 'ENABLE')
+    remote_driver_conn.commit()
+
+
+@pytest.fixture()
+def unprivileged_conn_string(unprivileged_remote_conn):
+    server, port, username, password, dbname = get_remote_connection_params('remote_driver')
+    return serialize_connection_string(server, port, 'testuser', 'testpassword', dbname)
+
+
+@pytest.fixture()
+def unprivileged_remote_conn(remote_driver_conn):
+    _init_rls_test(remote_driver_conn)
+    try:
+        with remote_driver_conn.cursor() as cur:
+            cur.execute("SET ROLE TO testuser;")
+        yield remote_driver_conn
+    finally:
+        # Reset the role back to admin so that the teardown doesn't break
+        with remote_driver_conn.cursor() as cur:
+            cur.execute("SET ROLE TO clientuser;")
+
+
+def test_rls_pull_public(empty_pg_conn, unprivileged_conn_string):
+    clone(empty_pg_conn, PG_MNT, remote_conn_string=unprivileged_conn_string)
+
+
+def test_rls_push_own_delete_own(empty_pg_conn, unprivileged_conn_string, unprivileged_remote_conn):
+    clone(empty_pg_conn, PG_MNT, remote_conn_string=unprivileged_conn_string)
+    checkout(empty_pg_conn, PG_MNT, tag='latest')
+
+    with empty_pg_conn.cursor() as cur:
+        cur.execute("""UPDATE "test/pg_mount".fruits SET name = 'banana' WHERE fruit_id = 1""")
+    commit(empty_pg_conn, PG_MNT)
+
+    target_repo = Repository(namespace='testuser', repository='pg_mount')
+
+    # Test we can push to our namespace
+    push(empty_pg_conn, PG_MNT, remote_conn_string=unprivileged_conn_string,
+         remote_repository=target_repo)
+
+    # Test we can delete our own repo once we've pushed it
+    unregister_repository(unprivileged_remote_conn, target_repo, is_remote=True)
+    assert len(get_all_images_parents(unprivileged_remote_conn, target_repo)) == 0
+
+
+def test_rls_push_others(empty_pg_conn, unprivileged_conn_string):
+    clone(empty_pg_conn, PG_MNT, remote_conn_string=unprivileged_conn_string)
+    checkout(empty_pg_conn, PG_MNT, tag='latest')
+
+    with empty_pg_conn.cursor() as cur:
+        cur.execute("""UPDATE "test/pg_mount".fruits SET name = 'banana' WHERE fruit_id = 1""")
+    commit(empty_pg_conn, PG_MNT)
+
+    with pytest.raises(ProgrammingError) as e:
+        push(empty_pg_conn, PG_MNT, remote_conn_string=unprivileged_conn_string, remote_repository=PG_MNT)
+    assert 'new row violates row-level security policy for table "images"' in str(e.value)
+
+
+def test_rls_delete_others(unprivileged_remote_conn):
+    # RLS doesn't actually raise an error for this, since it just appends the policy qualifier to the query.
+    # Hence in this case this simply does nothing (the rows in "test" namespace aren't available for deletion).
+    unregister_repository(unprivileged_remote_conn, PG_MNT, is_remote=True)
+
+    # Check that the policy worked by verifying that the repository still exists on the remote.
+    assert len(get_all_images_parents(unprivileged_remote_conn, PG_MNT)) > 0
+
+
+def test_rls_push_own_with_uploading(empty_pg_conn, unprivileged_conn_string):
+    clone(empty_pg_conn, PG_MNT, remote_conn_string=unprivileged_conn_string)
+    checkout(empty_pg_conn, PG_MNT, tag='latest')
+
+    with empty_pg_conn.cursor() as cur:
+        cur.execute("""UPDATE "test/pg_mount".fruits SET name = 'banana' WHERE fruit_id = 1""")
+    commit(empty_pg_conn, PG_MNT)
+
+    target_repo = Repository(namespace='testuser', repository='pg_mount')
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        push(empty_pg_conn, PG_MNT, remote_conn_string=unprivileged_conn_string, handler='FILE',
+             remote_repository=target_repo,
+             handler_options={'path': tmpdir})
+

--- a/test/splitgraph/test_rls.py
+++ b/test/splitgraph/test_rls.py
@@ -1,17 +1,17 @@
-import tempfile
-
 import pytest
+import tempfile
 from psycopg2._psycopg import ProgrammingError
-
-from splitgraph.commands import clone, push, commit, checkout, unmount
+from splitgraph.commands import clone, push, commit, checkout
+from splitgraph.commands.publish import publish
 from splitgraph.config.repo_lookups import get_remote_connection_params
 from splitgraph.constants import Repository, serialize_connection_string
 from splitgraph.meta_handler.common import toggle_registry_rls
 from splitgraph.meta_handler.images import get_all_images_parents
 from splitgraph.meta_handler.misc import unregister_repository
 from splitgraph.meta_handler.objects import register_object_locations
-from splitgraph.meta_handler.tables import get_object_for_table, get_table
-from splitgraph.meta_handler.tags import get_tagged_id
+from splitgraph.meta_handler.tables import get_table
+from splitgraph.meta_handler.tags import get_tagged_id, set_tag
+from splitgraph.registry_meta_handler import get_published_info, unpublish_repository
 from test.splitgraph.conftest import PG_MNT
 from test.splitgraph.test_sgfile import _add_multitag_dataset_to_remote_driver
 
@@ -113,3 +113,47 @@ def test_rls_impersonate_external_object(unprivileged_remote_conn):
     with pytest.raises(ProgrammingError) as e:
         register_object_locations(unprivileged_remote_conn, [(sample_object, 'fake_location', 'FILE')])
     assert 'new row violates row-level security policy for table "object_locations"' in str(e.value)
+
+
+def test_rls_publish_unpublish_own(empty_pg_conn, unprivileged_conn_string, unprivileged_remote_conn):
+    clone(empty_pg_conn, PG_MNT, remote_conn_string=unprivileged_conn_string)
+    set_tag(empty_pg_conn, PG_MNT, get_tagged_id(empty_pg_conn, PG_MNT, 'latest'), 'my_tag')
+    target_repo = Repository(namespace='testuser', repository='pg_mount')
+    push(empty_pg_conn, PG_MNT, remote_conn_string=unprivileged_conn_string,
+         remote_repository=target_repo)
+
+    publish(empty_pg_conn, PG_MNT, 'my_tag', remote_repository=target_repo,
+            remote_conn_string=unprivileged_conn_string, readme="my_readme",
+            include_provenance=True, include_table_previews=True)
+    assert get_published_info(unprivileged_remote_conn, target_repo, 'my_tag') is not None
+
+    unpublish_repository(unprivileged_remote_conn, target_repo)
+    assert get_published_info(unprivileged_remote_conn, target_repo, 'my_tag') is None
+
+
+def test_rls_publish_unpublish_others(empty_pg_conn, remote_driver_conn, unprivileged_conn_string):
+    # Tag the remote repo as an admin user and try to publish as an unprivileged one
+    with remote_driver_conn.cursor() as cur:
+        # Make sure we're running this with the elevated privileges
+        cur.execute("SET ROLE TO clientuser;")
+    set_tag(remote_driver_conn, PG_MNT, get_tagged_id(remote_driver_conn, PG_MNT, 'latest'), 'my_tag')
+    remote_driver_conn.commit()
+    clone(empty_pg_conn, PG_MNT, remote_conn_string=unprivileged_conn_string)
+
+    # Publish into the "test" namespace as someone who doesn't have access to it.
+    with pytest.raises(ProgrammingError) as e:
+        publish(empty_pg_conn, PG_MNT, 'my_tag', readme="my_readme", remote_conn_string=unprivileged_conn_string)
+        remote_driver_conn.rollback()
+    assert 'new row violates row-level security policy for table "images"' in str(e.value)
+
+    # Publish as the admin user
+    publish(empty_pg_conn, PG_MNT, 'my_tag', readme="my_readme",
+            remote_conn_string=serialize_connection_string(*get_remote_connection_params('remote_driver')))
+
+    # Try to delete as the remote user -- should fail (no error raised since the RLS just doesn't make
+    # those rows available for deletion)
+    with remote_driver_conn.cursor() as cur:
+        cur.execute("SET ROLE TO testuser;")
+
+    unpublish_repository(remote_driver_conn, PG_MNT)
+    assert get_published_info(remote_driver_conn, PG_MNT, 'my_tag') is not None


### PR DESCRIPTION
Added a setup function for a driver (common.py/setup_registry_mode) that makes sure the driver can work as a remote: grant RO access for unprivileged users, grant W access to tables where the namespace is the same as the username.