### PR TITLE
Changed pg_dump/restore shelling out to using postgres' COPY TO/FROM 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,10 +17,6 @@ addons:
     # using the same connection string, hence we map remote_driver on the host to localhost
     # (Docker networking takes care of wiring it up in the case of the container)
     - remote_driver
-  apt:
-    packages:
-      # external object tests use pg_dump/restore that is supposed to be able to talk to pg10
-      - postgresql-client-10
 
 env:
   COMPOSE_VERSION: 1.21.2

--- a/splitgraph/commandline.py
+++ b/splitgraph/commandline.py
@@ -1,11 +1,11 @@
+import json
+import re
 import sys
 from collections import Counter, defaultdict
+from pprint import pprint
 
 import click
-import json
 import psycopg2
-import re
-from pprint import pprint
 from psycopg2 import ProgrammingError
 from splitgraph.commands import mount, unmount, commit, checkout, diff, get_log, init, get_parent_children, pull, \
     clone, push, import_tables
@@ -281,7 +281,8 @@ def pull_c(repository, remote, download_all):
 @click.command(name='clone')
 @click.argument('remote_repository', type=to_repository)
 @click.argument('local_repository', required=False, type=to_repository)
-@click.option('-d', '--download-all', help='Download all objects immediately instead on checkout.')
+@click.option('-d', '--download-all', help='Download all objects immediately instead on checkout.',
+              default=False, is_flag=True)
 def clone_c(remote_repository, local_repository, download_all):
     conn = _conn()
     clone(conn, remote_repository, local_repository=local_repository, download_all=download_all)

--- a/splitgraph/commands/misc.py
+++ b/splitgraph/commands/misc.py
@@ -156,5 +156,5 @@ def delete_objects(conn, objects):
     """
     if objects:
         with conn.cursor() as cur:
-            cur.execute(SQL(";").join(SQL("DROP TABLE {}.{}").format(Identifier(SPLITGRAPH_META_SCHEMA),
-                                                                     Identifier(d)) for d in objects))
+            cur.execute(SQL(";").join(SQL("DROP TABLE IF EXISTS {}.{}").format(Identifier(SPLITGRAPH_META_SCHEMA),
+                                                                               Identifier(d)) for d in objects))

--- a/splitgraph/objects/dumping.py
+++ b/splitgraph/objects/dumping.py
@@ -1,3 +1,4 @@
+import gzip
 import json
 import logging
 
@@ -13,7 +14,7 @@ from splitgraph.pg_utils import get_full_table_schema, create_table
 # out of/into postgres as fast as possible.
 
 def dump_object_to_file(conn, object_id, path):
-    with open(path, 'wb') as f:
+    with gzip.open(path, 'wb') as f:
         schema = json.dumps(get_full_table_schema(conn, SPLITGRAPH_META_SCHEMA, object_id))
         f.write(schema.encode('utf-8') + b'\0')
         with conn.cursor() as cur:
@@ -23,7 +24,7 @@ def dump_object_to_file(conn, object_id, path):
 
 def load_object_from_file(conn, object_id, path):
     logging.info("Loading %s from %s", object_id, path)
-    with open(path, 'rb') as f:
+    with gzip.open(path, 'rb') as f:
         chars = b''
         # Read until the delimiter separating a JSON schema from the Postgres copy_to dump.
         # Surely this is buffered?

--- a/splitgraph/objects/dumping.py
+++ b/splitgraph/objects/dumping.py
@@ -1,42 +1,41 @@
-import shlex
-from os import environ
-
-from splitgraph.constants import SPLITGRAPH_META_SCHEMA, PG_HOST, PG_DB, PG_USER, PG_PORT, PG_PWD
+import json
 import logging
-import subprocess
+
+from psycopg2.sql import SQL, Identifier
+from splitgraph.constants import SPLITGRAPH_META_SCHEMA
+from splitgraph.pg_utils import get_full_table_schema, create_table
 
 
 # Utilities to dump objects (SNAP/DIFF) into an external format.
-# This used to be a SQL dump (inspect the schema and write a series of statements that recreate the table)
-# but we now just shell out to pg_dump -- this does require pg_dump locally to be compatible with the
-# driver (pg10).
+# We use a slightly ad hoc format: the schema (JSON) + a null byte + Postgres's copy_to
+# binary format (only contains data). There's probably some scope to make this more optimized, maybe
+# we should look into columnar on-disk formats (Parquet/Avro) but we currently just want to get the objects
+# out of/into postgres as fast as possible.
 
-def dump_object_to_file(object_id, path):
-    # Shell out into pg_dump and use its custom binary dump format to dump the object table.
-    subprocess.check_output(['pg_dump', '-h', PG_HOST, '-d', PG_DB, '-U', PG_USER, '-p', PG_PORT,
-                             '-t', SPLITGRAPH_META_SCHEMA + '.' + object_id,  # Only dump the single table
-                             '-Fc',  # Use the PG compressed binary format
-                             '-f', path], env={**environ, 'PGPASSWORD': PG_PWD})
-    # Note we pass the password to pg_dump with an envvar, which might be considered insecure on systems where one
-    # can inspect other processes' envvars
-    # Though the alternatives are piping it in (which I couldn't get to work since it uses the tty for password inputs
-    # and any information on how to bypass that leads to one of "well you shouldn't do it" and "use pexpect". Or
-    # we could use a .pgpass file but we store pg creds in .sgconfig anyway.
+def dump_object_to_file(conn, object_id, path):
+    with open(path, 'wb') as f:
+        schema = json.dumps(get_full_table_schema(conn, SPLITGRAPH_META_SCHEMA, object_id))
+        f.write(schema.encode('utf-8') + b'\0')
+        with conn.cursor() as cur:
+            cur.copy_expert(SQL("COPY {}.{} TO STDOUT WITH (FORMAT 'binary')")
+                            .format(Identifier(SPLITGRAPH_META_SCHEMA), Identifier(object_id)), f)
 
 
-def load_object_from_file(path):
-    logging.info("Loading objects from %s", path)
-    # Shell out into pg_restore to restore the object table from the archive.
-    # We are basically running some SQL code we downloaded off the internet, so some quick precautions here:
-    # we create only tables that don't exist and only in the splitgraph_meta schema.
-    # We could also run this with -l to list the contents of the archive and raise if something looks dodgy.
-    subprocess.check_output(['pg_restore', path, '-h', PG_HOST, '-d', PG_DB, '-U', PG_USER, '-p', PG_PORT,
-                             '-e',  # exit on error
-                             '-O',  # don't set ownership information
-                             '-x',  # don't set grants
-                             '-n', SPLITGRAPH_META_SCHEMA,  # pg_restore still doesn't support restoring into
-                             # a different schema
-                             # We could pass -t here to only specify a single table but then it wouldn't restore
-                             # its indices/constraints etc.
-                             '--no-data-for-failed-tables',  # don't append into tables that exist
-                             '-Fc'], env={**environ, 'PGPASSWORD': PG_PWD})
+def load_object_from_file(conn, object_id, path):
+    logging.info("Loading %s from %s", object_id, path)
+    with open(path, 'rb') as f:
+        chars = b''
+        # Read until the delimiter separating a JSON schema from the Postgres copy_to dump.
+        # Surely this is buffered?
+        while True:
+            c = f.read(1)
+            if c == b'\0':
+                break
+            chars += c
+
+        schema = json.loads(chars.decode('utf-8'))
+        create_table(conn, SPLITGRAPH_META_SCHEMA, object_id, schema)
+
+        with conn.cursor() as cur:
+            cur.copy_expert(SQL("COPY {}.{} FROM STDIN WITH (FORMAT 'binary')")
+                            .format(Identifier(SPLITGRAPH_META_SCHEMA), Identifier(object_id)), f)

--- a/splitgraph/objects/dumping.py
+++ b/splitgraph/objects/dumping.py
@@ -1,8 +1,7 @@
-import gzip
 import json
-import logging
 
 from psycopg2.sql import SQL, Identifier
+
 from splitgraph.constants import SPLITGRAPH_META_SCHEMA
 from splitgraph.pg_utils import get_full_table_schema, create_table
 
@@ -13,30 +12,27 @@ from splitgraph.pg_utils import get_full_table_schema, create_table
 # we should look into columnar on-disk formats (Parquet/Avro) but we currently just want to get the objects
 # out of/into postgres as fast as possible.
 
-def dump_object_to_file(conn, object_id, path):
-    with gzip.open(path, 'wb') as f:
-        schema = json.dumps(get_full_table_schema(conn, SPLITGRAPH_META_SCHEMA, object_id))
-        f.write(schema.encode('utf-8') + b'\0')
-        with conn.cursor() as cur:
-            cur.copy_expert(SQL("COPY {}.{} TO STDOUT WITH (FORMAT 'binary')")
-                            .format(Identifier(SPLITGRAPH_META_SCHEMA), Identifier(object_id)), f)
+def dump_object(conn, object_id, fobj):
+    schema = json.dumps(get_full_table_schema(conn, SPLITGRAPH_META_SCHEMA, object_id))
+    fobj.write(schema.encode('utf-8') + b'\0')
+    with conn.cursor() as cur:
+        cur.copy_expert(SQL("COPY {}.{} TO STDOUT WITH (FORMAT 'binary')")
+                        .format(Identifier(SPLITGRAPH_META_SCHEMA), Identifier(object_id)), fobj)
 
 
-def load_object_from_file(conn, object_id, path):
-    logging.info("Loading %s from %s", object_id, path)
-    with gzip.open(path, 'rb') as f:
-        chars = b''
-        # Read until the delimiter separating a JSON schema from the Postgres copy_to dump.
-        # Surely this is buffered?
-        while True:
-            c = f.read(1)
-            if c == b'\0':
-                break
-            chars += c
+def load_object(conn, object_id, fobj):
+    chars = b''
+    # Read until the delimiter separating a JSON schema from the Postgres copy_to dump.
+    # Surely this is buffered?
+    while True:
+        c = fobj.read(1)
+        if c == b'\0':
+            break
+        chars += c
 
-        schema = json.loads(chars.decode('utf-8'))
-        create_table(conn, SPLITGRAPH_META_SCHEMA, object_id, schema)
+    schema = json.loads(chars.decode('utf-8'))
+    create_table(conn, SPLITGRAPH_META_SCHEMA, object_id, schema)
 
-        with conn.cursor() as cur:
-            cur.copy_expert(SQL("COPY {}.{} FROM STDIN WITH (FORMAT 'binary')")
-                            .format(Identifier(SPLITGRAPH_META_SCHEMA), Identifier(object_id)), f)
+    with conn.cursor() as cur:
+        cur.copy_expert(SQL("COPY {}.{} FROM STDIN WITH (FORMAT 'binary')")
+                        .format(Identifier(SPLITGRAPH_META_SCHEMA), Identifier(object_id)), fobj)

--- a/splitgraph/objects/s3.py
+++ b/splitgraph/objects/s3.py
@@ -1,7 +1,7 @@
 import tempfile
 
 from minio import Minio
-from minio.error import (ResponseError, BucketAlreadyOwnedByYou,
+from minio.error import (BucketAlreadyOwnedByYou,
                          BucketAlreadyExists)
 from splitgraph.constants import S3_ACCESS_KEY, S3_SECRET_KEY, S3_PORT, S3_HOST
 from splitgraph.objects.dumping import dump_object_to_file, load_object_from_file
@@ -43,7 +43,7 @@ def s3_upload_objects(conn, objects_to_push, params):
         for object_id in objects_to_push:
             # First cut: dump the object to file and then upload it using Minio
             tmp_path = tmpdir + '/' + object_id
-            dump_object_to_file(object_id, tmp_path)
+            dump_object_to_file(conn, object_id, tmp_path)
             client.fput_object(bucket, object_id, tmp_path)
 
             urls.append('%s/%s/%s' % (endpoint, bucket, object_id))
@@ -68,4 +68,4 @@ def s3_download_objects(conn, objects_to_fetch, params):
 
             local_path = tmpdir + '/' + remote_object
             client.fget_object(bucket, remote_object, local_path)
-            load_object_from_file(local_path)
+            load_object_from_file(conn, object_id, local_path)

--- a/splitgraph/objects/s3.py
+++ b/splitgraph/objects/s3.py
@@ -1,10 +1,13 @@
 import tempfile
+from concurrent.futures import ThreadPoolExecutor
+from threading import Lock
 
 from minio import Minio
 from minio.error import (BucketAlreadyOwnedByYou,
                          BucketAlreadyExists)
+
+from splitgraph.objects.dumping import dump_object, load_object
 from splitgraph.constants import S3_ACCESS_KEY, S3_SECRET_KEY, S3_PORT, S3_HOST
-from splitgraph.objects.dumping import dump_object_to_file, load_object_from_file
 
 
 def _ensure_bucket(client, bucket):
@@ -28,25 +31,40 @@ def s3_upload_objects(conn, objects_to_push, params):
         * access_key: default SG_S3_KEY
         * bucket: default same as access_key
         * secret_key: default SG_S3_PWD
+
+        You can also specify the number of worker threads (`threads`) used to upload the
+        objects.
     """
     access_key = params.get('access_key', S3_ACCESS_KEY)
     endpoint = '%s:%s' % (params.get('host', S3_HOST), params.get('port', S3_PORT))
     bucket = params.get('bucket', access_key)
+    worker_threads = params.get('threads', 4)
     client = Minio(endpoint,
                    access_key=access_key,
                    secret_key=params.get('secret_key', S3_SECRET_KEY),
                    secure=False)
     _ensure_bucket(client, bucket)
 
-    urls = []
+    # Psycopg connection objects are not threadsafe -- make sure two threads can't use it at the same time.
+    # In the future, we should replace this with a pg connection pool instead
+    pg_conn_lock = Lock()
+
     with tempfile.TemporaryDirectory() as tmpdir:
-        for object_id in objects_to_push:
+        def _do_upload(object_id):
             # First cut: dump the object to file and then upload it using Minio
             tmp_path = tmpdir + '/' + object_id
-            dump_object_to_file(conn, object_id, tmp_path)
+
+            with pg_conn_lock:
+                with open(tmp_path, 'wb') as f:
+                    dump_object(conn, object_id, f)
+            # Minio pushes can happen concurrently
             client.fput_object(bucket, object_id, tmp_path)
 
-            urls.append('%s/%s/%s' % (endpoint, bucket, object_id))
+            return '%s/%s/%s' % (endpoint, bucket, object_id)
+
+        with ThreadPoolExecutor(max_workers=worker_threads) as tpe:
+            urls = tpe.map(_do_upload, objects_to_push)
+
     return urls
 
 
@@ -54,12 +72,13 @@ def s3_download_objects(conn, objects_to_fetch, params):
     # Maybe here we have to set these to None (anonymous) if the S3 host name doesn't match our own one.
     access_key = params.get('access_key', S3_ACCESS_KEY)
     secret_key = params.get('secret_key', S3_SECRET_KEY)
+    worker_threads = params.get('threads', 4)
+
+    pg_conn_lock = Lock()
 
     with tempfile.TemporaryDirectory() as tmpdir:
-        # Again, first download the objects and then import them (maybe can do streaming later)
-        for i, obj in enumerate(objects_to_fetch):
-            object_id, object_url = obj
-            print("(%d/%d) %s -> %s" % (i + 1, len(objects_to_fetch), object_url, object_id))
+        def _do_download(obj_id_url):
+            object_id, object_url = obj_id_url
             endpoint, bucket, remote_object = object_url.split('/')
             client = Minio(endpoint,
                            access_key=access_key,
@@ -68,4 +87,11 @@ def s3_download_objects(conn, objects_to_fetch, params):
 
             local_path = tmpdir + '/' + remote_object
             client.fget_object(bucket, remote_object, local_path)
-            load_object_from_file(conn, object_id, local_path)
+
+            with pg_conn_lock:
+                with open(local_path, 'rb') as f:
+                    load_object(conn, object_id, f)
+
+        # Again, first download the objects and then import them (maybe can do streaming later)
+        with ThreadPoolExecutor(max_workers=worker_threads) as tpe:
+            tpe.map(_do_download, objects_to_fetch)


### PR DESCRIPTION
Removes the binary dependency on pg_dump/restore. Much faster for lots of small objects, possibly slightly slower for large objects. Not sure at which point the overhead from gzipping beats the overhead from larger objects.

# Benchmarks

## Uploading 570 small-ish objects (<20 rows each) upstream (dumping + minio):

**BEFORE**: bulk of time spent farming out to pg_dump (startup takes about 0.8s)
```
Thu Nov 22 11:36:58 2018    push_s3_current.cprofile
         1627726 function calls (1627725 primitive calls) in 524.916 seconds
   Ordered by: cumulative time
   List reduced from 567 to 20 due to restriction <20>
   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        1    0.000    0.000  524.926  524.926 {built-in method builtins.exec}
        1    0.000    0.000  524.926  524.926 <string>:1(<module>)
        1    0.001    0.001  524.925  524.925 /home/mildbyte/splitgraph-opensource/splitgraph/commands/push_pull.py:176(push)
        1    0.002    0.002  522.233  522.233 /home/mildbyte/splitgraph-opensource/splitgraph/objects/loading.py:83(upload_objects)
        1    0.032    0.032  522.221  522.221 /home/mildbyte/splitgraph-opensource/splitgraph/objects/s3.py:20(s3_upload_objects)
      570    0.144    0.000  508.173    0.892 /home/mildbyte/splitgraph-opensource/splitgraph/objects/dumping.py:14(dump_object_to_file)
      570    0.028    0.000  507.636    0.891 /home/mildbyte/miniconda3/envs/splitgraph-prototype/lib/python3.6/subprocess.py:295(check_output)
      570    0.052    0.000  507.604    0.891 /home/mildbyte/miniconda3/envs/splitgraph-prototype/lib/python3.6/subprocess.py:372(run)
      570    0.026    0.000  500.243    0.878 /home/mildbyte/miniconda3/envs/splitgraph-prototype/lib/python3.6/subprocess.py:803(communicate)
     1144  500.060    0.437  500.060    0.437 {method 'read' of '_io.BufferedReader' objects}
      570    0.043    0.000   13.967    0.025 /home/mildbyte/miniconda3/envs/splitgraph-prototype/lib/python3.6/site-packages/minio-4.0.6-py3.6.egg/minio/api.py:522(fput_object)
      570    0.031    0.000   13.871    0.024 /home/mildbyte/miniconda3/envs/splitgraph-prototype/lib/python3.6/site-packages/minio-4.0.6-py3.6.egg/minio/api.py:723(put_object)
      570    0.026    0.000   13.777    0.024 /home/mildbyte/miniconda3/envs/splitgraph-prototype/lib/python3.6/site-packages/minio-4.0.6-py3.6.egg/minio/api.py:1420(_do_put_object)
      570    0.064    0.000   13.668    0.024 /home/mildbyte/miniconda3/envs/splitgraph-prototype/lib/python3.6/site-packages/minio-4.0.6-py3.6.egg/minio/api.py:1762(_url_open)
      572    0.037    0.000   12.778    0.022 /home/mildbyte/miniconda3/envs/splitgraph-prototype/lib/python3.6/site-packages/urllib3/poolmanager.py:301(urlopen)
      572    0.057    0.000   12.513    0.022 /home/mildbyte/miniconda3/envs/splitgraph-prototype/lib/python3.6/site-packages/urllib3/connectionpool.py:446(urlopen)
      572    0.103    0.000   11.804    0.021 /home/mildbyte/miniconda3/envs/splitgraph-prototype/lib/python3.6/site-packages/urllib3/connectionpool.py:319(_make_request)
      572    0.037    0.000   10.471    0.018 /home/mildbyte/miniconda3/envs/splitgraph-prototype/lib/python3.6/http/client.py:1287(getresponse)
      572    0.060    0.000   10.242    0.018 /home/mildbyte/miniconda3/envs/splitgraph-prototype/lib/python3.6/http/client.py:290(begin)
      572    0.038    0.000    9.507    0.017 /home/mildbyte/miniconda3/envs/splitgraph-prototype/lib/python3.6/http/client.py:257(_read_status)

```

**AFTER**: I think it's possible to make this ever so slightly faster by piping directly to Minio (currently we still dump files to /tmp for a 9.5s cost in this trace) + possibly running multiple jobs in parallel.
```
   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        1    0.000    0.000   28.853   28.853 {built-in method builtins.exec}
        1    0.001    0.001   28.853   28.853 <string>:1(<module>)
        1    0.001    0.001   28.849   28.849 /home/mildbyte/splitgraph-opensource/splitgraph/commands/push_pull.py:176(push)
        1    0.001    0.001   25.690   25.690 /home/mildbyte/splitgraph-opensource/splitgraph/objects/loading.py:83(upload_objects)
        1    0.017    0.017   25.687   25.687 /home/mildbyte/splitgraph-opensource/splitgraph/objects/s3.py:20(s3_upload_objects)
      570    0.029    0.000   16.058    0.028 /home/mildbyte/miniconda3/envs/splitgraph-prototype/lib/python3.6/site-packages/minio-4.0.6-py3.6.egg/minio/api.py:522(fput_object)
      570    0.023    0.000   15.989    0.028 /home/mildbyte/miniconda3/envs/splitgraph-prototype/lib/python3.6/site-packages/minio-4.0.6-py3.6.egg/minio/api.py:723(put_object)
      570    0.018    0.000   15.915    0.028 /home/mildbyte/miniconda3/envs/splitgraph-prototype/lib/python3.6/site-packages/minio-4.0.6-py3.6.egg/minio/api.py:1420(_do_put_object)
      570    0.029    0.000   15.854    0.028 /home/mildbyte/miniconda3/envs/splitgraph-prototype/lib/python3.6/site-packages/minio-4.0.6-py3.6.egg/minio/api.py:1762(_url_open)
      572    0.020    0.000   15.272    0.027 /home/mildbyte/miniconda3/envs/splitgraph-prototype/lib/python3.6/site-packages/urllib3/poolmanager.py:301(urlopen)
      572    0.042    0.000   15.129    0.026 /home/mildbyte/miniconda3/envs/splitgraph-prototype/lib/python3.6/site-packages/urllib3/connectionpool.py:446(urlopen)
      572    0.049    0.000   14.666    0.026 /home/mildbyte/miniconda3/envs/splitgraph-prototype/lib/python3.6/site-packages/urllib3/connectionpool.py:319(_make_request)
      572    0.013    0.000   14.029    0.025 /home/mildbyte/miniconda3/envs/splitgraph-prototype/lib/python3.6/http/client.py:1287(getresponse)
      572    0.040    0.000   13.952    0.024 /home/mildbyte/miniconda3/envs/splitgraph-prototype/lib/python3.6/http/client.py:290(begin)
      572    0.030    0.000   13.381    0.023 /home/mildbyte/miniconda3/envs/splitgraph-prototype/lib/python3.6/http/client.py:257(_read_status)
     6298    0.060    0.000   13.371    0.002 {method 'readline' of '_io.BufferedReader' objects}
      572    0.009    0.000   13.311    0.023 /home/mildbyte/miniconda3/envs/splitgraph-prototype/lib/python3.6/socket.py:572(readinto)
      572   13.297    0.023   13.297    0.023 {method 'recv_into' of '_socket.socket' objects}
     2319   10.242    0.004   10.522    0.005 {method 'execute' of 'psycopg2.extensions.cursor' objects}
      570    0.097    0.000    9.574    0.017 /home/mildbyte/splitgraph-opensource/splitgraph/objects/dumping.py:14(dump_object_to_file)
```

**Clone + download all objects: 40-45s**

**AFTER WITH GZIP**: basically the same
```
Thu Nov 22 14:07:04 2018    push_s3_copy_to_gzip.cprofile
         1205720 function calls (1205719 primitive calls) in 28.582 seconds
   Ordered by: cumulative time
   List reduced from 579 to 20 due to restriction <20>
   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        1    0.000    0.000   28.600   28.600 {built-in method builtins.exec}
        1    0.001    0.001   28.600   28.600 <string>:1(<module>)
        1    0.001    0.001   28.599   28.599 /home/mildbyte/splitgraph-opensource/splitgraph/commands/push_pull.py:176(push)
        1    0.001    0.001   25.588   25.588 /home/mildbyte/splitgraph-opensource/splitgraph/objects/loading.py:83(upload_objects)
        1    0.018    0.018   25.583   25.583 /home/mildbyte/splitgraph-opensource/splitgraph/objects/s3.py:20(s3_upload_objects)
      570    0.027    0.000   16.407    0.029 /home/mildbyte/miniconda3/envs/splitgraph-prototype/lib/python3.6/site-packages/minio-4.0.6-py3.6.egg/minio/api.py:522(fput_object)
      570    0.019    0.000   16.343    0.029 /home/mildbyte/miniconda3/envs/splitgraph-prototype/lib/python3.6/site-packages/minio-4.0.6-py3.6.egg/minio/api.py:723(put_object)
      570    0.018    0.000   16.288    0.029 /home/mildbyte/miniconda3/envs/splitgraph-prototype/lib/python3.6/site-packages/minio-4.0.6-py3.6.egg/minio/api.py:1420(_do_put_object)
      570    0.026    0.000   16.223    0.028 /home/mildbyte/miniconda3/envs/splitgraph-prototype/lib/python3.6/site-packages/minio-4.0.6-py3.6.egg/minio/api.py:1762(_url_open)
      572    0.018    0.000   15.687    0.027 /home/mildbyte/miniconda3/envs/splitgraph-prototype/lib/python3.6/site-packages/urllib3/poolmanager.py:301(urlopen)
      572    0.037    0.000   15.552    0.027 /home/mildbyte/miniconda3/envs/splitgraph-prototype/lib/python3.6/site-packages/urllib3/connectionpool.py:446(urlopen)
      572    0.048    0.000   15.055    0.026 /home/mildbyte/miniconda3/envs/splitgraph-prototype/lib/python3.6/site-packages/urllib3/connectionpool.py:319(_make_request)
      572    0.018    0.000   14.370    0.025 /home/mildbyte/miniconda3/envs/splitgraph-prototype/lib/python3.6/http/client.py:1287(getresponse)
      572    0.034    0.000   14.264    0.025 /home/mildbyte/miniconda3/envs/splitgraph-prototype/lib/python3.6/http/client.py:290(begin)
      572    0.033    0.000   13.693    0.024 /home/mildbyte/miniconda3/envs/splitgraph-prototype/lib/python3.6/http/client.py:257(_read_status)
     6298    0.063    0.000   13.686    0.002 {method 'readline' of '_io.BufferedReader' objects}
      572    0.011    0.000   13.623    0.024 /home/mildbyte/miniconda3/envs/splitgraph-prototype/lib/python3.6/socket.py:572(readinto)
      572   13.607    0.024   13.607    0.024 {method 'recv_into' of '_socket.socket' objects}
     2319    9.451    0.004    9.703    0.004 {method 'execute' of 'psycopg2.extensions.cursor' objects}
      570    0.053    0.000    9.118    0.016 /home/mildbyte/splitgraph-opensource/splitgraph/objects/dumping.py:16(dump_object_to_file)
```


## Large object benchmarks

### 1M SNAP, 10x 1000-row DIFFs:

**Sizes**: SNAP 82MiB, DIFF 116KiB (pg_dump/restore was 39MiB/45KiB), 41MiB/45KiB with gzipping

**Push**: 15s (pg_dump/restore was 30s), 45s with gzipping (?????)

**Clone + download all**: 20s (pg_dump/restore was 15s), 20s with gzipping


### 100K SNAP, 10x 1000-row DIFFs, with gzipping

**Sizes**: 4.1MiB/45KiB

**Push**: 6s (was 8s, probably comparable)

**Clone + download all**: 3s (was 4s, probably comparable)