### PR TITLE
Speedup for object tree crawling: fetch the whole tree and calculate

### DIFF
--- a/splitgraph/meta_handler/objects.py
+++ b/splitgraph/meta_handler/objects.py
@@ -5,6 +5,12 @@ from splitgraph.constants import SPLITGRAPH_META_SCHEMA
 from splitgraph.meta_handler.common import select, insert
 
 
+def get_full_object_tree(conn):
+    with conn.cursor() as cur:
+        cur.execute(select("objects", "object_id,parent_id,format"))
+        return cur.fetchall()
+
+
 def get_object_parents(conn, object_id):
     with conn.cursor() as cur:
         cur.execute(select("objects", "parent_id", "object_id = %s"), (object_id,))


### PR DESCRIPTION
the full path (DIFF->DIFF->...->SNAP) instead of firing off a query
back to the driver for every object.

Issue discovered by running an importer with about 500 small (<10 lines each) commits, with the committing slowing down further on: 
![image](https://user-images.githubusercontent.com/828006/48849165-b0672c00-ed9d-11e8-92c5-5a8e6a178a04.png)

This was because, as the object tree grew, the amount of calls to the driver to crawl it back up to the SNAP (to find out the current schema of the image) increased.

cProfile traces:

**BEFORE**

```
Wed Nov 21 13:56:11 2018    import_fRED.cprofile
         31680999 function calls (31635328 primitive calls) in 754.075 seconds
   Ordered by: cumulative time
   List reduced from 803 to 20 due to restriction <20>
   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        1    0.000    0.000  755.400  755.400 {built-in method builtins.exec}
        1    0.000    0.000  755.400  755.400 <string>:1(<module>)
        1    0.001    0.001  755.400  755.400 <ipython-input-2-dec9981bfe8f>:39(wrapped)
        1    0.223    0.223  755.371  755.371 <ipython-input-27-449f5a45e4c6>:3(dump_history_to_sg)
      570    0.084    0.000  743.728    1.305 /home/mildbyte/splitgraph-opensource/splitgraph/commands/commit.py:17(commit)
      570    0.067    0.000  688.903    1.209 /home/mildbyte/splitgraph-opensource/splitgraph/commands/commit.py:53(commit_pending_changes)
   344875  635.669    0.002  660.550    0.002 {method 'execute' of 'psycopg2.extensions.cursor' objects}
      569    0.035    0.000  637.864    1.121 /home/mildbyte/splitgraph-opensource/splitgraph/meta_handler/misc.py:74(table_schema_changed)
      569    2.977    0.005  623.327    1.095 /home/mildbyte/splitgraph-opensource/splitgraph/meta_handler/images.py:46(get_closest_parent_image_object)
   161596    4.841    0.000  309.057    0.002 /home/mildbyte/splitgraph-opensource/splitgraph/meta_handler/objects.py:8(get_object_parents)
   161596    4.148    0.000  307.619    0.002 /home/mildbyte/splitgraph-opensource/splitgraph/meta_handler/objects.py:14(get_object_format)
      569    0.131    0.000   38.870    0.068 /home/mildbyte/splitgraph-opensource/splitgraph/objects/creation.py:35(record_table_as_diff)
   325474    6.863    0.000   38.281    0.000 /home/mildbyte/splitgraph-opensource/splitgraph/meta_handler/common.py:95(select)
      569    0.041    0.000   32.140    0.056 /home/mildbyte/splitgraph-opensource/splitgraph/objects/creation.py:13(_create_diff_table)
     1142    0.078    0.000   31.804    0.028 /home/mildbyte/splitgraph-opensource/splitgraph/pg_audit.py:12(manage_audit_triggers)
     1142    0.078    0.000   21.976    0.019 /home/mildbyte/splitgraph-opensource/splitgraph/pg_audit.py:20(<listcomp>)
     2855   19.573    0.007   19.573    0.007 {method 'commit' of 'psycopg2.extensions.connection' objects}
     2853    0.082    0.000   18.606    0.007 /home/mildbyte/splitgraph-opensource/splitgraph/pg_utils.py:136(get_all_tables)
   341441    8.241    0.000   18.357    0.000 /home/mildbyte/miniconda3/envs/splitgraph-prototype/lib/python3.6/site-packages/psycopg2/sql.py:194(format)
     1138    0.047    0.000   14.496    0.013 /home/mildbyte/splitgraph-opensource/splitgraph/pg_utils.py:106(get_full_table_schema)
```

**AFTER:**

```
Wed Nov 21 14:48:23 2018    import_fred_new_version.cprofile
         4424059 function calls (4375429 primitive calls) in 115.433 seconds
   Ordered by: cumulative time
   List reduced from 1154 to 20 due to restriction <20>
   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
     35/1    0.004    0.000  115.518  115.518 {built-in method builtins.exec}
        1    0.000    0.000  115.518  115.518 <string>:1(<module>)
        1    0.002    0.002  115.518  115.518 <ipython-input-2-b4c5d9040083>:42(wrapped)
        1    0.256    0.256  115.333  115.333 <ipython-input-2-b4c5d9040083>:63(dump_history_to_sg)
      570    0.097    0.000  103.188    0.181 /home/mildbyte/splitgraph-opensource/splitgraph/commands/commit.py:17(commit)
    19967   74.928    0.004   76.657    0.004 {method 'execute' of 'psycopg2.extensions.cursor' objects}
      570    0.065    0.000   58.783    0.103 /home/mildbyte/splitgraph-opensource/splitgraph/commands/commit.py:53(commit_pending_changes)
      569    0.128    0.000   24.517    0.043 /home/mildbyte/splitgraph-opensource/splitgraph/objects/creation.py:35(record_table_as_diff)
     2855   22.613    0.008   22.613    0.008 {method 'commit' of 'psycopg2.extensions.connection' objects}
      569    0.109    0.000   20.706    0.036 /home/mildbyte/splitgraph-opensource/splitgraph/meta_handler/misc.py:74(table_schema_changed)
     1142    0.094    0.000   19.505    0.017 /home/mildbyte/splitgraph-opensource/splitgraph/pg_audit.py:12(manage_audit_triggers)
      569    0.049    0.000   17.274    0.030 /home/mildbyte/splitgraph-opensource/splitgraph/objects/creation.py:13(_create_diff_table)
     1138    0.047    0.000   14.208    0.012 /home/mildbyte/splitgraph-opensource/splitgraph/pg_utils.py:106(get_full_table_schema)
     1142    0.041    0.000    8.909    0.008 /home/mildbyte/splitgraph-opensource/splitgraph/pg_audit.py:20(<listcomp>)
     1711    0.059    0.000    8.301    0.005 /home/mildbyte/splitgraph-opensource/splitgraph/pg_utils.py:136(get_all_tables)
      571    0.027    0.000    7.814    0.014 /home/mildbyte/splitgraph-opensource/splitgraph/pg_audit.py:49(discard_pending_changes)
     2284    0.084    0.000    6.659    0.003 /home/mildbyte/splitgraph-opensource/splitgraph/meta_handler/common.py:127(ensure_metadata_schema)
      569    1.010    0.002    6.382    0.011 /home/mildbyte/splitgraph-opensource/splitgraph/meta_handler/images.py:47(get_closest_parent_image_object)
     1142    0.058    0.000    5.621    0.005 /home/mildbyte/splitgraph-opensource/splitgraph/meta_handler/misc.py:47(get_current_repositories)
     1140    0.028    0.000    5.096    0.004 /home/mildbyte/miniconda3/envs/splitgraph-prototype/lib/python3.6/site-packages/psycopg2/extras.py:1181(execute_batch)
```