### PR TITLE
Fixes for concurrent object managers downloading objects + cache eviction improvements

### DIFF
--- a/splitgraph/config/__init__.py
+++ b/splitgraph/config/__init__.py
@@ -26,4 +26,5 @@ PG_PWD = CONFIG["SG_ENGINE_PWD"]
 SPLITGRAPH_META_SCHEMA = CONFIG["SG_META_SCHEMA"]
 REGISTRY_META_SCHEMA = "registry_meta"
 
-logging.basicConfig(format='%(asctime)s %(levelname)s %(message)s', level=CONFIG["SG_LOGLEVEL"])
+# Log timestamp and PID. By default we only log WARNINGs in the command line interface.
+logging.basicConfig(format='%(asctime)s [%(process)d] %(levelname)s %(message)s', level=CONFIG["SG_LOGLEVEL"])

--- a/splitgraph/config/keys.py
+++ b/splitgraph/config/keys.py
@@ -31,6 +31,7 @@ DEFAULTS = {
     # See splitgraph.core.object_manager for an explanation.
     "SG_EVICTION_DECAY": 0.002,
     "SG_EVICTION_FLOOR": 1,
+    "SG_EVICTION_MIN_FRACTION": 0.05,
     "SG_FDW_CLASS": "splitgraph.core.fdw_checkout.QueryingForeignDataWrapper",
 }
 
@@ -66,6 +67,7 @@ ARGUMENT_KEY_MAP = {
     "--object-cache-size": "SG_OBJECT_CACHE_SIZE",
     "--eviction-decay": "SG_EVICTION_DECAY",
     "--eviction-floor": "SG_EVICTION_FLOOR",
+    "--eviction-fraction": "SG_EVICTION_MIN_FRACTION",
     "--fdw-class": "SG_FDW_CLASS",
 }
 

--- a/splitgraph/core/repository.py
+++ b/splitgraph/core/repository.py
@@ -61,7 +61,7 @@ class ImageManager:
                                     (self.repository.namespace, self.repository.repository,),
                                     return_shape=ResultShape.ONE_MANY)
             if result is None:
-                raise SplitGraphException("No commits found in %s!")
+                raise SplitGraphException("No images found in %s!", self.repository.to_schema())
             return self._make_image(result)
 
         result = engine.run_sql(select("tags", "image_hash", "namespace = %s AND repository = %s AND tag = %s"),

--- a/splitgraph/engine/postgres/engine.py
+++ b/splitgraph/engine/postgres/engine.py
@@ -73,7 +73,8 @@ class PsycopgEngine(SQLEngine):
         self._pool.putconn(conn)
 
     def lock_table(self, schema, table):
-        self.run_sql(SQL("LOCK TABLE {}.{} IN ACCESS EXCLUSIVE MODE").format(Identifier(schema), Identifier(table)))
+        # Allow SELECTs but not writes to a given table.
+        self.run_sql(SQL("LOCK TABLE {}.{} IN EXCLUSIVE MODE").format(Identifier(schema), Identifier(table)))
 
     @property
     def connection(self):

--- a/test/splitgraph/test_object_cache.py
+++ b/test/splitgraph/test_object_cache.py
@@ -113,7 +113,7 @@ def test_object_cache_non_existing_objects(local_engine_empty, pg_repo_remote):
     # Make sure the claims have been released on failure (not inserted into the table at all)
     assert _get_refcount(object_manager, fruits_v3.objects[0]) is None
     # Now, also delete objects from Minio and make sure it's detected at download time
-    object_manager.run_eviction(object_manager.get_full_object_tree(), keep_objects=[], required_space=None)
+    object_manager.run_eviction(keep_objects=[], required_space=None)
 
     assert len(object_manager.get_downloaded_objects()) == 0
     assert object_manager.get_cache_occupancy() == 0
@@ -164,7 +164,7 @@ def test_object_cache_eviction(local_engine_empty, pg_repo_remote):
     assert _get_refcount(object_manager, vegetables_snap) == 0
 
     # Delete all objects and re-load the fruits table
-    object_manager.run_eviction(object_manager.get_full_object_tree(), [], None)
+    object_manager.run_eviction([], None)
     assert len(object_manager.get_downloaded_objects()) == 0
     assert object_manager.get_cache_occupancy() == 0
     with object_manager.ensure_objects(fruits_v3):
@@ -179,7 +179,7 @@ def test_object_cache_eviction(local_engine_empty, pg_repo_remote):
         assert len(object_manager.get_downloaded_objects()) == 1
 
     # Loading the next version (DIFF + SNAP) (not enough space for 2 objects).
-    object_manager.run_eviction(object_manager.get_full_object_tree(), [], None)
+    object_manager.run_eviction([], None)
     with pytest.raises(SplitGraphException) as ex:
         with object_manager.ensure_objects(fruits_v3):
             pass
@@ -207,7 +207,7 @@ def test_object_cache_locally_created_dont_get_evicted(local_engine_empty, pg_re
     assert object_manager.get_cache_occupancy() == 8192 * 4  # 5 objects on the engine, 1 of them was created locally.
 
     # Evict all objects -- check to see the one we created still exists.
-    object_manager.run_eviction(object_manager.get_full_object_tree(), keep_objects=[], required_space=None)
+    object_manager.run_eviction(keep_objects=[], required_space=None)
     downloaded = object_manager.get_downloaded_objects()
     assert len(downloaded) == 1
     assert fruits_v4.objects[0] in downloaded
@@ -235,7 +235,7 @@ def test_object_cache_nested(local_engine_empty, pg_repo_remote):
             assert len(object_manager.get_downloaded_objects()) == 3
 
     # Now evict everything from the cache.
-    object_manager.run_eviction(object_manager.get_full_object_tree(), keep_objects=[], required_space=None)
+    object_manager.run_eviction(keep_objects=[], required_space=None)
     assert len(object_manager.get_downloaded_objects()) == 0
 
     object_manager.cache_size = 8192 * 2


### PR DESCRIPTION
* Moved the full-table lock slightly earlier (when we calculate the size of objects we need to download and whether we need to free any space in the cache) so that multiple object managers don't try to evict the same amount of space one after another
* Flipped the bookkeeping order during the actual eviction: first, delete the objects from the cache status table, then delete the physical objects (physical object deletion can commit several times as with large amounts of tables to be deleted we exhaust the pg's lock limit in one tx). This fixes multiple object managers thinking that they've freed more space than they actually have (as they try to delete the same tables), underestimating the cache occupancy (the value stored in `object_cache_occupancy` diverges from the actual occupancy)
* Actually recalculate the list of objects this instance is supposed to be downloading and relock those rows (using SELECT FOR UPDATE) to fix multiple object managers downloading the same objects at the same time + not waiting for an object to be downloaded
* Add SG_EVICTION_FRACTION: by default, every eviction clears out 5% of the cache (if that number is greater than the amount we actually need to free). This is to avoid every download having to run eviction when the cache is saturated.
* Extra logging: log the PID of the calling process, log the min/max last used timestamps of objects that are being evicted.