### PR TITLE
Speed up hashing committed tables

### DIFF
--- a/splitgraph/__init__.py
+++ b/splitgraph/__init__.py
@@ -8,4 +8,3 @@ from .config import CONFIG
 from .core.repository import Repository
 from .engine import get_engine, switch_engine
 from .exceptions import SplitGraphException
-from .splitfile import *

--- a/splitgraph/commandline/__init__.py
+++ b/splitgraph/commandline/__init__.py
@@ -13,11 +13,12 @@ from splitgraph.commandline.misc import rm_c, init_c, cleanup_c, config_c, prune
 from splitgraph.commandline.mount import mount_c
 from splitgraph.commandline.push_pull import pull_c, clone_c, push_c, publish_c, upstream_c
 from splitgraph.commandline.splitfile import build_c, provenance_c, rebuild_c
-from splitgraph.engine import get_engine
+from splitgraph.ingestion import csv
 
 
 def _commit_connection(_):
     """Commit and close the PG connection when the application finishes."""
+    from splitgraph.engine import get_engine
     get_engine().commit()
     get_engine().close()
 
@@ -80,17 +81,5 @@ cli.add_command(rebuild_c)
 # Examples
 cli.add_command(example)
 
-# Try importing the CSV ingestion extras
-try:
-    from splitgraph.ingestion import csv
-
-    cli.add_command(csv)
-except ImportError:
-    @click.command(name="csv")
-    def csv_dummy():
-        """Import/export Splitgraph images in CSV format."""
-        print("Install the ""ingestion"" setuptools extra to enable this feature!")
-        exit(1)
-
-
-    cli.add_command(csv_dummy)
+# CSV
+cli.add_command(csv)

--- a/splitgraph/commandline/_common.py
+++ b/splitgraph/commandline/_common.py
@@ -26,14 +26,16 @@ class ImageType(click.ParamType):
             tag_or_hash = repo_image[1]
         else:
             tag_or_hash = self.default
-        return RepositoryType(repo_image[0]), tag_or_hash
+        from splitgraph.core import Repository
+        return Repository.from_schema(repo_image[0]), tag_or_hash
 
 
 class RepositoryType(click.ParamType):
     name = "Repository"
 
     def convert(self, value, param, ctx):
-        return RepositoryType(value)
+        from splitgraph.core import Repository
+        return Repository.from_schema(value)
 
 
 class Color:

--- a/splitgraph/commandline/_common.py
+++ b/splitgraph/commandline/_common.py
@@ -1,31 +1,39 @@
 """
 Various common functions used by the command line interface.
 """
+import click
 
-from splitgraph.core.repository import Repository
 
+class ImageType(click.ParamType):
+    name = 'Image'
 
-def image_spec_parser(default='latest'):
-    """
-    Makes a parser that extracts the full image specification (repository and hash/tag).
+    def __init__(self, default='latest'):
+        """
+        Makes a parser that extracts the full image specification (repository and hash/tag).
 
-    Image specification must have the format [NAMESPACE/]REPOSITORY[:HASH_OR_TAG].
+        Image specification must have the format [NAMESPACE/]REPOSITORY[:HASH_OR_TAG].
 
-    The parser returns a tuple of (repository object, tag or hash).
+        The parser returns a tuple of (repository object, tag or hash).
 
-    :param default: Default tag/hash for image where it's not specified.
-    """
+        :param default: Default tag/hash for image where it's not specified.
+        """
+        self.default = default
 
-    def image_spec(spec):
-        repo_image = spec.split(':')
+    def convert(self, value, param, ctx):
+        repo_image = value.split(':')
 
         if len(repo_image) == 2:
             tag_or_hash = repo_image[1]
         else:
-            tag_or_hash = default
-        return Repository.from_schema(repo_image[0]), tag_or_hash
+            tag_or_hash = self.default
+        return RepositoryType(repo_image[0]), tag_or_hash
 
-    return image_spec
+
+class RepositoryType(click.ParamType):
+    name = "Repository"
+
+    def convert(self, value, param, ctx):
+        return RepositoryType(value)
 
 
 class Color:

--- a/splitgraph/commandline/example.py
+++ b/splitgraph/commandline/example.py
@@ -5,7 +5,8 @@ from hashlib import sha256
 
 import click
 
-from splitgraph.core import Repository, repository_exists, Identifier, SQL, select
+from splitgraph.commandline._common import RepositoryType
+from splitgraph.core import repository_exists, Identifier, SQL, select
 from splitgraph.engine import ResultShape
 
 _DEMO_TABLE_SIZE = 10
@@ -84,7 +85,7 @@ def alter_table(repository, table_name, rows_added, rows_deleted, rows_updated):
 
 
 @click.command(name='generate')
-@click.argument('repository', type=Repository.from_schema)
+@click.argument('repository', type=RepositoryType())
 def generate_c(repository):
     """
     Generate a repository with some example data.
@@ -104,7 +105,7 @@ def generate_c(repository):
 
 
 @click.command(name='alter')
-@click.argument('repository', type=Repository.from_schema)
+@click.argument('repository', type=RepositoryType())
 def alter_c(repository):
     """
     Alter the table in an example repository.
@@ -117,8 +118,8 @@ def alter_c(repository):
 
 
 @click.command(name='splitfile')
-@click.argument('repository_1', type=Repository.from_schema)
-@click.argument('repository_2', type=Repository.from_schema)
+@click.argument('repository_1', type=RepositoryType())
+@click.argument('repository_2', type=RepositoryType())
 def splitfile_c(repository_1, repository_2):
     """
     Generate a sample Splitfile.

--- a/splitgraph/commandline/image_creation.py
+++ b/splitgraph/commandline/image_creation.py
@@ -8,13 +8,12 @@ from collections import defaultdict
 import click
 
 from splitgraph import SplitGraphException
+from splitgraph.commandline._common import ImageType, RepositoryType
 from splitgraph.core.engine import repository_exists
-from splitgraph.core.repository import Repository
-from ._common import image_spec_parser
 
 
 @click.command(name='checkout')
-@click.argument('image_spec', type=image_spec_parser(default='HEAD'))
+@click.argument('image_spec', type=ImageType(default='HEAD'))
 @click.option('-f', '--force', help="Discard all pending changes to the schema", is_flag=True, default=False)
 @click.option('-u', '--uncheckout', help="Delete the checked out copy instead", is_flag=True, default=False)
 @click.option('-l', '--layered', help="Don't materialize the tables, use layered querying instead.",
@@ -54,7 +53,7 @@ def checkout_c(image_spec, force, uncheckout, layered):
 
 
 @click.command(name='commit')
-@click.argument('repository', type=Repository.from_schema)
+@click.argument('repository', type=RepositoryType())
 @click.option('-s', '--snap', default=False, is_flag=True,
               help='Store the table as a full table snapshot. This consumes more space, but makes checkouts faster.')
 @click.option('-c', '--chunk-size', default=None, type=int,
@@ -84,7 +83,7 @@ def commit_c(repository, snap, chunk_size, split_changesets, message):
 
 
 @click.command(name='tag')
-@click.argument('image_spec', type=image_spec_parser(default=None))
+@click.argument('image_spec', type=ImageType(default=None))
 @click.argument('tag', required=False)
 @click.option('-r', '--remove', required=False, is_flag=True, help="Remove the tag instead.")
 def tag_c(image_spec, tag, remove):
@@ -155,9 +154,9 @@ def tag_c(image_spec, tag, remove):
 
 
 @click.command(name='import')
-@click.argument('image_spec', type=image_spec_parser())
+@click.argument('image_spec', type=ImageType())
 @click.argument('table_or_query')
-@click.argument('target_repository', type=Repository.from_schema)
+@click.argument('target_repository', type=RepositoryType())
 @click.argument('target_table', required=False)
 def import_c(image_spec, table_or_query, target_repository, target_table):
     """

--- a/splitgraph/commandline/image_info.py
+++ b/splitgraph/commandline/image_info.py
@@ -12,12 +12,11 @@ from splitgraph.core._common import pretty_size
 from splitgraph.core._drawing import render_tree
 from splitgraph.core.engine import get_current_repositories
 from splitgraph.core.object_manager import ObjectManager
-from splitgraph.core.repository import Repository
-from ._common import image_spec_parser, pluralise
+from ._common import ImageType, pluralise, RepositoryType
 
 
 @click.command(name='log')
-@click.argument('repository', type=Repository.from_schema)
+@click.argument('repository', type=RepositoryType())
 @click.option('-t', '--tree', is_flag=True)
 def log_c(repository, tree):
     """
@@ -43,7 +42,7 @@ def log_c(repository, tree):
 @click.option('-v', '--verbose', default=False, is_flag=True,
               help='Include the actual differences rather than just the total number of updated rows.')
 @click.option('-t', '--table-name', help='Show the differences for a single table.')
-@click.argument('repository', type=Repository.from_schema)
+@click.argument('repository', type=RepositoryType())
 @click.argument('tag_or_hash_1', required=False)
 @click.argument('tag_or_hash_2', required=False)
 def diff_c(verbose, table_name, repository, tag_or_hash_1, tag_or_hash_2):
@@ -130,7 +129,7 @@ def _get_actual_hashes(repository, image_1, image_2):
 
 
 @click.command(name='show')
-@click.argument('image_spec', type=image_spec_parser(default='HEAD'))
+@click.argument('image_spec', type=ImageType(default='HEAD'))
 @click.option('-v', '--verbose', default=False, is_flag=True,
               help='Also show all tables in this image and the objects they map to.')
 def show_c(image_spec, verbose):
@@ -239,7 +238,7 @@ def sql_c(sql, schema, show_all):
 
 
 @click.command(name='status')
-@click.argument('repository', required=False, type=Repository.from_schema)
+@click.argument('repository', required=False, type=RepositoryType())
 def status_c(repository):
     """
     Show the status of the Splitgraph engine. If a repository is passed, show information about

--- a/splitgraph/commandline/misc.py
+++ b/splitgraph/commandline/misc.py
@@ -11,11 +11,11 @@ from splitgraph.core.engine import init_engine, repository_exists
 from splitgraph.core.object_manager import ObjectManager
 from splitgraph.core.repository import Repository
 from splitgraph.engine import get_engine
-from ._common import image_spec_parser
+from ._common import ImageType, RepositoryType
 
 
 @click.command(name='rm')
-@click.argument('image_spec', type=image_spec_parser(default=None))
+@click.argument('image_spec', type=ImageType(default=None))
 @click.option('-r', '--remote', help="Perform the deletion on a remote instead, specified by its alias")
 @click.option('-y', '--yes', help="Agree to deletion without confirmation", is_flag=True, default=False)
 def rm_c(image_spec, remote, yes):
@@ -89,7 +89,7 @@ def rm_c(image_spec, remote, yes):
 
 
 @click.command(name='prune')
-@click.argument('repository', type=Repository.from_schema)
+@click.argument('repository', type=RepositoryType())
 @click.option('-r', '--remote', help="Perform the deletion on a remote instead, specified by its alias")
 @click.option('-y', '--yes', help="Agree to deletion without confirmation", is_flag=True, default=False)
 def prune_c(repository, remote, yes):
@@ -129,7 +129,7 @@ def prune_c(repository, remote, yes):
 
 
 @click.command(name='init')
-@click.argument('repository', type=Repository.from_schema, required=False, default=None)
+@click.argument('repository', type=RepositoryType(), required=False, default=None)
 def init_c(repository):
     """
     Initialize a new repository/engine.
@@ -225,7 +225,7 @@ def config_c(no_shielding, config_format):
 
 
 @click.command(name='dump')
-@click.argument('repository', type=Repository.from_schema)
+@click.argument('repository', type=RepositoryType())
 def dump_c(repository):
     """
     Dump a repository to SQL.

--- a/splitgraph/commandline/push_pull.py
+++ b/splitgraph/commandline/push_pull.py
@@ -9,11 +9,12 @@ import click
 
 import splitgraph.engine
 import splitgraph.engine.postgres.engine
+from splitgraph.commandline._common import RepositoryType
 from splitgraph.core.repository import clone, Repository
 
 
 @click.command(name='pull')
-@click.argument('repository', type=Repository.from_schema)
+@click.argument('repository', type=RepositoryType())
 @click.option('-d', '--download-all', help='Download all objects immediately instead on checkout.')
 def pull_c(repository, download_all):
     """
@@ -23,8 +24,8 @@ def pull_c(repository, download_all):
 
 
 @click.command(name='clone')
-@click.argument('remote_repository', type=Repository.from_schema)
-@click.argument('local_repository', required=False, type=Repository.from_schema)
+@click.argument('remote_repository', type=RepositoryType())
+@click.argument('local_repository', required=False, type=RepositoryType())
 @click.option('-r', '--remote', help='Alias or full connection string for the remote engine')
 @click.option('-d', '--download-all', help='Download all objects immediately instead on checkout.',
               default=False, is_flag=True)
@@ -47,8 +48,8 @@ def clone_c(remote_repository, local_repository, remote, download_all):
 
 
 @click.command(name='push')
-@click.argument('repository', type=Repository.from_schema)
-@click.argument('remote_repository', required=False, type=Repository.from_schema)
+@click.argument('repository', type=RepositoryType())
+@click.argument('remote_repository', required=False, type=RepositoryType())
 @click.option('-r', '--remote', help='Alias or full connection string for the remote engine')
 @click.option('-h', '--upload-handler', help='Upload handler', default='DB')
 @click.option('-o', '--upload-handler-options', help='Upload handler parameters', default="{}")
@@ -77,7 +78,7 @@ def push_c(repository, remote_repository, remote, upload_handler, upload_handler
 
 
 @click.command(name='publish')
-@click.argument('repository', type=Repository.from_schema)
+@click.argument('repository', type=RepositoryType())
 @click.argument('tag')
 @click.option('-r', '--readme', type=click.File('r'))
 @click.option('--skip-provenance', is_flag=True, help="Don't include provenance in the published information.")
@@ -98,10 +99,9 @@ def publish_c(repository, tag, readme, skip_provenance, skip_previews):
 
 
 @click.command(name='upstream')
-@click.argument('repository', type=Repository.from_schema)
+@click.argument('repository', type=RepositoryType())
 @click.option('-s', '--set', 'set_to',
-              help="Set the upstream to a engine alias + repository", type=(str,
-                                                                            Repository.from_schema),
+              help="Set the upstream to a engine alias + repository", type=(str, RepositoryType()),
               default=("", None))
 @click.option('-r', '--reset', help="Delete the upstream", is_flag=True, default=False)
 def upstream_c(repository, set_to, reset):

--- a/splitgraph/commandline/splitfile.py
+++ b/splitgraph/commandline/splitfile.py
@@ -4,7 +4,6 @@ sgr commands related to building and rebuilding Splitfiles.
 
 import click
 
-from splitgraph.splitfile import execute_commands, rebuild_image
 from ._common import ImageType, RepositoryType
 
 
@@ -40,6 +39,9 @@ def build_c(splitfile, args, output_repository):
     """
     args = {k: v for k, v in args}
     print("Executing Splitfile %s with arguments %r" % (splitfile.name, args))
+
+    # Inline import: importing it at every sgr invocation takes extra time because of compiling the Splitfile grammar.
+    from splitgraph.splitfile import execute_commands
     execute_commands(splitfile.read(), args, output=output_repository)
 
 
@@ -148,4 +150,5 @@ def rebuild_c(image_spec, update, against):
     print("Rerunning %s:%s against:" % (str(repository), image.image_hash))
     print('\n'.join("%s:%s" % rs for rs in new_images.items()))
 
+    from splitgraph.splitfile import rebuild_image
     rebuild_image(image, new_images)

--- a/splitgraph/commandline/splitfile.py
+++ b/splitgraph/commandline/splitfile.py
@@ -4,9 +4,8 @@ sgr commands related to building and rebuilding Splitfiles.
 
 import click
 
-from splitgraph.core.repository import Repository
 from splitgraph.splitfile import execute_commands, rebuild_image
-from ._common import image_spec_parser
+from ._common import ImageType, RepositoryType
 
 
 @click.command(name='build')
@@ -15,7 +14,7 @@ from ._common import image_spec_parser
               help='Parameters to be substituted into the Splitfile. All parameters mentioned in the file'
                    ' must be specified in order for the Splitfile to be executed.')
 @click.option('-o', '--output-repository', help='Repository to store the result in.',
-              type=Repository.from_schema)
+              type=RepositoryType())
 def build_c(splitfile, args, output_repository):
     """
     Build Splitgraph images.
@@ -45,7 +44,7 @@ def build_c(splitfile, args, output_repository):
 
 
 @click.command(name='provenance')
-@click.argument('image_spec', type=image_spec_parser())
+@click.argument('image_spec', type=ImageType())
 @click.option('-f', '--full', required=False, is_flag=True, help='Recreate the Splitfile used to create this image')
 @click.option('-e', '--error-on-end', required=False, default=True, is_flag=True,
               help='If False, bases the recreated Splitfile on the last image where the provenance chain breaks')
@@ -109,9 +108,9 @@ def provenance_c(image_spec, full, error_on_end):
 
 
 @click.command(name='rebuild')
-@click.argument('image_spec', type=image_spec_parser())
+@click.argument('image_spec', type=ImageType())
 @click.option('-u', '--update', is_flag=True, help='Rederive the image against the latest version of all dependencies.')
-@click.option('-a', '--against', multiple=True, type=image_spec_parser(),
+@click.option('-a', '--against', multiple=True, type=ImageType(),
               help='Images to substitute into the reconstructed Splitfile, of the form'
                    ' [NAMESPACE/]REPOSITORY[:HASH_OR_TAG]. Default tag is \'latest\'.')
 def rebuild_c(image_spec, update, against):

--- a/splitgraph/core/_common.py
+++ b/splitgraph/core/_common.py
@@ -46,7 +46,7 @@ def manage_audit_triggers(engine, object_engine=None):
 
     from splitgraph.core.engine import get_current_repositories
     repos_tables = [(r.to_schema(), t) for r, head in get_current_repositories(engine) if head is not None
-                    for t in set(engine.get_all_tables(r.to_schema())) & set(head.get_tables())]
+                    for t in set(object_engine.get_all_tables(r.to_schema())) & set(head.get_tables())]
     tracked_tables = engine.get_tracked_tables()
 
     to_untrack = [t for t in tracked_tables if t not in repos_tables]

--- a/splitgraph/splitfile/_parsing.py
+++ b/splitgraph/splitfile/_parsing.py
@@ -33,7 +33,7 @@ SPLITFILE_GRAMMAR = Grammar(r"""
     # "identifier" anyway. This is so that the grammar is slightly more readable. 
 
     handler = identifier
-    repository = ~"[_a-zA-Z0-9\-/]+"
+    repository = ~"[_a-zA-Z0-9-/]+"
     table_name = identifier
     table_alias = identifier
     tag_or_hash = identifier
@@ -51,7 +51,7 @@ SPLITFILE_GRAMMAR = Grammar(r"""
     non_single_quote = ~"(\\\\\\'|[^'])*"
 
     no_db_conn_string = ~"(\S+):(\S+)@(.+):(\d+)"
-    identifier = ~"[_a-zA-Z0-9\-]+"
+    identifier = ~"[_a-zA-Z0-9-]+"
     space = ~"\s*"
 """)
 

--- a/test/splitgraph/test_commandline.py
+++ b/test/splitgraph/test_commandline.py
@@ -4,9 +4,9 @@ from decimal import Decimal
 
 import pytest
 
-from splitgraph import ResultShape
+from splitgraph import ResultShape, get_engine
 from splitgraph.commandline import *
-from splitgraph.commandline._common import image_spec_parser
+from splitgraph.commandline._common import ImageType
 from splitgraph.commandline.example import generate_c, alter_c, splitfile_c
 from splitgraph.commandline.image_info import object_c
 from splitgraph.config import PG_PWD, PG_USER
@@ -29,12 +29,12 @@ from click.testing import CliRunner
 
 
 def test_image_spec_parsing():
-    assert image_spec_parser()('test/pg_mount') == (Repository('test', 'pg_mount'), 'latest')
-    assert image_spec_parser(default='HEAD')('test/pg_mount') == (Repository('test', 'pg_mount'), 'HEAD')
-    assert image_spec_parser()('test/pg_mount:some_tag') == (Repository('test', 'pg_mount'), 'some_tag')
-    assert image_spec_parser()('pg_mount') == (Repository('', 'pg_mount'), 'latest')
-    assert image_spec_parser()('pg_mount:some_tag') == (Repository('', 'pg_mount'), 'some_tag')
-    assert image_spec_parser(default='HEAD')('pg_mount:some_tag') == (Repository('', 'pg_mount'), 'some_tag')
+    assert ImageType()('test/pg_mount') == (Repository('test', 'pg_mount'), 'latest')
+    assert ImageType(default='HEAD')('test/pg_mount') == (Repository('test', 'pg_mount'), 'HEAD')
+    assert ImageType()('test/pg_mount:some_tag') == (Repository('test', 'pg_mount'), 'some_tag')
+    assert ImageType()('pg_mount') == (Repository('', 'pg_mount'), 'latest')
+    assert ImageType()('pg_mount:some_tag') == (Repository('', 'pg_mount'), 'some_tag')
+    assert ImageType(default='HEAD')('pg_mount:some_tag') == (Repository('', 'pg_mount'), 'some_tag')
 
 
 def test_conn_string_parsing():

--- a/test/splitgraph/test_object_hashing.py
+++ b/test/splitgraph/test_object_hashing.py
@@ -4,8 +4,9 @@ from hashlib import sha256
 
 import pytest
 
-from splitgraph import SPLITGRAPH_META_SCHEMA, execute_commands, Repository
+from splitgraph import SPLITGRAPH_META_SCHEMA, Repository
 from splitgraph.core.fragment_manager import Digest
+from splitgraph.splitfile import execute_commands
 from test.splitgraph.conftest import OUTPUT, PG_DATA, load_splitfile
 
 TEST_ROWS = ['zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight', 'nine']


### PR DESCRIPTION
Hash table fragments after they've been copied over to a temporary location rather than extracting hashes from the whole table with LIMIT.

Improves the time taken to commit a table with 1M rows:

  * original: 88s to create a table, 310s to commit (275s in `calculate_content_hash`);
  * new: 74s to commit (29s in `copy_table`, 40s in `calculate_content_hash`)