### PR TITLE
Performance fixes to layered querying + fix for PG11 engine

### DIFF
--- a/splitgraph/config/keys.py
+++ b/splitgraph/config/keys.py
@@ -29,10 +29,7 @@ DEFAULTS = {
     # See splitgraph.core.object_manager for an explanation.
     "SG_EVICTION_DECAY": 0.002,
     "SG_EVICTION_FLOOR": 1,
-    # Times the object manager returns a DIFF chain in a given window of time before it materializes
-    # it instead (to speed up layered querying).
-    "SG_SNAP_CACHE_MISSES": 5,
-    "SG_SNAP_CACHE_LOOKBACK": 300
+    "SG_FDW_CLASS": "splitgraph.core.fdw_checkout.QueryingForeignDataWrapper",
 }
 
 KEYS = list(DEFAULTS.keys())
@@ -66,8 +63,7 @@ ARGUMENT_KEY_MAP = {
     "--object-cache-size": "SG_OBJECT_CACHE_SIZE",
     "--eviction-decay": "SG_EVICTION_DECAY",
     "--eviction-floor": "SG_EVICTION_FLOOR",
-    "--cache-misses-for-snap": "SG_SNAP_CACHE_MISSES",
-    "--cache-misses-lookback": "SG_SNAP_CACHE_LOOKBACK",
+    "--fdw-class": "SG_FDW_CLASS",
 }
 
 ARG_KEYS = list(ARGUMENT_KEY_MAP.keys())

--- a/splitgraph/config/keys.py
+++ b/splitgraph/config/keys.py
@@ -11,6 +11,8 @@ DEFAULTS = {
     "SG_ENGINE_ADMIN_USER": "sgr",
     "SG_ENGINE_ADMIN_PWD": "supersecure",
     "SG_ENGINE_POSTGRES_DB_NAME": "postgres",
+    # Size of the connection pool used to download/upload objects
+    "SG_ENGINE_POOL": 8,
     "SG_CONFIG_FILE": None,
     "SG_META_SCHEMA": "splitgraph_meta",
     "SG_CONFIG_DIRS": None,
@@ -50,6 +52,7 @@ ARGUMENT_KEY_MAP = {
     "--engine-admin-user": "SG_ENGINE_ADMIN_USER",
     "--engine-admin-pwd": "SG_ENGINE_ADMIN_PWD",
     "--engine-postgres-db-name": "SG_ENGINE_POSTGRES_DB_NAME",
+    "--engine-pool": "SG_ENGINE_POOL",
     "--config-file": "SG_CONFIG_FILE",
     "--meta-schema": "SG_META_SCHEMA",
     "--config-dirs": "SG_CONFIG_DIRS",

--- a/splitgraph/config/keys.py
+++ b/splitgraph/config/keys.py
@@ -11,8 +11,8 @@ DEFAULTS = {
     "SG_ENGINE_ADMIN_USER": "sgr",
     "SG_ENGINE_ADMIN_PWD": "supersecure",
     "SG_ENGINE_POSTGRES_DB_NAME": "postgres",
-    # Size of the connection pool used to download/upload objects
-    "SG_ENGINE_POOL": 8,
+    # Size of the connection pool used to download/upload objects + talk to the engine
+    "SG_ENGINE_POOL": 16,
     "SG_CONFIG_FILE": None,
     "SG_META_SCHEMA": "splitgraph_meta",
     "SG_CONFIG_DIRS": None,

--- a/splitgraph/core/fragment_manager.py
+++ b/splitgraph/core/fragment_manager.py
@@ -8,8 +8,8 @@ from random import getrandbits
 
 from psycopg2.extras import Json
 from psycopg2.sql import SQL, Identifier
-from splitgraph.engine.postgres.engine import SG_UD_FLAG
 
+from splitgraph.engine.postgres.engine import SG_UD_FLAG
 from ._common import adapt, SPLITGRAPH_META_SCHEMA, ResultShape, insert, coerce_val_to_json
 
 # PG types we can run max/min on
@@ -302,22 +302,25 @@ class FragmentManager:
         table_size = self.object_engine.run_sql(SQL("SELECT COUNT (1) FROM {}.{}")
                                                 .format(Identifier(repository.to_schema()), Identifier(table_name)),
                                                 return_shape=ResultShape.ONE_ONE)
-        if chunk_size and table_size:
-            for offset in range(0, table_size, chunk_size):
-                object_id = get_random_object_id()
-                self.object_engine.copy_table(repository.to_schema(), table_name, SPLITGRAPH_META_SCHEMA, object_id,
-                                              with_pk_constraints=True, limit=chunk_size, offset=offset,
-                                              order_by_pk=True)
-                self.register_object(object_id, object_format='SNAP', namespace=repository.namespace,
-                                     parent_object=None)
-                object_ids.append(object_id)
-        else:
+
+        def _insert_and_register_fragment(source_schema, source_table, limit=None, offset=None):
             object_id = get_random_object_id()
-            self.object_engine.copy_table(repository.to_schema(), table_name, SPLITGRAPH_META_SCHEMA, object_id,
-                                          with_pk_constraints=True)
+            self.object_engine.copy_table(source_schema, source_table, SPLITGRAPH_META_SCHEMA, object_id,
+                                          with_pk_constraints=True, limit=limit, offset=offset,
+                                          order_by_pk=(offset is not None))
+            self.object_engine.run_sql(SQL("ALTER TABLE {}.{} ADD COLUMN {} BOOLEAN DEFAULT TRUE")
+                                       .format(Identifier(SPLITGRAPH_META_SCHEMA), Identifier(object_id),
+                                               Identifier(SG_UD_FLAG)))
             self.register_object(object_id, object_format='SNAP', namespace=repository.namespace,
                                  parent_object=None)
-            object_ids = [object_id]
+            return object_id
+
+        if chunk_size and table_size:
+            for offset in range(0, table_size, chunk_size):
+                object_ids.append(_insert_and_register_fragment(repository.to_schema(), table_name,
+                                                                limit=chunk_size, offset=offset))
+        else:
+            object_ids.append(_insert_and_register_fragment(repository.to_schema(), table_name))
         table_schema = self.object_engine.get_full_table_schema(repository.to_schema(), table_name)
         self.register_table(repository, table_name, image_hash, table_schema, object_ids)
 

--- a/splitgraph/core/image.py
+++ b/splitgraph/core/image.py
@@ -110,7 +110,7 @@ class Image(namedtuple('Image', IMAGE_COLS + ['repository', 'engine'])):
                 self.get_table(table).materialize(table)
         set_head(self.repository, self.image_hash)
 
-    def _lq_checkout(self, target_schema=None):
+    def _lq_checkout(self, target_schema=None, wrapper='splitgraph.core.fdw_checkout.QueryingForeignDataWrapper'):
         """
         Intended to be run on the sgr side. Initializes the FDW for all tables in a given image,
         allowing to query them directly without materializing the tables.
@@ -123,7 +123,7 @@ class Image(namedtuple('Image', IMAGE_COLS + ['repository', 'engine'])):
         engine = self.repository.engine
 
         init_fdw(engine, server_id=server_id, wrapper='multicorn',
-                 server_options={'wrapper': 'splitgraph.core.fdw_checkout.QueryingForeignDataWrapper',
+                 server_options={'wrapper': wrapper,
                                  'engine': engine.name,
                                  'use_socket': 'True',
                                  'namespace': self.repository.namespace,

--- a/splitgraph/core/image.py
+++ b/splitgraph/core/image.py
@@ -7,7 +7,7 @@ from random import getrandbits
 
 from psycopg2.extras import Json
 from psycopg2.sql import SQL, Identifier
-from splitgraph.config import SPLITGRAPH_META_SCHEMA
+from splitgraph.config import SPLITGRAPH_META_SCHEMA, CONFIG
 from splitgraph.engine import ResultShape
 from splitgraph.exceptions import SplitGraphException
 from splitgraph.hooks.mount_handlers import init_fdw
@@ -19,6 +19,7 @@ IMAGE_COLS = ["image_hash", "parent_id", "created", "comment", "provenance_type"
 _PROV_QUERY = SQL("""UPDATE {}.images SET provenance_type = %s, provenance_data = %s WHERE
                             namespace = %s AND repository = %s AND image_hash = %s""") \
     .format(Identifier(SPLITGRAPH_META_SCHEMA))
+FDW_CLASS = CONFIG['SG_FDW_CLASS']
 
 
 class Image(namedtuple('Image', IMAGE_COLS + ['repository', 'engine'])):
@@ -110,7 +111,7 @@ class Image(namedtuple('Image', IMAGE_COLS + ['repository', 'engine'])):
                 self.get_table(table).materialize(table)
         set_head(self.repository, self.image_hash)
 
-    def _lq_checkout(self, target_schema=None, wrapper='splitgraph.core.fdw_checkout.QueryingForeignDataWrapper'):
+    def _lq_checkout(self, target_schema=None, wrapper=FDW_CLASS):
         """
         Intended to be run on the sgr side. Initializes the FDW for all tables in a given image,
         allowing to query them directly without materializing the tables.

--- a/splitgraph/core/object_manager.py
+++ b/splitgraph/core/object_manager.py
@@ -7,13 +7,13 @@ from contextlib import contextmanager
 from datetime import datetime as dt
 
 from psycopg2.sql import SQL, Identifier
+
 from splitgraph.config import SPLITGRAPH_META_SCHEMA, CONFIG
 from splitgraph.core.fragment_manager import FragmentManager
 from splitgraph.core.metadata_manager import MetadataManager
 from splitgraph.engine import ResultShape, switch_engine
 from splitgraph.exceptions import SplitGraphException
 from splitgraph.hooks.external_objects import get_external_object_handler
-
 from ._common import META_TABLES, select, insert, pretty_size, Tracer
 
 
@@ -117,9 +117,6 @@ class ObjectManager(FragmentManager, MetadataManager):
 
         # Increase the refcount on all of the objects we're giving back to the caller so that others don't GC them.
         logging.info("Claiming %d object(s)", len(required_objects))
-
-        # here: only claim external objects (if an object exists locally and doesn't have an entry in the cache,
-        # don't add one)
 
         self._claim_objects(required_objects)
         tracer.log('claim_objects')

--- a/splitgraph/core/table.py
+++ b/splitgraph/core/table.py
@@ -4,6 +4,7 @@ import logging
 
 from psycopg2.sql import SQL, Identifier
 from splitgraph.config import SPLITGRAPH_META_SCHEMA
+from splitgraph.core.fragment_manager import get_random_object_id, quals_to_sql
 
 
 class Table:
@@ -50,3 +51,85 @@ class Table:
                 *(Identifier(cname) for _, cname, _, _ in self.table_schema))
             query += SQL(") SERVER {} OPTIONS (table %s)").format(Identifier(lq_server))
             engine.run_sql(query, (self.table_name,))
+
+    def query(self, columns, quals):
+        """
+        Run a read-only query against this table without materializing it.
+
+        :param columns: List of columns from this table to fetch
+        :param quals: List of qualifiers in conjunctive normal form. See the documentation for
+            FragmentManager.filter_fragments for the actual format.
+        :return: List of tuples of results
+        """
+
+        sql_quals, sql_qual_vals = quals_to_sql(quals, column_types={c[1]: c[2] for c in self.table_schema})
+
+        object_manager = self.repository.objects
+        engine = self.repository.engine
+        with object_manager.ensure_objects(self, quals=quals) as required_objects:
+            logging.info("Using fragments %r to satisfy the query", required_objects)
+            if not required_objects:
+                return []
+            if len(required_objects) == 1:
+                # If one object has our answer, we can send queries directly to it
+                return self._run_select_from_staging(SPLITGRAPH_META_SCHEMA, required_objects[0], columns,
+                                                     drop_table=False, qual_sql=sql_quals, qual_args=sql_qual_vals)
+
+            # Accumulate the query result in a temporary table.
+            staging_table = self._create_staging_table(required_objects[0])
+
+            # Apply the fragments (just the parts that match the qualifiers) to the staging area
+            if quals:
+                engine.apply_fragments([(SPLITGRAPH_META_SCHEMA, o) for o in required_objects],
+                                       SPLITGRAPH_META_SCHEMA, staging_table,
+                                       extra_quals=sql_quals,
+                                       extra_qual_args=sql_qual_vals)
+            else:
+                engine.apply_fragments([(SPLITGRAPH_META_SCHEMA, o) for o in required_objects],
+                                       SPLITGRAPH_META_SCHEMA, staging_table)
+        return self._run_select_from_staging(SPLITGRAPH_META_SCHEMA, staging_table, columns,
+                                             drop_table=True)
+
+    def _create_staging_table(self, snap):
+        staging_table = get_random_object_id()
+        engine = self.repository.engine
+
+        logging.info("Using staging table %s", staging_table)
+        engine.run_sql(SQL("CREATE TABLE {0}.{1} AS SELECT * FROM {0}.{2} LIMIT 1 WITH NO DATA").format(
+            Identifier(SPLITGRAPH_META_SCHEMA), Identifier(staging_table), Identifier(snap)))
+        pks = engine.get_primary_keys(SPLITGRAPH_META_SCHEMA, snap)
+        if pks:
+            engine.run_sql(SQL("ALTER TABLE {}.{} ADD PRIMARY KEY (").format(
+                Identifier(SPLITGRAPH_META_SCHEMA), Identifier(staging_table)) + SQL(',').join(
+                SQL("{}").format(Identifier(c)) for c, _ in pks) + SQL(")"))
+        return staging_table
+
+    def _run_select_from_staging(self, schema, table, columns, drop_table=False, qual_sql=None, qual_args=None):
+        """Runs the actual select query against the partially materialized table.
+        If qual_sql is passed, this will include it in the SELECT query. Despite that Postgres
+        will check our results again, this is still useful so that we don't pass all the rows
+        in the SNAP through the Python runtime."""
+        engine = self.repository.engine
+
+        cur = engine.connection.cursor('sg_layered_query_cursor')
+        query = SQL("SELECT ") + SQL(',').join(Identifier(c) for c in columns) \
+                + SQL(" FROM {}.{}").format(Identifier(schema),
+                                            Identifier(table))
+        if qual_args:
+            query += SQL(" WHERE ") + qual_sql
+            query = cur.mogrify(query, qual_args)
+        cur.execute(query)
+
+        while True:
+            try:
+                yield {c: v for c, v in zip(columns, next(cur))}
+            except StopIteration:
+                # When the cursor has been consumed, delete the staging table and close it.
+                cur.close()
+                if drop_table:
+                    engine.delete_table(schema, table)
+
+                # End the transaction so that nothing else deadlocks (at this point we've returned
+                # all the data we needed to the runtime so nothing will be lost).
+                engine.commit()
+                return

--- a/splitgraph/core/table.py
+++ b/splitgraph/core/table.py
@@ -3,8 +3,10 @@
 import logging
 
 from psycopg2.sql import SQL, Identifier
+
 from splitgraph.config import SPLITGRAPH_META_SCHEMA
 from splitgraph.core.fragment_manager import get_random_object_id, quals_to_sql
+from splitgraph.engine.postgres.engine import SG_UD_FLAG
 
 
 class Table:
@@ -39,6 +41,10 @@ class Table:
             with object_manager.ensure_objects(self) as required_objects:
                 engine.copy_table(SPLITGRAPH_META_SCHEMA, required_objects[0], destination_schema, destination,
                                   with_pk_constraints=True)
+                # Make sure we don't include the update-delete flag
+                engine.run_sql(SQL("ALTER TABLE {}.{} DROP COLUMN IF EXISTS {}")
+                               .format(Identifier(destination_schema), Identifier(destination),
+                                       Identifier(SG_UD_FLAG)))
                 if len(required_objects) > 1:
                     logging.info("Applying %d fragment(s)...", (len(required_objects) - 1))
                     engine.apply_fragments([(SPLITGRAPH_META_SCHEMA, d) for d in required_objects[1:]],
@@ -81,13 +87,13 @@ class Table:
             # Apply the fragments (just the parts that match the qualifiers) to the staging area
             if quals:
                 engine.apply_fragments([(SPLITGRAPH_META_SCHEMA, o) for o in required_objects],
-                                       SPLITGRAPH_META_SCHEMA, staging_table,
+                                       "pg_temp", staging_table,
                                        extra_quals=sql_quals,
                                        extra_qual_args=sql_qual_vals)
             else:
                 engine.apply_fragments([(SPLITGRAPH_META_SCHEMA, o) for o in required_objects],
-                                       SPLITGRAPH_META_SCHEMA, staging_table)
-        return self._run_select_from_staging(SPLITGRAPH_META_SCHEMA, staging_table, columns,
+                                       "pg_temp", staging_table)
+        return self._run_select_from_staging("pg_temp", staging_table, columns,
                                              drop_table=True)
 
     def _create_staging_table(self, snap):
@@ -95,12 +101,13 @@ class Table:
         engine = self.repository.engine
 
         logging.info("Using staging table %s", staging_table)
-        engine.run_sql(SQL("CREATE TABLE {0}.{1} AS SELECT * FROM {0}.{2} LIMIT 1 WITH NO DATA").format(
+        engine.run_sql(SQL("CREATE TEMPORARY TABLE {1} "
+                           "AS SELECT * FROM {0}.{2} LIMIT 1 WITH NO DATA").format(
             Identifier(SPLITGRAPH_META_SCHEMA), Identifier(staging_table), Identifier(snap)))
         pks = engine.get_primary_keys(SPLITGRAPH_META_SCHEMA, snap)
         if pks:
             engine.run_sql(SQL("ALTER TABLE {}.{} ADD PRIMARY KEY (").format(
-                Identifier(SPLITGRAPH_META_SCHEMA), Identifier(staging_table)) + SQL(',').join(
+                Identifier("pg_temp"), Identifier(staging_table)) + SQL(',').join(
                 SQL("{}").format(Identifier(c)) for c, _ in pks) + SQL(")"))
         return staging_table
 

--- a/splitgraph/engine/__init__.py
+++ b/splitgraph/engine/__init__.py
@@ -120,7 +120,7 @@ class SQLEngine(ABC):
 
     def delete_table(self, schema, table):
         """Drop a table from a schema if it exists"""
-        if self.get_table_type(schema, table) != 'FOREIGN TABLE':
+        if self.get_table_type(schema, table) not in ('FOREIGN TABLE', 'FOREIGN'):
             self.run_sql(SQL("DROP TABLE IF EXISTS {}.{}").format(Identifier(schema), Identifier(table)))
         else:
             self.run_sql(SQL("DROP FOREIGN TABLE IF EXISTS {}.{}").format(Identifier(schema), Identifier(table)))

--- a/splitgraph/engine/__init__.py
+++ b/splitgraph/engine/__init__.py
@@ -191,7 +191,7 @@ class SQLEngine(ABC):
         :param schema: Schema to create the table in
         :param table: Table name to create
         :param schema_spec: A list of (ordinal_position, column_name, data_type, is_pk) specifying the table schema
-        :param unlogged: If True, the table won't be reflected in the WAL.
+        :param unlogged: If True, the table won't be reflected in the WAL or scanned by the analyzer/autovacuum.
         """
 
         schema_spec = sorted(schema_spec)
@@ -207,6 +207,8 @@ class SQLEngine(ABC):
                 "))")
         else:
             query += SQL(")")
+        if unlogged:
+            query += SQL(" WITH(autovacuum_enabled=false)")
         self.run_sql(query, return_shape=ResultShape.NONE)
 
     def dump_table_sql(self, schema, table_name, stream, columns='*', where='', where_args=None):

--- a/splitgraph/engine/__init__.py
+++ b/splitgraph/engine/__init__.py
@@ -10,6 +10,7 @@ from contextlib import contextmanager
 from enum import Enum
 
 from psycopg2.sql import SQL, Identifier
+
 from splitgraph.config import CONFIG, PG_HOST, PG_PORT, PG_USER, PG_PWD, PG_DB
 
 
@@ -119,7 +120,7 @@ class SQLEngine(ABC):
 
     def delete_table(self, schema, table):
         """Drop a table from a schema if it exists"""
-        if self.get_table_type(schema, table) == 'BASE TABLE':
+        if self.get_table_type(schema, table) != 'FOREIGN TABLE':
             self.run_sql(SQL("DROP TABLE IF EXISTS {}.{}").format(Identifier(schema), Identifier(table)))
         else:
             self.run_sql(SQL("DROP FOREIGN TABLE IF EXISTS {}.{}").format(Identifier(schema), Identifier(table)))
@@ -183,19 +184,20 @@ class SQLEngine(ABC):
             queries.append(query)
         return SQL(';').join(queries)
 
-    def create_table(self, schema, table, schema_spec):
+    def create_table(self, schema, table, schema_spec, unlogged=False):
         """
         Creates a table using a previously-dumped table schema spec
 
         :param schema: Schema to create the table in
         :param table: Table name to create
         :param schema_spec: A list of (ordinal_position, column_name, data_type, is_pk) specifying the table schema
+        :param unlogged: If True, the table won't be reflected in the WAL.
         """
 
         schema_spec = sorted(schema_spec)
 
         target = SQL("{}.{}").format(Identifier(schema), Identifier(table))
-        query = SQL("CREATE TABLE {} (").format(target) \
+        query = SQL("CREATE " + ("UNLOGGED" if unlogged else "") + " TABLE {} (").format(target) \
                 + SQL(','.join("{} %s " % ctype for _, _, ctype, _ in schema_spec)) \
                     .format(*(Identifier(cname) for _, cname, _, _ in schema_spec))
 

--- a/splitgraph/engine/postgres/engine.py
+++ b/splitgraph/engine/postgres/engine.py
@@ -353,7 +353,12 @@ class PostgresEngine(AuditTriggerChangeEngine, ObjectEngine):
         return query
 
     def apply_fragments(self, objects, target_schema, target_table, extra_quals=None, extra_qual_args=None):
-        ri_data = self._prepare_ri_data(target_schema, target_table)
+        if not objects:
+            return
+        # In the case where we're applying fragments into a temporary table, we can't find out its schema
+        # using normal methods. Hence, we assume that the fragments have the same schema and use that instead.
+        # This will break if our fragments only describe a subset of all columns (which they currently don't).
+        ri_data = self._prepare_ri_data(objects[0][0], objects[0][1])
         query = SQL(";").join(self._generate_fragment_application(ss, st, target_schema, target_table,
                                                                   ri_data, extra_quals)
                               for ss, st in objects)

--- a/splitgraph/engine/postgres/engine.py
+++ b/splitgraph/engine/postgres/engine.py
@@ -387,7 +387,7 @@ class PostgresEngine(AuditTriggerChangeEngine, ObjectEngine):
             chars += char
 
         schema_spec = json.loads(chars.decode('utf-8'))
-        self.create_table(schema, table, schema_spec)
+        self.create_table(schema, table, schema_spec, unlogged=True)
 
         with self.connection.cursor() as cur:
             cur.copy_expert(SQL("COPY {}.{} FROM STDIN WITH (FORMAT 'binary')")

--- a/splitgraph/engine/postgres/engine.py
+++ b/splitgraph/engine/postgres/engine.py
@@ -82,7 +82,11 @@ class PsycopgEngine(SQLEngine):
         retries = 0
         while True:
             try:
-                return self._pool.getconn(get_ident())
+                conn = self._pool.getconn(get_ident())
+                if conn.closed:
+                    self._pool.putconn(conn)
+                    conn = self._pool.getconn(get_ident())
+                return conn
             except psycopg2.Error:
                 # The fast retrying is really used to claim connections from the pool, not to try to reconnect
                 # to the engine. Maybe it's worth even splitting the engine into something that's used for

--- a/splitgraph/engine/postgres/engine.py
+++ b/splitgraph/engine/postgres/engine.py
@@ -33,7 +33,7 @@ RETRY_DELAY_BASE = 0.01
 RETRY_DELAY_CAP = 10
 
 # Max number of retries before failing
-RETRY_AMOUNT = 15
+RETRY_AMOUNT = 20
 
 
 class PsycopgEngine(SQLEngine):

--- a/splitgraph/hooks/s3.py
+++ b/splitgraph/hooks/s3.py
@@ -53,7 +53,7 @@ class S3ExternalObjectHandler(ExternalObjectHandler):
         access_key = self.params.get('access_key', S3_ACCESS_KEY)
         endpoint = '%s:%s' % (self.params.get('host', S3_HOST), self.params.get('port', S3_PORT))
         bucket = self.params.get('bucket', access_key)
-        worker_threads = self.params.get('threads', CONFIG['SG_ENGINE_POOL'] - 1)
+        worker_threads = self.params.get('threads', int(CONFIG['SG_ENGINE_POOL']) - 1)
 
         logging.info("Uploading %d object(s) to %s/%s", len(objects), endpoint, bucket)
         client = Minio(endpoint,
@@ -92,7 +92,7 @@ class S3ExternalObjectHandler(ExternalObjectHandler):
         secret_key = self.params.get('secret_key', S3_SECRET_KEY)
         # By default, take up the whole connection pool with downloaders (less one connection for the main
         # thread that handles metadata)
-        worker_threads = self.params.get('threads', CONFIG['SG_ENGINE_POOL'] - 1)
+        worker_threads = self.params.get('threads', int(CONFIG['SG_ENGINE_POOL']) - 1)
 
         def _do_download(obj_id_url):
             object_id, object_url = obj_id_url

--- a/test/splitgraph/commands/test_commit_diff.py
+++ b/test/splitgraph/commands/test_commit_diff.py
@@ -3,6 +3,7 @@ from decimal import Decimal
 
 import pytest
 from psycopg2.sql import SQL, Identifier
+
 from splitgraph import SPLITGRAPH_META_SCHEMA, ResultShape, select
 from test.splitgraph.conftest import OUTPUT, PG_DATA
 
@@ -181,7 +182,7 @@ def test_commit_diff_splitting(local_engine_empty):
 
     # Check the contents of the newly created objects.
     assert OUTPUT.run_sql(select(new_objects[0])) == \
-           [(0, 'zero', -1)]  # No deletions in this fragment, so no deletion flag. New inserted value only.
+           [(True, 0, 'zero', -1)]  # upserted=True, key, new_value_1, new_value_2
     assert OUTPUT.run_sql(select(new_objects[1])) == \
            [(True, 5, 'UPDATED', 8),  # upserted=True, key, new_value_1, new_value_2
             (False, 4, None, None)]  # upserted=False, key, None, None
@@ -189,7 +190,7 @@ def test_commit_diff_splitting(local_engine_empty):
            [(False, 6, None, None)]  # upserted=False, key, None, None
     # No need to check new_objects[3] (since it's the same as the old fragment)
     assert OUTPUT.run_sql(select(new_objects[4])) == \
-           [(12, 'l', 22)]
+           [(True, 12, 'l', 22)]  # same
 
 
 def test_commit_diff_splitting_composite(local_engine_empty):

--- a/test/splitgraph/commands/test_layered_querying.py
+++ b/test/splitgraph/commands/test_layered_querying.py
@@ -1,6 +1,7 @@
 from datetime import datetime as dt
 
 import pytest
+
 from splitgraph.core import clone
 
 
@@ -232,3 +233,14 @@ def test_lq_single_non_snap_object(local_engine_empty, pg_repo_remote):
            == [(3, 'celery')]
     used_objects = pg_repo_local.objects.get_downloaded_objects()
     assert len(used_objects) == 1
+
+
+def test_direct_table_lq(pg_repo_local):
+    # Test LQ using the Table.query() call instead of the FDW
+    prepare_lq_repo(pg_repo_local, commit_after_every=True, include_pk=True)
+
+    new_head = pg_repo_local.head
+    table = new_head.get_table('fruits')
+
+    assert list(table.query(columns=['name', 'timestamp'], quals=[[('fruit_id', '=', '2')]])) \
+           == [{'name': 'guitar', 'timestamp': _DT}]

--- a/test/splitgraph/commands/test_misc.py
+++ b/test/splitgraph/commands/test_misc.py
@@ -96,3 +96,14 @@ def test_image_resolution(pg_repo_local):
         img = pg_repo_local.images['abcdef1234567890abcdef']
     with pytest.raises(SplitGraphException):
         img = pg_repo_local.images['some_weird_tag']
+
+
+def test_tag_errors(pg_repo_local):
+    pg_repo_local.uncheckout()
+    with pytest.raises(SplitGraphException) as e:
+        head = pg_repo_local.images.by_tag('HEAD')
+    assert "No current checked out revision found" in str(e)
+
+    with pytest.raises(SplitGraphException) as e:
+        tag = pg_repo_local.images.by_tag('notatag')
+    assert "Tag notatag not found" in str(e)

--- a/test/splitgraph/commands/test_schema_changes.py
+++ b/test/splitgraph/commands/test_schema_changes.py
@@ -1,6 +1,7 @@
 import pytest
 
 from splitgraph.config import SPLITGRAPH_META_SCHEMA
+from splitgraph.engine.postgres.engine import SG_UD_FLAG
 
 TEST_CASES = [
     ("ALTER TABLE fruits DROP COLUMN name",
@@ -42,7 +43,7 @@ def test_schema_changes(pg_repo_local, test_case):
     new_snap = new_head.get_table('fruits').objects[0]
     assert pg_repo_local.objects.get_object_meta([new_snap])[0][2] is None  # no parent
     assert pg_repo_local.engine.get_full_table_schema(SPLITGRAPH_META_SCHEMA, new_snap) == _reassign_ordinals(
-        expected_new_schema)
+        expected_new_schema) + [(len(expected_new_schema) + 1, SG_UD_FLAG, 'boolean', False)]
 
     head.checkout()
     assert pg_repo_local.engine.get_full_table_schema(pg_repo_local.to_schema(), 'fruits') == OLD_SCHEMA

--- a/test/splitgraph/test_commandline.py
+++ b/test/splitgraph/test_commandline.py
@@ -721,7 +721,7 @@ def test_commandline_lq_checkout(pg_repo_local):
     assert result.exit_code == 0
     assert pg_repo_local.head is not None
     assert get_engine().schema_exists(str(pg_repo_local))
-    assert get_engine().get_table_type(str(pg_repo_local), 'fruits') == 'FOREIGN TABLE'
+    assert get_engine().get_table_type(str(pg_repo_local), 'fruits') in ('FOREIGN TABLE', 'FOREIGN')
 
 
 def test_commandline_dump_load(pg_repo_local):


### PR DESCRIPTION
* LQ execution is now part of the Table class and can be called without any FDWs
* Allow swapping in different FDW classes to mount Splitgraph images
* Fragment format change: add upsert/delete flags to all fragments
* Object cache performance improvements:
  * TEMPORARY tables for LQ execution that don't get analyzed/flushed to disk
  * UNLOGGED tables with autovacuum off for the object cache (objects can always be redownloaded)
  * Use a thread pool for the PG engine. allowing concurrent S3 downloads and using the engine from multiple threads
* PG engine class now tries to reconnect to actual engine (with exponential backoff retries) on connection failure -- UX slightly debatable as the reconnect loop is used to wait on connections from pool to become free (initial delay 50ms, then 100ms, then 200ms...) which results in logspam when the engine is actually down
* Test fix for pg11 engine