### PR TITLE
Add branch coverage to tests, fix clean_test.sh

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -2,6 +2,6 @@
 test=pytest
 
 [tool:pytest]
-addopts = --cov splitgraph --cov-report term --cov-report html
-env = 
+addopts = --cov splitgraph --cov-branch --cov-report term --cov-report html
+env =
     SG_CONFIG_FILE = test/resources/.sgconfig

--- a/test/architecture/dev/docker-config/pytest.dev.ini
+++ b/test/architecture/dev/docker-config/pytest.dev.ini
@@ -1,6 +1,6 @@
 # pytest configuration file for running pytest in sgr container
 
 [pytest]
-addopts = --cov splitgraph --cov-report term --cov-report html
+addopts = --cov splitgraph --cov-branch --cov-report term --cov-report html
 env =
     SG_CONFIG_FILE = /sgconfig/.sgconfig

--- a/test/architecture/dev/docker-entrypoint-dev.sh
+++ b/test/architecture/dev/docker-entrypoint-dev.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 
 main() {
-    ( install_latest_sgr && clear_pycache_files ) || return 1
+    # Clear pycache files before (be considerate to us) and after (be considerate to the host)
+    ( clear_pycache_files && install_latest_sgr && clear_pycache_files ) || return 1
     return 0
 }
 

--- a/test/architecture/wait-for-architecture.sh
+++ b/test/architecture/wait-for-architecture.sh
@@ -36,7 +36,7 @@ _wait_for_test_architecture() {
     local counter=0
     while true ; do
 
-        if test $counter -eq 10 ; then
+        if test $counter -eq 15 ; then
             echo
             echo "FATAL: Could not connect to test-architecture after 10 tries"
             exit 1

--- a/test/clean_test.sh
+++ b/test/clean_test.sh
@@ -18,6 +18,7 @@ REPO_ROOT_DIR="${TEST_DIR}/.."
 pushd "$REPO_ROOT_DIR" \
     && pushd "${ARCHITECTURE_DIR}" \
     && docker-compose pull \
+    && docker-compose down -v \
     && docker-compose build \
     && docker-compose up -d --force-recreate --remove-orphans \
     && popd \


### PR DESCRIPTION
# 🔧

Hello

Changes in this PR:

```
- Collect and report branch coverage when running tests, whether from
  within docker container (where tests are configured with pytest.dev.ini),
  or on the host (where tests are configured with setup.cfg)
- Fix bug in entrypoint of sgr dev container where pycache files were cleaned
  only after installing sgr, when they should be cleaned before (and might as
  well be cleaned after, too, so as not to cause the same problem when
  importing later from the host). Point is, with bind mounting, we don't
  know at any given time where the pycache (+ .pyc) files came from -- the
  host or the container -- so they could be wrong at any given time, and
  thus we err on the side of caution by clearing them aggressively.
- Add down -v directive to clean_test.sh to make sure tests all start from
  fresh volumes (e.g. fix problem where existing volume was created with pg10
  and new engine is pg11 complaining about incompatible format)
```

Thank you