### PR TITLE
Changed the object dumper to call into pg_dump instead

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,10 @@ addons:
     # using the same connection string, hence we map remote_driver on the host to localhost
     # (Docker networking takes care of wiring it up in the case of the container)
     - remote_driver
+  apt:
+    packages:
+      # external object tests use pg_dump/restore that is supposed to be able to talk to pg10
+      - postgresql-client-10
 
 env:
   COMPOSE_VERSION: 1.21.2

--- a/splitgraph/commands/misc.py
+++ b/splitgraph/commands/misc.py
@@ -141,7 +141,7 @@ def cleanup_objects(conn, include_external=False):
         # the object downloader interface.
         if include_external:
             cur.execute(SQL("SELECT object_id FROM {}.object_locations").format(Identifier(SPLITGRAPH_META_SCHEMA)))
-            to_delete += set(c[0] for c in cur.fetchall())
+            to_delete = to_delete.union(set(c[0] for c in cur.fetchall()))
 
     delete_objects(conn, to_delete)
     return to_delete

--- a/splitgraph/objects/dumping.py
+++ b/splitgraph/objects/dumping.py
@@ -1,21 +1,38 @@
-import gzip
-
-from splitgraph.constants import SPLITGRAPH_META_SCHEMA
-from splitgraph.pg_utils import table_dump_generator
-
-
-def dump_object_to_file(conn, object_id, path):
-    with gzip.open(path, 'wb') as f:
-        f.writelines(table_dump_generator(conn, SPLITGRAPH_META_SCHEMA, object_id))
+from splitgraph.constants import SPLITGRAPH_META_SCHEMA, PG_HOST, PG_DB, PG_USER, PG_PORT, PG_PWD
+import logging
+import subprocess
 
 
-def load_object_from_file(conn, path):
-    with gzip.open(path, 'rb') as f:
-        with conn.cursor() as cur:
-            # Insert into the locally checked out schema by default since the dump doesn't have the schema
-            # qualification.
-            cur.execute("SET search_path TO %s", (SPLITGRAPH_META_SCHEMA,))
-            for chunk in f.readlines():
-                cur.execute(chunk)
-            # Set the schema to (presumably) the default one.
-            cur.execute("SET search_path TO public")
+# Utilities to dump objects (SNAP/DIFF) into an external format.
+# This used to be a SQL dump (inspect the schema and write a series of statements that recreate the table)
+# but we now just shell out to pg_dump -- this does require pg_dump locally to be compatible with the
+# driver (pg10).
+
+def dump_object_to_file(object_id, path):
+    # Shell out into pg_dump and use its custom binary dump format to dump the object table.
+    subprocess.check_output(['pg_dump', '-h', PG_HOST, '-d', PG_DB, '-U', PG_USER, '-p', PG_PORT,
+                             '-w',  # Prompt for a password without an extra roundtrip
+                             '-t', SPLITGRAPH_META_SCHEMA + '.' + object_id,  # Only dump the single table
+                             '-Fc',  # Use the PG compressed binary format
+                             '-f', path],
+                            input='{}\n'.format(PG_PWD).encode('utf-8'))  # Pipe the password to the process
+
+
+def load_object_from_file(path):
+    logging.info("Loading objects from %s", path)
+    # Shell out into pg_restore to restore the object table from the archive.
+    # We are basically running some SQL code we downloaded off the internet, so some quick precautions here:
+    # we create only tables that don't exist and only in the splitgraph_meta schema.
+    # We could also run this with -l to list the contents of the archive and raise if something looks dodgy.
+    subprocess.check_output(['pg_restore', path, '-h', PG_HOST, '-d', PG_DB, '-U', PG_USER, '-p', PG_PORT,
+                             '-w',  # prompt for a password without an extra roundtrip
+                             '-e',  # exit on error
+                             '-O',  # don't set ownership information
+                             '-x',  # don't set grants
+                             '-n', SPLITGRAPH_META_SCHEMA,  # pg_restore still doesn't support restoring into
+                             # a different schema
+                             # We could pass -t here to only specify a single table but then it wouldn't restore
+                             # its indices/constraints etc.
+                             '--no-data-for-failed-tables',  # don't append into tables that exist
+                             '-Fc'],
+                            input='{}\n'.format(PG_PWD).encode('utf-8'))  # Pipe the password to the process.

--- a/splitgraph/objects/s3.py
+++ b/splitgraph/objects/s3.py
@@ -32,11 +32,11 @@ def _s3_upload_objects(conn, objects_to_push, params):
     with tempfile.TemporaryDirectory() as tmpdir:
         for object_id in objects_to_push:
             # First cut: dump the object to file and then upload it using Minio
-            tmp_path = tmpdir + '/' + object_id + '.gz'
-            dump_object_to_file(conn, object_id, tmp_path)
-            client.fput_object(bucket, object_id + '.gz', tmp_path)
+            tmp_path = tmpdir + '/' + object_id
+            dump_object_to_file(object_id, tmp_path)
+            client.fput_object(bucket, object_id, tmp_path)
 
-            urls.append('%s/%s/%s' % (endpoint, bucket, object_id + '.gz'))
+            urls.append('%s/%s/%s' % (endpoint, bucket, object_id))
     return urls
 
 
@@ -58,4 +58,4 @@ def _s3_download_objects(conn, objects_to_fetch, params):
 
             local_path = tmpdir + '/' + remote_object
             client.fget_object(bucket, remote_object, local_path)
-            load_object_from_file(conn, local_path)
+            load_object_from_file(local_path)

--- a/splitgraph/pg_utils.py
+++ b/splitgraph/pg_utils.py
@@ -118,24 +118,6 @@ def get_full_table_schema(conn, schema, table_name):
     return [(o, n, dt, (n in pks)) for o, n, dt in results]
 
 
-def table_dump_generator(conn, schema, table):
-    """Returns an iterator that generates a SQL table dump, non-schema qualified."""
-    # Don't include a schema qualifier since the dump might be imported into a different place.
-    yield (dump_table_creation(conn, schema, [table], created_schema=None) + SQL(';\n')).as_string(conn).encode('utf-8')
-
-    # Use a server-side cursor here so we don't fetch the whole db into memory immediately.
-    with conn.cursor(name='sg_table_upload_cursor') as cur:
-        cur.itersize = 10000
-        cur.execute(SQL("SELECT * FROM {}.{}""").format(Identifier(schema), Identifier(table)))
-        row = next(cur)
-        q = '(' + ','.join('%s' for _ in row) + ')'
-        yield cur.mogrify(SQL("INSERT INTO {} VALUES " + q).format(Identifier(table)), row)
-        for row in cur:
-            yield cur.mogrify(',' + q, row)
-        yield ';\n'.encode('utf-8')
-    return
-
-
 def execute_sql_in(conn, schema, sql):
     """
     Executes a non-schema-qualified query against a specific schema, using PG's search_path.


### PR DESCRIPTION
## TL; DR
  * pg_dump/restore's custom binary format has comparable sizes to what we currently do (hand-generating the SQL and gzipping it)
  * bad point 1: pg_dump/restore has to be available on the host and be compatible with the driver version (pg10)
  * bad point 2: currently there's no way to restore into a different schema (defaults to the creator's SPLITGRAPH_META), not sure if we care since we're only restoring object tables.
  * bad point 3: the dump might leak some things about the creator, like the username
  * good point 1: it is considerably faster (2-3x) for uploading/downloading large (1M rows) tables, same speed for a 100k row table
  * good point 2: we currently just run the downloaded SQL against the db -- pg_restore has some security capabilities (filtering tables and not allowing to create new tables etc, see the commandline invocation.
  * good point 3: seems like there's also scope for dumping/restoring things like indexes, constraints etc

## full benchmarks
### Setup: 1 table, 100k rows, 10 commits (1000 UPDATEs each)

#### current (ad hoc SQL dump with gzipping):

Sizes: Diffs: 43KiB each, SNAP: 3.9MiB

    [2018-11-14 11:29:35 GMT] 3.9MiB o3c511cc767cd97b1b7911b63842bc741a47b8445cd4e7fa4511586cd9be785.gz
    [2018-11-14 11:29:29 GMT]  43KiB o59021f7dd55dd3d7ff883c72161a986e83f265fca03660b4f7fc34b3edc06a.gz
    [...]

Time to upload: ~7s
Time to download: ~5s

#### pg_dump/restore with pg's custom binary format:

Sizes:  DIFFs: 45KiB, SNAP 3.9MiB

    [2018-11-14 11:10:48 GMT]  45KiB o5892def4e08074af3ba33998862486152bd91ede444705afc1e62158468b7d
    [2018-11-14 11:10:46 GMT] 3.9MiB o60b0c6286ec267bcf1efb62ef673d012db06c91f8be52cd13ebbc3893667b7
    [...]

Time to upload: ~8s
Time to download: ~4s (Minio -> temporary -> restore to cache) -- without checkouts

Time to checkout: ~8s (both)

### Same but with 1M rows in the SNAP

#### current (ad hoc SQL dump with gzipping):

Sizes:
    [2018-11-14 11:38:12 GMT]  39MiB o8c03b5cc183ae082fdb40212e9526772a16da7c988c72879fc03bc64fc80c5.gz
(DIFFS have the same size)

Time to upload: ~1min
Time to download: ~2min30s (with minio download taking v little time -- bulk is loading into the DB)

#### pg_dump/restore:

Sizes:
    [2018-11-14 11:47:28 GMT]  39MiB of1545714dd70847a66255389698688ad6b05aab9746d8d89070ee8070eb4dd
(DIFFS have the same size)

Time to upload: ~30s
Time to download: ~15s
Checkout (both versions, for reference): ~30s
