### PR TITLE
Feature/push pull api

### DIFF
--- a/splitgraph/commandline/example.py
+++ b/splitgraph/commandline/example.py
@@ -4,7 +4,9 @@ Command line routines generating example data / Splitfiles
 from random import getrandbits
 
 import click
-from splitgraph.core import Repository, repository_exists, ResultShape, Identifier, SQL, select
+
+from splitgraph.engine import ResultShape
+from splitgraph.core import Repository, repository_exists, Identifier, SQL, select
 
 _DEMO_TABLE_SIZE = 10
 _DEMO_CHANGE_SIZE = 2

--- a/splitgraph/commandline/image_creation.py
+++ b/splitgraph/commandline/image_creation.py
@@ -6,10 +6,10 @@ import sys
 from collections import defaultdict
 
 import click
+
 from splitgraph import SplitGraphException
 from splitgraph.core.engine import repository_exists
 from splitgraph.core.repository import Repository
-
 from ._common import image_spec_parser
 
 
@@ -86,9 +86,8 @@ def commit_c(repository, snap, chunk_size, split_changesets, message):
 @click.command(name='tag')
 @click.argument('image_spec', type=image_spec_parser(default=None))
 @click.argument('tag', required=False)
-@click.option('-f', '--force', required=False, is_flag=True, help="Overwrite the tag if it already exists.")
 @click.option('-r', '--remove', required=False, is_flag=True, help="Remove the tag instead.")
-def tag_c(image_spec, tag, force, remove):
+def tag_c(image_spec, tag, remove):
     """
     Manage tags on images.
 
@@ -108,7 +107,7 @@ def tag_c(image_spec, tag, force, remove):
     ``sgr tag noaa/climate:abcdef1234567890 my_new_tag``
 
     Tag the image ``noaa/climate:abcdef1234567890...`` with ``my_new_tag``. If the tag already exists, this will
-    raise an error, unless ``-f`` is passed, which will overwrite the tag.
+    overwrite the tag.
 
     ``sgr tag noaa/climate my_new_tag``
 
@@ -151,7 +150,7 @@ def tag_c(image_spec, tag, force, remove):
     else:
         image = repository.images[image]
 
-    image.tag(tag, force)
+    image.tag(tag)
     print("Tagged %s:%s with %s." % (str(repository), image.image_hash, tag))
 
 

--- a/splitgraph/config/__init__.py
+++ b/splitgraph/config/__init__.py
@@ -25,6 +25,7 @@ PG_USER = CONFIG["SG_ENGINE_USER"]
 PG_PWD = CONFIG["SG_ENGINE_PWD"]
 SPLITGRAPH_META_SCHEMA = CONFIG["SG_META_SCHEMA"]
 REGISTRY_META_SCHEMA = "registry_meta"
+SPLITGRAPH_API_SCHEMA = "splitgraph_api"
 
 # Log timestamp and PID. By default we only log WARNINGs in the command line interface.
 logging.basicConfig(format='%(asctime)s [%(process)d] %(levelname)s %(message)s', level=CONFIG["SG_LOGLEVEL"])

--- a/splitgraph/core/_common.py
+++ b/splitgraph/core/_common.py
@@ -235,7 +235,7 @@ def _create_metadata_schema(engine):
                    return_shape=None)
 
 
-def select(table, columns='*', where='', schema=SPLITGRAPH_META_SCHEMA):
+def select(table, columns='*', where='', schema=SPLITGRAPH_META_SCHEMA, table_args=None):
     """
     A generic SQL SELECT constructor to simplify metadata access queries so that we don't have to repeat the same
     identifiers everywhere.
@@ -244,9 +244,13 @@ def select(table, columns='*', where='', schema=SPLITGRAPH_META_SCHEMA):
     :param columns: Columns to select as a string. WARN: concatenated directly without any formatting.
     :param where: If specified, added to the query with a "WHERE" keyword. WARN also concatenated directly.
     :param schema: Defaults to SPLITGRAPH_META_SCHEMA.
+    :param table_args: If specified, appends to the FROM clause after the table specification,
+        for example, SELECT * FROM "splitgraph_api"."get_images" (%s, %s) ...
     :return: A psycopg2.sql.SQL object with the query.
     """
     query = SQL("SELECT " + columns + " FROM {}.{}").format(Identifier(schema), Identifier(table))
+    if table_args:
+        query += SQL(table_args)
     if where:
         query += SQL(" WHERE " + where)
     return query

--- a/splitgraph/core/_common.py
+++ b/splitgraph/core/_common.py
@@ -204,12 +204,14 @@ def _create_metadata_schema(engine):
     # in S3/some FTP/HTTP server/torrent etc.
     # Lookup path to resolve an object on checkout: local -> this table -> remote (so that we don't bombard
     # the remote with queries for tables that may have been uploaded to a different place).
-    engine.run_sql(SQL("""CREATE TABLE {}.{} (
+    engine.run_sql(SQL("""CREATE TABLE {0}.{1} (
                     object_id          VARCHAR NOT NULL,
                     location           VARCHAR NOT NULL,
                     protocol           VARCHAR NOT NULL,
-                    PRIMARY KEY (object_id))""").format(Identifier(SPLITGRAPH_META_SCHEMA),
-                                                        Identifier("object_locations")),
+                    PRIMARY KEY (object_id),
+                    CONSTRAINT ol_fk FOREIGN KEY (object_id) REFERENCES {0}.{2})
+                    """).format(Identifier(SPLITGRAPH_META_SCHEMA), Identifier("object_locations"),
+                                Identifier("objects")),
                    return_shape=None)
 
     # Miscellaneous key-value information for this engine (e.g. whether uploading objects is permitted etc).

--- a/splitgraph/core/engine.py
+++ b/splitgraph/core/engine.py
@@ -4,10 +4,10 @@ Routines for managing Splitgraph engines, including looking up repositories and 
 import logging
 
 from psycopg2.sql import SQL, Identifier
-from splitgraph.config import SPLITGRAPH_META_SCHEMA, CONFIG
-from splitgraph.engine import ResultShape, get_engine
-from splitgraph.exceptions import SplitGraphException
 
+from splitgraph.config import SPLITGRAPH_META_SCHEMA, CONFIG, SPLITGRAPH_API_SCHEMA
+from splitgraph.engine import get_engine
+from splitgraph.exceptions import SplitGraphException
 from ._common import select, ensure_metadata_schema
 
 
@@ -49,14 +49,9 @@ def repository_exists(repository):
 
     :param repository: Repository object
     """
-    return repository.engine.run_sql(SQL("SELECT 1 FROM {}.images WHERE namespace = %s AND repository = %s")
-                                     .format(Identifier(SPLITGRAPH_META_SCHEMA)),
-                                     (repository.namespace, repository.repository),
-                                     return_shape=ResultShape.ONE_ONE) is not None or \
-           repository.engine.run_sql(SQL("SELECT 1 FROM {}.tags WHERE namespace = %s AND repository = %s")
-                                     .format(Identifier(SPLITGRAPH_META_SCHEMA)),
-                                     (repository.namespace, repository.repository),
-                                     return_shape=ResultShape.ONE_ONE) is not None
+    return repository.engine.run_sql(SQL("SELECT 1 FROM {}.get_images(%s,%s)")
+                                     .format(Identifier(SPLITGRAPH_API_SCHEMA)),
+                                     (repository.namespace, repository.repository)) is not None
 
 
 def lookup_repository(name, include_local=False):

--- a/splitgraph/core/engine.py
+++ b/splitgraph/core/engine.py
@@ -6,7 +6,7 @@ import logging
 from psycopg2.sql import SQL, Identifier
 
 from splitgraph.config import SPLITGRAPH_META_SCHEMA, CONFIG, SPLITGRAPH_API_SCHEMA
-from splitgraph.engine import get_engine
+from splitgraph.engine import get_engine, ResultShape
 from splitgraph.exceptions import SplitGraphException
 from ._common import select, ensure_metadata_schema
 
@@ -51,7 +51,8 @@ def repository_exists(repository):
     """
     return repository.engine.run_sql(SQL("SELECT 1 FROM {}.get_images(%s,%s)")
                                      .format(Identifier(SPLITGRAPH_API_SCHEMA)),
-                                     (repository.namespace, repository.repository)) is not None
+                                     (repository.namespace, repository.repository),
+                                     return_shape=ResultShape.ONE_ONE) is not None
 
 
 def lookup_repository(name, include_local=False):

--- a/splitgraph/core/fragment_manager.py
+++ b/splitgraph/core/fragment_manager.py
@@ -82,6 +82,7 @@ class FragmentManager:
     """
 
     def __init__(self, object_engine, metadata_engine=None):
+        super().__init__(object_engine, metadata_engine)
         self.object_engine = object_engine
         self.metadata_engine = metadata_engine or object_engine
 

--- a/splitgraph/core/image.py
+++ b/splitgraph/core/image.py
@@ -8,7 +8,7 @@ from random import getrandbits
 from psycopg2.extras import Json
 from psycopg2.sql import SQL, Identifier
 
-from splitgraph.config import SPLITGRAPH_META_SCHEMA, CONFIG
+from splitgraph.config import SPLITGRAPH_META_SCHEMA, CONFIG, SPLITGRAPH_API_SCHEMA
 from splitgraph.engine import ResultShape
 from splitgraph.exceptions import SplitGraphException
 from splitgraph.hooks.mount_handlers import init_fdw
@@ -60,26 +60,18 @@ class Image(namedtuple('Image', IMAGE_COLS + ['repository', 'engine', 'object_en
     def get_table(self, table_name):
         """
         Returns a Table object representing a version of a given table.
-        Contains a list of objects that the table is linked to: a DIFF object (beginning a chain of DIFFs that
-        describe a table), a SNAP object (a full table copy), or both.
+        Contains a list of objects that the table is linked to and the table's schema.
 
         :param table_name: Name of the table
         :return: Table object or None
         """
-        objects = self.engine.run_sql(SQL("""SELECT {0}.tables.object_ids FROM {0}.tables WHERE
-                                             {0}.tables.namespace = %s AND repository = %s AND image_hash = %s
-                                              AND table_name = %s""")
-                                      .format(Identifier(SPLITGRAPH_META_SCHEMA)),
-                                      (self.repository.namespace, self.repository.repository,
-                                       self.image_hash, table_name),
-                                      return_shape=ResultShape.ONE_ONE)
-        if not objects:
+        result = self.engine.run_sql(select("get_tables", "table_schema,object_ids", "table_name = %s",
+                                            table_args="(%s,%s,%s)", schema=SPLITGRAPH_API_SCHEMA),
+                                     (self.repository.namespace, self.repository.repository,
+                                      self.image_hash, table_name), return_shape=ResultShape.ONE_MANY)
+        if not result:
             return None
-        table_schema = self.engine.run_sql(SQL("SELECT table_schema FROM {}.tables WHERE namespace = %s "
-                                               "AND repository = %s AND image_hash = %s AND table_name = %s")
-                                           .format(Identifier(SPLITGRAPH_META_SCHEMA)),
-                                           (self.repository.namespace, self.repository.repository,
-                                            self.image_hash, table_name), return_shape=ResultShape.ONE_ONE)
+        table_schema, objects = result
         return Table(self.repository, self, table_name, table_schema, objects)
 
     @manage_audit

--- a/splitgraph/core/image.py
+++ b/splitgraph/core/image.py
@@ -160,14 +160,14 @@ class Image(namedtuple('Image', IMAGE_COLS + ['repository', 'engine', 'object_en
                 SQL("DROP SCHEMA IF EXISTS {} CASCADE; DROP SERVER IF EXISTS {} CASCADE;").format(
                 Identifier(tmp_schema), Identifier(tmp_schema + '_lq_checkout_server')))
 
-    def tag(self, tag, force=False):
+    def tag(self, tag):
         """
-        Tags a given image. All tags are unique inside of a repository.
+        Tags a given image. All tags are unique inside of a repository. If a tag already exists, it's removed
+        from the previous image and given to the new image.
 
         :param tag: Tag to set. 'latest' and 'HEAD' are reserved tags.
-        :param force: Whether to remove the old tag if an image with this tag already exists.
         """
-        set_tag(self.repository, self.image_hash, tag, force)
+        set_tag(self.repository, self.image_hash, tag)
 
     def get_tags(self):
         """Lists all tags that this image has."""

--- a/splitgraph/core/metadata_manager.py
+++ b/splitgraph/core/metadata_manager.py
@@ -87,9 +87,8 @@ class MetadataManager:
         :param objects: List of objects stored externally.
         :return: List of (object_id, location, protocol).
         """
-        return self.metadata_engine.run_sql(select("object_locations", "object_id, location, protocol",
-                                                   "object_id IN (" + ','.join('%s' for _ in objects) + ")"),
-                                            objects)
+        return self.metadata_engine.run_sql(select("get_object_locations", "object_id, location, protocol",
+                                                   schema=SPLITGRAPH_API_SCHEMA, table_args="(%s)"), (objects,))
 
     def get_object_meta(self, objects):
         """
@@ -98,5 +97,7 @@ class MetadataManager:
         :param objects: List of objects to get metadata for.
         :return: List of (object_id, format, parent_id, namespace, size, index).
         """
-        return self.metadata_engine.run_sql(select("objects", "object_id, format, parent_id, namespace, size, index",
-                                                   "object_id IN (" + ','.join('%s' for _ in objects) + ")"), objects)
+
+        return self.metadata_engine.run_sql(select("get_object_meta",
+                                                   "object_id, format, parent_id, namespace, size, index",
+                                                   schema=SPLITGRAPH_API_SCHEMA, table_args="(%s)"), (objects,))

--- a/splitgraph/core/metadata_manager.py
+++ b/splitgraph/core/metadata_manager.py
@@ -94,6 +94,8 @@ class MetadataManager:
         :param objects: List of objects to get metadata for.
         :return: List of (object_id, format, parent_id, namespace, size, index).
         """
+        if not objects:
+            return []
 
         return self.metadata_engine.run_sql(select("get_object_meta",
                                                    "object_id, format, parent_id, namespace, size, index",

--- a/splitgraph/core/object_manager.py
+++ b/splitgraph/core/object_manager.py
@@ -480,7 +480,7 @@ class ObjectManager(FragmentManager, MetadataManager):
                     primary_objects.update(new_parents)
 
         # Go through the tables that aren't repository-dependent and delete entries there.
-        for table_name in ['objects', 'object_locations', 'object_cache_status']:
+        for table_name in ['object_locations', 'object_cache_status', 'objects']:
             query = SQL("DELETE FROM {}.{}").format(Identifier(SPLITGRAPH_META_SCHEMA), Identifier(table_name))
             if primary_objects:
                 query += SQL(" WHERE object_id NOT IN (" + ','.join('%s' for _ in range(len(primary_objects))) + ")")

--- a/splitgraph/core/object_manager.py
+++ b/splitgraph/core/object_manager.py
@@ -441,10 +441,8 @@ class ObjectManager(FragmentManager, MetadataManager):
         if handler_params is None:
             handler_params = {}
 
-        # Get objects that exist on the remote engine
-        existing_objects = target.get_existing_objects()
-
-        objects_to_push = list(set(o for o in objects_to_push if o not in existing_objects))
+        # Check which objects we need to push out
+        objects_to_push = target.get_new_objects(objects_to_push)
         if not objects_to_push:
             logging.info("Nothing to upload.")
             return []

--- a/splitgraph/core/registry.py
+++ b/splitgraph/core/registry.py
@@ -5,7 +5,7 @@ Functions for communicating with the remote Splitgraph catalog
 from psycopg2.extras import Json
 from psycopg2.sql import SQL, Identifier
 
-from splitgraph.config import REGISTRY_META_SCHEMA, SPLITGRAPH_META_SCHEMA
+from splitgraph.config import REGISTRY_META_SCHEMA, SPLITGRAPH_META_SCHEMA, SPLITGRAPH_API_SCHEMA
 from splitgraph.core._common import select, insert
 from splitgraph.engine import ResultShape
 
@@ -136,6 +136,8 @@ def setup_registry_mode(engine):
         # Grant everything by default -- RLS will supersede these.
         engine.run_sql(SQL("GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA {} TO PUBLIC")
                        .format(Identifier(schema)))
+
+    engine.run_sql(SQL("GRANT USAGE ON SCHEMA {} TO PUBLIC").format(Identifier(SPLITGRAPH_API_SCHEMA)))
 
     engine.run_sql(SQL("REVOKE INSERT, DELETE, UPDATE ON TABLE {}.info FROM PUBLIC").format(
         Identifier(SPLITGRAPH_META_SCHEMA)))

--- a/splitgraph/core/registry.py
+++ b/splitgraph/core/registry.py
@@ -144,15 +144,7 @@ def setup_registry_mode(engine):
     engine.run_sql(SQL("ALTER DEFAULT PRIVILEGES IN SCHEMA {} GRANT SELECT ON TABLES TO PUBLIC")
                    .format(Identifier(SPLITGRAPH_META_SCHEMA)))
 
-    for table in _RLS_TABLES:
-        _setup_rls_policies(engine, table)
-
-    # Object_locations is different, since we have to refer to the objects table for the namespace of the object
-    # whose location we're changing.
-    test_query = """(EXISTS (SELECT object_id FROM {0}.objects
-                        WHERE {0}.objects.namespace = current_user
-                        AND object_id = {0}.{1}.object_id))"""
-    _setup_rls_policies(engine, "object_locations", condition=test_query)
+    # Set up RLS policies on the registry schema
     _setup_rls_policies(engine, "images", schema=REGISTRY_META_SCHEMA)
 
     set_info_key(engine, "registry_mode", "true")

--- a/splitgraph/core/registry.py
+++ b/splitgraph/core/registry.py
@@ -120,27 +120,25 @@ def setup_registry_mode(engine):
 
     * Normal users aren't allowed to create tables/schemata (can't do checkouts inside of a registry or
       upload SG objects directly to it)
-    * images/tables/tags meta tables: can only create/update/delete records where the namespace = user ID
-    * objects/object_location tables: same. An object (piece of data) becomes owned by the user that creates
-      it and still remains so even if someone else's image starts using it. Hence, the original owner can delete
-      or change it (since they control the external location they've uploaded it to anyway).
+    * Normal users can't access the splitgraph_meta schema directly: they're only supposed to be able to
+      talk to it via stored procedures in splitgraph_api. Those procedures are set up with SECURITY INVOKER
+      (run with those users' credentials) and what they can access is further restricted by RLS:
+      * images/tables/tags meta tables: can only create/update/delete records where the namespace = user ID
+      * objects/object_location tables: same. An object (piece of data) becomes owned by the user that creates
+        it and still remains so even if someone else's image starts using it. Hence, the original owner can delete
+        or change it (since they control the external location they've uploaded it to anyway).
 
     """
 
     if get_info_key(engine, "registry_mode") == 'true':
         return
 
-    for schema in (SPLITGRAPH_META_SCHEMA, REGISTRY_META_SCHEMA):
+    for schema in (SPLITGRAPH_META_SCHEMA, REGISTRY_META_SCHEMA, SPLITGRAPH_API_SCHEMA):
         engine.run_sql(SQL("REVOKE CREATE ON SCHEMA {} FROM PUBLIC").format(Identifier(schema)))
+        # Allow schema usage (including splitgraph_meta) but don't actually allow writing to
+        # tables. This is so that users can still download objects that are stored directly
+        # on the registry.
         engine.run_sql(SQL("GRANT USAGE ON SCHEMA {} TO PUBLIC").format(Identifier(schema)))
-        # Grant everything by default -- RLS will supersede these.
-        engine.run_sql(SQL("GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA {} TO PUBLIC")
-                       .format(Identifier(schema)))
-
-    engine.run_sql(SQL("GRANT USAGE ON SCHEMA {} TO PUBLIC").format(Identifier(SPLITGRAPH_API_SCHEMA)))
-
-    engine.run_sql(SQL("REVOKE INSERT, DELETE, UPDATE ON TABLE {}.info FROM PUBLIC").format(
-        Identifier(SPLITGRAPH_META_SCHEMA)))
 
     # Allow everyone to read objects that have been uploaded
     engine.run_sql(SQL("ALTER DEFAULT PRIVILEGES IN SCHEMA {} GRANT SELECT ON TABLES TO PUBLIC")

--- a/splitgraph/core/repository.py
+++ b/splitgraph/core/repository.py
@@ -483,16 +483,15 @@ class Repository:
         return self.engine.run_sql(select("get_tagged_images", "image_hash, tag", schema=SPLITGRAPH_API_SCHEMA,
                                           table_args="(%s,%s)"), (self.namespace, self.repository))
 
-    def set_tags(self, tags, force=False):
+    def set_tags(self, tags):
         """
         Sets tags for multiple images.
 
         :param tags: List of (image_hash, tag)
-        :param force: Whether to remove the old tag if an image with this tag already exists.
         """
         for tag, image_id in tags.items():
             if tag != 'HEAD':
-                self.images.by_hash(image_id).tag(tag, force)
+                self.images.by_hash(image_id).tag(tag)
 
     def run_sql(self, sql, arguments=None, return_shape=ResultShape.MANY_MANY):
         """Execute an arbitrary SQL statement inside of this repository's checked out schema."""
@@ -891,7 +890,7 @@ def _sync(target, source, download=True, download_all=False, handler='DB', handl
 
     # Register the new tables / tags.
     target.objects.register_tables(target, table_meta)
-    target.set_tags(tags, force=False)
+    target.set_tags(tags)
 
     print(("Fetched" if download else "Uploaded") +
           " metadata for %d object(s), %d table version(s) and %d tag(s)." % (len(object_meta), len(table_meta),

--- a/splitgraph/core/repository.py
+++ b/splitgraph/core/repository.py
@@ -516,8 +516,7 @@ class Repository:
 
         # Get required objects
         required_objects = set()
-        for image_hash in self.images:
-            image = self.images.by_hash(image_hash)
+        for image in self.images:
             for table_name in image.get_tables():
                 for object_id in image.get_table(table_name).objects:
                     required_objects.add(object_id)

--- a/splitgraph/core/repository.py
+++ b/splitgraph/core/repository.py
@@ -15,8 +15,8 @@ from splitgraph.config import SPLITGRAPH_META_SCHEMA, SPLITGRAPH_API_SCHEMA
 from splitgraph.core.fragment_manager import get_random_object_id
 from splitgraph.exceptions import SplitGraphException
 from ._common import manage_audit_triggers, set_head, manage_audit, select, insert, aggregate_changes, slow_diff, \
-    prepare_publish_data, gather_sync_metadata
-from .engine import repository_exists, lookup_repository, ResultShape, get_engine
+    prepare_publish_data, gather_sync_metadata, ResultShape
+from .engine import repository_exists, lookup_repository, get_engine
 from .image import Image, IMAGE_COLS
 from .object_manager import ObjectManager
 from .registry import publish_tag

--- a/splitgraph/core/repository.py
+++ b/splitgraph/core/repository.py
@@ -32,9 +32,9 @@ class ImageManager:
     def __call__(self):
         """Get all Image objects in the repository."""
         result = []
-        for image in self.engine.run_sql(select("images", ','.join(IMAGE_COLS), "repository = %s AND namespace = %s") +
-                                         SQL(" ORDER BY created"),
-                                         (self.repository.repository, self.repository.namespace)):
+        for image in self.engine.run_sql(select("get_images", ','.join(IMAGE_COLS), schema=SPLITGRAPH_API_SCHEMA,
+                                                table_args="(%s, %s)"),
+                                         (self.repository.namespace, self.repository.repository)):
             result.append(self._make_image(image))
         return result
 

--- a/splitgraph/core/repository.py
+++ b/splitgraph/core/repository.py
@@ -149,11 +149,10 @@ class ImageManager:
             (one of None, FROM, MOUNT, IMPORT, SQL)
         :param provenance_data: Extra provenance data (dictionary).
         """
-        self.engine.run_sql(
-            insert("images", ("image_hash", "namespace", "repository", "parent_id", "created", "comment",
-                              "provenance_type", "provenance_data")),
-            (image, self.repository.namespace, self.repository.repository, parent_id, created or datetime.now(),
-             comment, provenance_type, Json(provenance_data)))
+        self.engine.run_sql(SQL("SELECT {}.add_image(%s, %s, %s, %s, %s, %s, %s, %s)")
+                            .format(Identifier(SPLITGRAPH_API_SCHEMA)),
+                            (self.repository.namespace, self.repository.repository, image, parent_id,
+                             created or datetime.now(), comment, provenance_type, Json(provenance_data)))
 
     def delete(self, images):
         """

--- a/splitgraph/core/repository.py
+++ b/splitgraph/core/repository.py
@@ -11,7 +11,7 @@ from random import getrandbits
 from psycopg2.extras import Json
 from psycopg2.sql import SQL, Identifier
 
-from splitgraph.config import SPLITGRAPH_META_SCHEMA
+from splitgraph.config import SPLITGRAPH_META_SCHEMA, SPLITGRAPH_API_SCHEMA
 from splitgraph.core.fragment_manager import get_random_object_id
 from splitgraph.exceptions import SplitGraphException
 from ._common import manage_audit_triggers, set_head, manage_audit, select, insert, ensure_metadata_schema, \
@@ -861,6 +861,10 @@ def _sync(target, source, download=True, download_all=False, handler='DB', handl
     if not new_images:
         logging.info("Nothing to do.")
         return
+
+    for image in new_images:
+        target.images.add(image.parent_id, image.image_hash, image.created, image.comment, image.provenance_type,
+                          image.provenance_data)
 
     if download:
         # Don't actually download any real objects until the user tries to check out a revision.

--- a/splitgraph/core/repository.py
+++ b/splitgraph/core/repository.py
@@ -527,7 +527,7 @@ class Repository:
                     required_objects.add(object_id)
 
         # Expand the required objects into a full set
-        all_required_objects = set(self.objects.get_all_required_objects(required_objects))
+        all_required_objects = set(self.objects.get_all_required_objects(list(required_objects)))
 
         object_qual = "object_id IN (" + ",".join(itertools.repeat('%s', len(all_required_objects))) + ")"
 

--- a/splitgraph/core/repository.py
+++ b/splitgraph/core/repository.py
@@ -481,8 +481,8 @@ class Repository:
 
         :return: List of (image_hash, tag)
         """
-        return self.engine.run_sql(select("tags", "image_hash, tag", "namespace = %s AND repository = %s"),
-                                   (self.namespace, self.repository,))
+        return self.engine.run_sql(select("get_tagged_images", "image_hash, tag", schema=SPLITGRAPH_API_SCHEMA,
+                                          table_args="(%s,%s)"), (self.namespace, self.repository))
 
     def set_tags(self, tags, force=False):
         """

--- a/splitgraph/core/repository.py
+++ b/splitgraph/core/repository.py
@@ -30,7 +30,7 @@ class ImageManager:
         self.engine = repository.engine
 
     def __call__(self):
-        """Get all Image objects in the repository."""
+        """Get all Image objects in the repository, ordered by their creation time (earliest first)."""
         result = []
         for image in self.engine.run_sql(select("get_images", ','.join(IMAGE_COLS), schema=SPLITGRAPH_API_SCHEMA,
                                                 table_args="(%s, %s)"),

--- a/splitgraph/engine/postgres/engine.py
+++ b/splitgraph/engine/postgres/engine.py
@@ -22,6 +22,7 @@ from splitgraph.hooks.mount_handlers import mount_postgres
 
 _AUDIT_SCHEMA = 'audit'
 _AUDIT_TRIGGER = 'resources/audit_trigger.sql'
+_PUSH_PULL = 'resources/push_pull.sql'
 _PACKAGE = 'splitgraph'
 ROW_TRIGGER_NAME = "audit_trigger_row"
 STM_TRIGGER_NAME = "audit_trigger_stm"
@@ -184,6 +185,11 @@ class PsycopgEngine(SQLEngine):
                     cur.execute(SQL("CREATE DATABASE {}").format(Identifier(pg_db)))
                 else:
                     logging.info("Database %s already exists, skipping", pg_db)
+
+        # Install the push/pull API functions
+        logging.info("Installing the push/pull API functions...")
+        push_pull = get_data(_PACKAGE, _PUSH_PULL)
+        self.run_sql(push_pull.decode('utf-8'), return_shape=ResultShape.NONE)
 
         # Install the audit trigger if it doesn't exist
         if not self.schema_exists(_AUDIT_SCHEMA):

--- a/splitgraph/resources/push_pull.sql
+++ b/splitgraph/resources/push_pull.sql
@@ -66,6 +66,37 @@ BEGIN
 END
 $$ LANGUAGE plpgsql SECURITY INVOKER;
 
+-- get_object_meta(object_ids): get metadata for objects
+CREATE OR REPLACE FUNCTION splitgraph_api.get_object_meta(object_ids varchar[])
+  RETURNS TABLE (
+    object_id VARCHAR,
+    format    VARCHAR,
+    parent_id VARCHAR,
+    namespace VARCHAR,
+    size      BIGINT,
+    index     JSONB) AS $$
+BEGIN
+   RETURN QUERY
+   SELECT o.object_id, o.format, o.parent_id, o.namespace, o.size, o.index
+   FROM splitgraph_meta.objects o
+   WHERE o.object_id = ANY(object_ids);
+END
+$$ LANGUAGE plpgsql SECURITY INVOKER;
+
+-- get_object_locations(object_ids): get external locations for objects
+CREATE OR REPLACE FUNCTION splitgraph_api.get_object_locations(object_ids varchar[])
+  RETURNS TABLE (
+    object_id VARCHAR,
+    location  VARCHAR,
+    protocol  VARCHAR) AS $$
+BEGIN
+   RETURN QUERY
+   SELECT o.object_id, o.location, o.protocol
+   FROM splitgraph_meta.object_locations o
+   WHERE o.object_id = ANY(object_ids);
+END
+$$ LANGUAGE plpgsql SECURITY INVOKER;
+
 
 --
 -- TABLE API

--- a/splitgraph/resources/push_pull.sql
+++ b/splitgraph/resources/push_pull.sql
@@ -20,7 +20,7 @@ BEGIN
    WHERE i.namespace = _namespace and i.repository = _repository
    ORDER BY created ASC;
 END
-$$ LANGUAGE plpgsql SECURITY DEFINER;
+$$ LANGUAGE plpgsql SECURITY INVOKER;
 
 CREATE OR REPLACE FUNCTION splitgraph_api.get_object_path(object_ids varchar[]) RETURNS varchar[] AS $$
 BEGIN
@@ -30,4 +30,17 @@ BEGIN
             FROM parents p JOIN splitgraph_meta.objects o ON p.parent_id = o.object_id)
         SELECT object_id FROM parents);
 END
-$$ LANGUAGE plpgsql SECURITY DEFINER;
+$$ LANGUAGE plpgsql SECURITY INVOKER;
+
+CREATE OR REPLACE FUNCTION splitgraph_api.get_tables(_namespace varchar, _repository varchar, _image_hash varchar)
+  RETURNS TABLE (
+    table_name VARCHAR,
+    table_schema JSONB,
+    object_ids VARCHAR[]) AS $$
+BEGIN
+  RETURN QUERY
+  SELECT t.table_name, t.table_schema, t.object_ids
+  FROM splitgraph_meta.tables t
+  WHERE t.namespace = _namespace AND t.repository = _repository AND t._image_hash = image_hash
+END
+$$ LANGUAGE plpgsql SECURITY INVOKER;

--- a/splitgraph/resources/push_pull.sql
+++ b/splitgraph/resources/push_pull.sql
@@ -1,0 +1,33 @@
+-- API functions to access various parts of splitgraph_meta related to downloading and uploading images.
+-- Serves as a level of indirection between Splitgraph push/pull logic and the organisation of the actual
+-- SQL tables.
+
+DROP SCHEMA IF EXISTS splitgraph_api CASCADE;
+CREATE SCHEMA splitgraph_api;
+
+CREATE OR REPLACE FUNCTION splitgraph_api.get_images(_namespace varchar, _repository varchar)
+  RETURNS TABLE (
+    image_hash      VARCHAR,
+    parent_id       VARCHAR,
+    created         TIMESTAMP,
+    comment         VARCHAR,
+    provenance_type VARCHAR,
+    provenance_data JSONB) AS $$
+BEGIN
+   RETURN QUERY
+   SELECT i.image_hash, i.parent_id, i.created, i.comment, i.provenance_type, i.provenance_data
+   FROM splitgraph_meta.images i
+   WHERE i.namespace = _namespace and i.repository = _repository
+   ORDER BY created ASC;
+END
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+CREATE OR REPLACE FUNCTION splitgraph_api.get_object_path(object_ids varchar[]) RETURNS varchar[] AS $$
+BEGIN
+    RETURN ARRAY(WITH RECURSIVE parents AS
+        (SELECT object_id, parent_id FROM splitgraph_meta.objects WHERE object_id = ANY(object_ids)
+            UNION ALL SELECT o.object_id, o.parent_id
+            FROM parents p JOIN splitgraph_meta.objects o ON p.parent_id = o.object_id)
+        SELECT object_id FROM parents);
+END
+$$ LANGUAGE plpgsql SECURITY DEFINER;

--- a/splitgraph/resources/push_pull.sql
+++ b/splitgraph/resources/push_pull.sql
@@ -205,3 +205,42 @@ BEGIN
     VALUES (namespace, repository, image_hash, table_name, table_schema, object_ids);
 END
 $$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = splitgraph_meta, pg_temp;
+
+--
+-- PUBLISH API
+--
+
+-- publish_image(namespace, repository, tag, image_hash, published, provenance, readme, schemata, previews)
+CREATE OR REPLACE FUNCTION splitgraph_api.publish_image(
+    namespace varchar, repository varchar, tag varchar, image_hash varchar, published timestamp, provenance json,
+    readme varchar, schemata json, previews json) RETURNS void AS $$
+BEGIN
+    PERFORM splitgraph_api.check_privilege(namespace);
+    INSERT INTO registry_meta.images(namespace, repository, tag, image_hash, published, provenance, readme, schemata,
+        previews)
+    VALUES (namespace, repository, tag, image_hash, published, provenance, readme, schemata, previews);
+END
+$$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = registry_meta, pg_temp;
+
+CREATE OR REPLACE FUNCTION splitgraph_api.get_published_image(_namespace varchar, _repository varchar, _tag varchar)
+  RETURNS TABLE (
+    image_hash VARCHAR,
+    published  TIMESTAMP,
+    provenance JSON,
+    readme     VARCHAR,
+    schemata   JSON,
+    previews   JSON) AS $$
+BEGIN
+   RETURN QUERY
+   SELECT i.image_hash, i.published, i.provenance, i.readme, i.schemata, i.previews
+   FROM registry_meta.images i
+   WHERE i.namespace = _namespace AND i.repository = _repository AND i.tag = _tag;
+END
+$$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = registry_meta, pg_temp;
+
+CREATE OR REPLACE FUNCTION splitgraph_api.unpublish_repository(_namespace varchar, _repository varchar)
+RETURNS void AS $$ BEGIN
+    PERFORM splitgraph_api.check_privilege(_namespace);
+    DELETE FROM registry_meta.images WHERE namespace = _namespace AND repository = _repository;
+END
+$$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = registry_meta, pg_temp;

--- a/splitgraph/resources/push_pull.sql
+++ b/splitgraph/resources/push_pull.sql
@@ -167,7 +167,6 @@ CREATE OR REPLACE FUNCTION splitgraph_api.add_object_location(_object_id varchar
 DECLARE namespace VARCHAR;
 BEGIN
     namespace = (SELECT o.namespace FROM splitgraph_meta.objects o WHERE o.object_id = _object_id);
-    RAISE WARNING 'checking privilege (%) current user (%)', namespace, session_user;
     PERFORM splitgraph_api.check_privilege(namespace);
     INSERT INTO splitgraph_meta.object_locations(object_id, location, protocol)
     VALUES (_object_id, location, protocol);

--- a/test/splitgraph/commands/test_external_objects.py
+++ b/test/splitgraph/commands/test_external_objects.py
@@ -20,8 +20,8 @@ def test_s3_push_pull(local_engine_empty, pg_repo_remote, clean_minio):
 
     # Check that the actual objects don't exist on the remote but are instead registered with an URL.
     # All the objects on pgcache were registered remotely
-    objects = pg_repo_remote.objects.get_existing_objects()
-    local_objects = PG_MNT.objects.get_existing_objects()
+    objects = pg_repo_remote.objects.get_all_objects()
+    local_objects = PG_MNT.objects.get_all_objects()
     assert all(o in objects for o in local_objects)
     # Two non-local objects in the local engine, both registered as non-local on the remote engine.
     ext_objects_orig = PG_MNT.objects.get_external_object_locations(list(objects))
@@ -49,4 +49,4 @@ def test_s3_push_pull(local_engine_empty, pg_repo_remote, clean_minio):
     right.checkout()
     assert len(PG_MNT.objects.get_downloaded_objects()) == 4
     # Only now we actually have all the objects materialized.
-    assert PG_MNT.objects.get_downloaded_objects() == PG_MNT.objects.get_existing_objects()
+    assert PG_MNT.objects.get_downloaded_objects() == PG_MNT.objects.get_all_objects()

--- a/test/splitgraph/commands/test_import.py
+++ b/test/splitgraph/commands/test_import.py
@@ -76,7 +76,7 @@ def test_import_from_remote(local_engine_empty, pg_repo_remote):
     local_objects = OUTPUT.objects
 
     assert len(local_objects.get_downloaded_objects()) == 2
-    assert len(local_objects.get_existing_objects()) == 2
+    assert len(local_objects.get_all_objects()) == 2
     assert local_engine_empty.get_all_tables(OUTPUT.to_schema()) == ['test']
 
     # Import the 'fruits' table from the origin.

--- a/test/splitgraph/commands/test_layered_querying.py
+++ b/test/splitgraph/commands/test_layered_querying.py
@@ -142,9 +142,9 @@ def test_lq_external(local_engine_empty, pg_repo_remote):
     pg_repo_remote.engine.commit()
     pg_repo_local.objects.cleanup()
 
-    assert len(pg_repo_local.objects.get_existing_objects()) == 0
+    assert len(pg_repo_local.objects.get_all_objects()) == 0
     assert len(pg_repo_local.objects.get_downloaded_objects()) == 0
-    assert len(remote.objects.get_existing_objects()) == 6
+    assert len(remote.objects.get_all_objects()) == 6
     assert len(remote.objects.get_downloaded_objects()) == 0
 
     # Proceed as per the previous test

--- a/test/splitgraph/commands/test_layered_querying.py
+++ b/test/splitgraph/commands/test_layered_querying.py
@@ -3,8 +3,9 @@ from datetime import datetime as dt
 import pytest
 
 from splitgraph import Repository
-from splitgraph.core import clone, ResultShape
+from splitgraph.core import clone
 from splitgraph.core._common import META_TABLES
+from splitgraph.engine import ResultShape
 
 
 def prepare_lq_repo(repo, commit_after_every, include_pk, snap_only=False):

--- a/test/splitgraph/commands/test_push_pull.py
+++ b/test/splitgraph/commands/test_push_pull.py
@@ -52,7 +52,7 @@ def test_pulls_with_lazy_object_downloads(local_engine_empty, pg_repo_remote):
 
     PG_MNT.images.by_hash(remote_head.image_hash).checkout()
     assert len(PG_MNT.objects.get_downloaded_objects()) == 2  # Original fruits and vegetables tables.
-    assert PG_MNT.objects.get_downloaded_objects() == PG_MNT.objects.get_existing_objects()
+    assert PG_MNT.objects.get_downloaded_objects() == PG_MNT.objects.get_all_objects()
 
     # In the meantime, make two branches off of origin (a total of 3 commits)
     pg_repo_remote.run_sql("INSERT INTO fruits VALUES (3, 'mayonnaise')")
@@ -65,7 +65,7 @@ def test_pulls_with_lazy_object_downloads(local_engine_empty, pg_repo_remote):
     # Pull from upstream.
     PG_MNT.pull(download_all=False)
     # Make sure we have the pointers to the three versions of the fruits table + the original vegetables
-    assert len(PG_MNT.objects.get_existing_objects()) == 4
+    assert len(PG_MNT.objects.get_all_objects()) == 4
 
     # Also make sure still only have the objects with the original fruits + vegetables tables
     assert len(PG_MNT.objects.get_downloaded_objects()) == 2
@@ -77,7 +77,7 @@ def test_pulls_with_lazy_object_downloads(local_engine_empty, pg_repo_remote):
 
     PG_MNT.images.by_hash(right.image_hash).checkout()
     assert len(PG_MNT.objects.get_downloaded_objects()) == 4  # now have 2 versions of fruits + 1 vegetables
-    assert PG_MNT.objects.get_downloaded_objects() == PG_MNT.objects.get_existing_objects()
+    assert PG_MNT.objects.get_downloaded_objects() == PG_MNT.objects.get_all_objects()
 
 
 def test_push(local_engine_empty, pg_repo_remote):
@@ -95,7 +95,7 @@ def test_push(local_engine_empty, pg_repo_remote):
     PG_MNT.push(remote_repository=pg_repo_remote)
 
     # See if the original mountpoint got updated.
-    assert len(pg_repo_remote.objects.get_existing_objects()) == 3
+    assert len(pg_repo_remote.objects.get_all_objects()) == 3
 
     pg_repo_remote.images.by_hash(head_1.image_hash).checkout()
     assert pg_repo_remote.run_sql("SELECT * FROM fruits") == [(1, 'apple'), (2, 'orange'), (3, 'mayonnaise')]

--- a/test/splitgraph/splitfile/test_execution.py
+++ b/test/splitgraph/splitfile/test_execution.py
@@ -119,7 +119,7 @@ def test_import_updating_splitfile_with_uploading(local_engine_empty, remote_eng
     execute_commands(load_splitfile('import_and_update.splitfile'), output=OUTPUT)
     head = OUTPUT.head
 
-    assert len(OUTPUT.objects.get_existing_objects()) == 4  # Two original tables + two updates
+    assert len(OUTPUT.objects.get_all_objects()) == 4  # Two original tables + two updates
 
     # Push with upload. Have to specify the remote repo.
     remote_output = Repository(OUTPUT.namespace, OUTPUT.repository, remote_engine)
@@ -130,12 +130,12 @@ def test_import_updating_splitfile_with_uploading(local_engine_empty, remote_eng
     # OUTPUT doesn't exist but we use its ObjectManager reference to access the global object
     # manager for the engine (maybe should inject it into local_engine/remote_engine instead)
     OUTPUT.objects.cleanup()
-    assert not OUTPUT.objects.get_existing_objects()
+    assert not OUTPUT.objects.get_all_objects()
 
     clone(OUTPUT.to_schema(), download_all=False)
 
     assert not OUTPUT.objects.get_downloaded_objects()
-    existing_objects = list(OUTPUT.objects.get_existing_objects())
+    existing_objects = list(OUTPUT.objects.get_all_objects())
     assert len(existing_objects) == 4  # Two original tables + two updates
     # Only 2 objects are stored externally (the other two have been on the remote the whole time)
     assert len(OUTPUT.objects.get_external_object_locations(existing_objects)) == 2

--- a/test/splitgraph/test_commandline.py
+++ b/test/splitgraph/test_commandline.py
@@ -274,10 +274,14 @@ def test_commandline_tag_checkout(pg_repo_local):
     assert result.exit_code == 0
     assert pg_repo_local.images['v1'].image_hash == old_head
 
-    # sgr tag <mountpoint> with the same tag -- expect an error
+    # sgr tag <mountpoint> with the same tag -- should move the tag to current HEAD again
     result = runner.invoke(tag_c, [str(pg_repo_local), 'v1'])
-    assert result.exit_code != 0
-    assert 'Tag v1 already exists' in str(result.exc_info)
+    assert result.exit_code == 0
+    assert pg_repo_local.images['v1'].image_hash == new_head
+
+    # Tag the old head again
+    result = runner.invoke(tag_c, [str(pg_repo_local) + ':' + old_head[:10], 'v1'])
+    assert result.exit_code == 0
 
     # list tags
     result = runner.invoke(tag_c, [str(pg_repo_local)])

--- a/test/splitgraph/test_commandline.py
+++ b/test/splitgraph/test_commandline.py
@@ -3,13 +3,14 @@ import subprocess
 from decimal import Decimal
 
 import pytest
-from splitgraph import ResultShape, insert
+
+from splitgraph import ResultShape
 from splitgraph.commandline import *
 from splitgraph.commandline._common import image_spec_parser
 from splitgraph.commandline.example import generate_c, alter_c, splitfile_c
 from splitgraph.commandline.image_info import object_c
 from splitgraph.config import PG_PWD, PG_USER
-from splitgraph.core._common import parse_connection_string, serialize_connection_string
+from splitgraph.core._common import parse_connection_string, serialize_connection_string, insert
 from splitgraph.core.engine import repository_exists
 from splitgraph.core.registry import get_published_info
 from splitgraph.core.repository import Repository

--- a/test/splitgraph/test_drawing.py
+++ b/test/splitgraph/test_drawing.py
@@ -1,9 +1,17 @@
 from splitgraph.core._drawing import render_tree
-from splitgraph.splitfile.execution import execute_commands
+from splitgraph.splitfile.execution import execute_commands, rebuild_image
 from test.splitgraph.conftest import OUTPUT, load_splitfile
 
 
 def test_drawing(pg_repo_local, mg_repo_local):
     # Doesn't really check anything, mostly used to make sure the tree drawing code doesn't throw.
     execute_commands(load_splitfile('import_local.splitfile'), output=OUTPUT)
+
+    # Make another branch to check multi-branch repositories can render.
+    pg_repo_local.images()[1].checkout()
+    pg_repo_local.run_sql("INSERT INTO fruits VALUES (3, 'kiwi')")
+    pg_repo_local.commit()
+
+    rebuild_image(OUTPUT.head, {pg_repo_local: pg_repo_local.head.image_hash})
+
     render_tree(OUTPUT)

--- a/test/splitgraph/test_object_cache.py
+++ b/test/splitgraph/test_object_cache.py
@@ -37,9 +37,9 @@ def _setup_object_cache_test(pg_repo_remote, longer_chain=False):
     pg_repo_local = clone(pg_repo_remote, download_all=False)
 
     # 6 objects in the tree (SNAP -> SNAP -> DIFF for both tables)
-    assert len(pg_repo_local.objects.get_existing_objects()) == 6 if not longer_chain else 7
+    assert len(pg_repo_local.objects.get_all_objects()) == 6 if not longer_chain else 7
     assert len(pg_repo_local.objects.get_downloaded_objects()) == 0
-    assert len(remote.objects.get_existing_objects()) == 6 if not longer_chain else 7
+    assert len(remote.objects.get_all_objects()) == 6 if not longer_chain else 7
     assert len(remote.objects.get_downloaded_objects()) == 0
 
     # Nothing has yet been downloaded (cache entries only for externally downloaded things)

--- a/test/splitgraph/test_object_cache.py
+++ b/test/splitgraph/test_object_cache.py
@@ -2,8 +2,9 @@ from datetime import datetime as dt
 
 import pytest
 
-from splitgraph.core import clone, select, ResultShape, SPLITGRAPH_META_SCHEMA
+from splitgraph.core import clone, select, SPLITGRAPH_META_SCHEMA
 from splitgraph.core.fragment_manager import _quals_to_clause
+from splitgraph.engine import ResultShape
 from splitgraph.exceptions import SplitGraphException
 from test.splitgraph.commands.test_layered_querying import prepare_lq_repo
 from test.splitgraph.conftest import OUTPUT, _cleanup_minio


### PR DESCRIPTION
* Added a set of SQL stored procedures that the client is supposed to access `splitgraph_meta` (and `registry_meta`) over -- see `resources/push_pull.sql`.
* Rewrote most client-side functions to access the API instead with some simplifying of the code (e.g. using the stored procedure for object tree crawling at materialization and push/pull time)
* Direct access to meta tables in `splitgraph_meta` is now supposed to be forbidden (RLS tests now ban it and check that an unprivileged user can still push/pull). Downloading objects from `splitgraph_meta` is still allowed (all tables newly created in the schema have SELECT privileges) but I'm not sure if we want to ban it and keep all downloads S3-only.
* Authorization is now done via the `check_privileges` function in `push_pull.sql`: currently mirrors the RLS policies (can read anything, can't write to things with namespace different from the username)
* Removed `splitgraph_meta` RLS policies (API functions run with `SECURITY DEFINER`), `registry_meta` policies are still there