### PR TITLE
Feature/dual engines

### DIFF
--- a/splitgraph/core/_common.py
+++ b/splitgraph/core/_common.py
@@ -13,7 +13,9 @@ from splitgraph.config import SPLITGRAPH_META_SCHEMA
 from splitgraph.engine import ResultShape
 from splitgraph.exceptions import SplitGraphException
 
-META_TABLES = ['images', 'tags', 'objects', 'tables', 'upstream', 'object_locations', 'object_cache_status', 'info']
+META_TABLES = ['images', 'tags', 'objects', 'tables', 'upstream', 'object_locations', 'object_cache_status',
+               'object_cache_occupancy', 'info']
+OBJECT_MANAGER_TABLES = ['object_cache_status', 'object_cache_occupancy']
 _PUBLISH_PREVIEW_SIZE = 100
 
 
@@ -178,7 +180,11 @@ def _create_metadata_schema(engine):
                         ready      BOOLEAN,
                         last_used  TIMESTAMP)""")
                    .format(Identifier(SPLITGRAPH_META_SCHEMA), Identifier("object_cache_status"),
-                           Identifier(SPLITGRAPH_META_SCHEMA), Identifier("objects")), return_shape=None)
+                           Identifier(SPLITGRAPH_META_SCHEMA), Identifier("objects")))
+
+    # Size of all objects cached on the engine (existing externally and downloaded for a materialization/LQ)
+    engine.run_sql(SQL("""CREATE TABLE {0}.{1} (total_size BIGINT); INSERT INTO {0}.{1} VALUES (0)""")
+                   .format(Identifier(SPLITGRAPH_META_SCHEMA), Identifier("object_cache_occupancy")))
 
     # Maps a given table at a given point in time to a list of fragments that it's assembled from.
     # Only the "top" fragments are listed here: to actually materialize a given table, the parent chain of every

--- a/splitgraph/core/fdw_checkout.py
+++ b/splitgraph/core/fdw_checkout.py
@@ -70,6 +70,12 @@ class QueryingForeignDataWrapper(ForeignDataWrapper):
         self.fdw_columns = fdw_columns
 
         # Try using a UNIX socket if the engine is local to us
-        self.engine = get_engine(self.fdw_options['engine'], bool(self.fdw_options.get('use_socket', False)))
-        self.repository = Repository(fdw_options['namespace'], self.fdw_options['repository'], self.engine)
-        self.table = self.repository.images[self.fdw_options['image_hash']].get_table(self.fdw_options['table'])
+        engine = get_engine(self.fdw_options['engine'], bool(self.fdw_options.get('use_socket', False)))
+        if 'object_engine' in self.fdw_options:
+            object_engine = get_engine(self.fdw_options['object_engine'],
+                                       bool(self.fdw_options.get('use_socket', False)))
+        else:
+            object_engine = engine
+        repository = Repository(fdw_options['namespace'], self.fdw_options['repository'],
+                                engine=engine, object_engine=object_engine)
+        self.table = repository.images[self.fdw_options['image_hash']].get_table(self.fdw_options['table'])

--- a/splitgraph/core/image.py
+++ b/splitgraph/core/image.py
@@ -139,6 +139,7 @@ class Image(namedtuple('Image', IMAGE_COLS + ['repository', 'engine', 'object_en
             logging.info("Mounting %s:%s/%s into %s", self.repository.to_schema(), self.image_hash, table_name,
                          target_schema)
             self.get_table(table_name).materialize(table_name, target_schema, lq_server=server_id)
+        object_engine.commit()
 
     @contextmanager
     def query_schema(self):

--- a/splitgraph/core/object_manager.py
+++ b/splitgraph/core/object_manager.py
@@ -176,6 +176,7 @@ class ObjectManager(FragmentManager, MetadataManager):
         try:
             # Release the lock and yield to the caller.
             self.object_engine.commit()
+            self.metadata_engine.commit()
             yield required_objects
         finally:
             # Decrease the refcounts on the objects. Optionally, evict them.
@@ -189,6 +190,8 @@ class ObjectManager(FragmentManager, MetadataManager):
             logging.info("Timing stats for %s/%s/%s/%s: \n%s", table.repository.namespace, table.repository.repository,
                          table.image.image_hash, table.table_name, tracer)
             self.object_engine.commit()
+            # Release the metadata tables as well
+            self.metadata_engine.commit()
 
     def _filter_objects(self, objects, table, quals):
         if quals:

--- a/splitgraph/core/object_manager.py
+++ b/splitgraph/core/object_manager.py
@@ -276,6 +276,8 @@ class ObjectManager(FragmentManager, MetadataManager):
 
     def _increase_cache_occupancy(self, objects):
         """Increase the cache occupancy by objects' total size."""
+        if not objects:
+            return
         total_size = sum(o[4] for o in self.get_object_meta(objects))
         self.object_engine.run_sql(SQL("UPDATE {}.object_cache_occupancy SET total_size = total_size + %s")
                                    .format(Identifier(SPLITGRAPH_META_SCHEMA)), (total_size,))

--- a/splitgraph/core/table.py
+++ b/splitgraph/core/table.py
@@ -139,4 +139,6 @@ class Table:
                 # End the transaction so that nothing else deadlocks (at this point we've returned
                 # all the data we needed to the runtime so nothing will be lost).
                 engine.commit()
+                # Release the metadata tables as well
+                self.repository.engine.commit()
                 return

--- a/splitgraph/engine/__init__.py
+++ b/splitgraph/engine/__init__.py
@@ -122,8 +122,6 @@ class SQLEngine(ABC):
         """Drop a table from a schema if it exists"""
         if self.get_table_type(schema, table) not in ('FOREIGN TABLE', 'FOREIGN'):
             self.run_sql(SQL("DROP TABLE IF EXISTS {}.{}").format(Identifier(schema), Identifier(table)))
-        else:
-            self.run_sql(SQL("DROP FOREIGN TABLE IF EXISTS {}.{}").format(Identifier(schema), Identifier(table)))
 
     def delete_schema(self, schema):
         """Delete a schema if it exists, including all the tables in it."""

--- a/test/splitgraph/commands/test_layered_querying.py
+++ b/test/splitgraph/commands/test_layered_querying.py
@@ -164,6 +164,7 @@ def _prepare_fully_remote_repo(local_engine_empty, pg_repo_remote):
     pg_repo_remote.objects.delete_objects(remote.objects.get_downloaded_objects())
     pg_repo_remote.engine.commit()
     pg_repo_local.objects.cleanup()
+    pg_repo_local.object_engine.commit()
 
 
 @pytest.mark.parametrize("test_case", [
@@ -281,7 +282,7 @@ def test_multiengine_flow(local_engine_empty, pg_repo_remote):
 
     # Test the local engine doesn't actually have any metadata stored on it.
     for table in META_TABLES:
-        if table != 'object_cache_status':
+        if table not in ('object_cache_status', 'object_cache_occupancy'):
             assert local_engine_empty.run_sql("SELECT COUNT(1) FROM splitgraph_meta." + table,
                                               return_shape=ResultShape.ONE_ONE) == 0
 


### PR DESCRIPTION
Allow using two engines throughout the API:

  * metadata engine: manages the images/objects/tables/tags tables (Splitgraph image metadata). Essentially, all writes/reads to splitgraph_meta tables go to the metadata engine (apart from object_cache_status and cached objects)
  * object engine: is responsible for object storage, checking fragments out, creating fragments, audit triggers and layered querying.

By default, both engines are the same but can be overridden at Repository object creation. The rough places where each engine is used:

  * ObjectManager mostly uses the object engine (including for cache occupancy calculations where it uses the physical table sizes of cached objects rather than querying the objects table)
  * FragmentManager uses the metadata engine to resolve/register fragments and the object engine to store/apply them
  * MetadataManager uses the metadata engine throughout
  * Repository mostly uses the object engine (e.g. to find out which tables have changed schemas etc) apart from actually recording new image metadata/importing images.

Only reading with two engines (e.g. running an LQ with the metadata engine + a different object engine) is supported and tested; writing for now isn't.

Also, speed up object fetching by maintaining a table with cache occupancy instead of recalculating it at every download.