### PR TITLE
Various bugfixes and style improvements

### DIFF
--- a/splitgraph/__init__.py
+++ b/splitgraph/__init__.py
@@ -7,4 +7,4 @@ from splitgraph.core.registry import *
 from .config import CONFIG
 from .core.repository import Repository
 from .engine import get_engine, switch_engine
-from .exceptions import SplitGraphException
+from .exceptions import SplitGraphError

--- a/splitgraph/commandline/image_creation.py
+++ b/splitgraph/commandline/image_creation.py
@@ -6,8 +6,6 @@ import sys
 from collections import defaultdict
 
 import click
-
-from splitgraph import SplitGraphException
 from splitgraph.commandline._common import ImageType, RepositoryType
 from splitgraph.core.engine import repository_exists
 
@@ -169,7 +167,7 @@ def tag_c(image_spec, tag, remove):
         return
 
     if tag == "HEAD":
-        raise SplitGraphException("HEAD is a reserved tag!")
+        raise click.BadArgumentUsage("HEAD is a reserved tag!")
 
     if image is None:
         image = repository.head

--- a/splitgraph/commandline/misc.py
+++ b/splitgraph/commandline/misc.py
@@ -4,13 +4,14 @@ Miscellaneous image management sgr commands.
 import sys
 
 import click
-
-from splitgraph import SplitGraphException, CONFIG
+from splitgraph import CONFIG
 from splitgraph.config.keys import KEYS, SENSITIVE_KEYS
 from splitgraph.core.engine import init_engine, repository_exists
 from splitgraph.core.object_manager import ObjectManager
 from splitgraph.core.repository import Repository
 from splitgraph.engine import get_engine
+from splitgraph.exceptions import CheckoutError
+
 from ._common import ImageType, RepositoryType
 
 
@@ -84,7 +85,7 @@ def rm_c(image_spec, remote, yes):
             # If we're deleting an image that we currently have checked out,
             # we need to make sure the rest of the metadata (e.g. current state of the audit table) is consistent,
             # it's better to disallow these deletions completely.
-            raise SplitGraphException(
+            raise CheckoutError(
                 "Deletion will affect a checked-out image! Check out a different branch "
                 "or do sgr checkout -u %s!" % repository.to_schema()
             )

--- a/splitgraph/core/_common.py
+++ b/splitgraph/core/_common.py
@@ -93,7 +93,7 @@ def manage_audit(func):
             manage_audit_triggers(repository.engine, repository.object_engine)
             return func(self, *args, **kwargs)
         finally:
-            repository.commit_engines()
+            repository.object_engine.commit()
             manage_audit_triggers(repository.engine, repository.object_engine)
 
     return wrapped

--- a/splitgraph/core/_drawing.py
+++ b/splitgraph/core/_drawing.py
@@ -4,7 +4,7 @@ Routines for rendering a Splitgraph repository as a tree of images
 """
 from collections import defaultdict
 
-from splitgraph.exceptions import SplitGraphException
+from splitgraph.exceptions import SplitGraphError
 
 
 def _calc_columns(children, start):
@@ -69,7 +69,7 @@ def render_tree(repository):
         children[image.parent_id].append(image.image_hash)
 
     if base_node is None:
-        raise SplitGraphException("Something is seriously wrong with the index.")
+        raise SplitGraphError("Something is seriously wrong with the index.")
 
     # Calculate the column in which each node should be displayed.
     node_cols = _calc_columns(children, base_node)

--- a/splitgraph/core/engine.py
+++ b/splitgraph/core/engine.py
@@ -1,14 +1,13 @@
 """
 Routines for managing Splitgraph engines, including looking up repositories and managing objects.
 """
-import logging
 
 from psycopg2.sql import SQL, Identifier
-
-from splitgraph.config import SPLITGRAPH_META_SCHEMA, CONFIG, SPLITGRAPH_API_SCHEMA
+from splitgraph.config import CONFIG, SPLITGRAPH_API_SCHEMA
 from splitgraph.engine import get_engine, ResultShape
-from splitgraph.exceptions import SplitGraphException
-from ._common import select, ensure_metadata_schema
+from splitgraph.exceptions import RepositoryNotFoundError
+
+from ._common import select
 
 
 def _parse_paths_overrides(lookup_path, override_path):
@@ -89,7 +88,7 @@ def lookup_repository(name, include_local=False):
             return candidate
         candidate.engine.close()
 
-    raise SplitGraphException("Unknown repository %s!" % name)
+    raise RepositoryNotFoundError("Unknown repository %s!" % name)
 
 
 def get_current_repositories(engine):

--- a/splitgraph/core/fragment_manager.py
+++ b/splitgraph/core/fragment_manager.py
@@ -431,7 +431,7 @@ class FragmentManager(MetadataManager):
 
             if split_changeset:
                 # Follow the chains down to the base fragments that we'll use to find the chunk boundaries
-                base_fragments = [self.get_all_required_objects([o])[-1] for o in top_fragments]
+                base_fragments = [self.get_all_required_objects([o])[0] for o in top_fragments]
 
                 table_pks = self.object_engine.get_change_key(schema, old_table.table_name)
                 min_max = self._extract_min_max_pks(base_fragments, table_pks)
@@ -627,7 +627,8 @@ class FragmentManager(MetadataManager):
         """
         Follow the parent chains of multiple objects until the base objects are reached.
         :param object_ids: Object IDs to start the traversal on.
-        :return: Expanded chain. Parents of objects are guaranteed to come after those objects.
+        :return: Expanded chain. Parents of objects are guaranteed to come before those objects and
+            the order in the `object_ids` array is preserved.
         """
         parents = self.metadata_engine.run_sql(
             SQL("SELECT {}.get_object_path(%s)").format(Identifier(SPLITGRAPH_API_SCHEMA)),

--- a/splitgraph/core/image.py
+++ b/splitgraph/core/image.py
@@ -7,11 +7,11 @@ from random import getrandbits
 
 from psycopg2.extras import Json
 from psycopg2.sql import SQL, Identifier
-
 from splitgraph.config import SPLITGRAPH_META_SCHEMA, CONFIG, SPLITGRAPH_API_SCHEMA
 from splitgraph.engine import ResultShape
-from splitgraph.exceptions import SplitGraphException
+from splitgraph.exceptions import SplitGraphError
 from splitgraph.hooks.mount_handlers import init_fdw
+
 from ._common import set_tag, select, manage_audit, set_head
 from .table import Table
 
@@ -101,7 +101,7 @@ class Image(namedtuple("Image", IMAGE_COLS + ["repository", "engine", "object_en
         target_schema = self.repository.to_schema()
         if self.repository.has_pending_changes():
             if not force:
-                raise SplitGraphException(
+                raise SplitGraphError(
                     "{0} has pending changes! Pass force=True or do sgr checkout -f {0}:HEAD".format(
                         target_schema
                     )
@@ -250,7 +250,7 @@ class Image(namedtuple("Image", IMAGE_COLS + ["repository", "engine", "object_en
                     break
             elif prov_type in (None, "MOUNT") and parent:
                 if err_on_end:
-                    raise SplitGraphException(
+                    raise SplitGraphError(
                         "Image %s is linked to its parent with provenance %s"
                         " that can't be reproduced!" % (image_hash, prov_type)
                     )
@@ -413,4 +413,4 @@ def _prov_command_to_splitfile(prov_type, prov_data, image_hash, source_replacem
         return "FROM %s:%s" % (str(repo), source_replacement.get(repo, image_hash))
     if prov_type == "SQL":
         return "SQL " + prov_data.replace("\n", "\\\n")
-    raise SplitGraphException("Cannot reconstruct provenance %s!" % prov_type)
+    raise SplitGraphError("Cannot reconstruct provenance %s!" % prov_type)

--- a/splitgraph/core/object_manager.py
+++ b/splitgraph/core/object_manager.py
@@ -7,13 +7,13 @@ from contextlib import contextmanager
 from datetime import datetime as dt
 
 from psycopg2.sql import SQL, Identifier
+
 from splitgraph.config import SPLITGRAPH_META_SCHEMA, CONFIG
 from splitgraph.core.fragment_manager import FragmentManager
 from splitgraph.core.metadata_manager import MetadataManager
 from splitgraph.engine import ResultShape, switch_engine
 from splitgraph.exceptions import SplitGraphError, ObjectCacheError
 from splitgraph.hooks.external_objects import get_external_object_handler
-
 from ._common import META_TABLES, select, insert, pretty_size, Tracer
 
 
@@ -246,6 +246,10 @@ class ObjectManager(FragmentManager, MetadataManager):
 
         if not new_objects:
             return
+
+        # Similar to claim_objects, make sure we don't deadlock with other uploaders
+        # by keeping a consistent order.
+        new_objects = sorted(new_objects)
 
         # Insert the objects into the cache status table (marking them as not ready)
         now = dt.now()

--- a/splitgraph/core/object_manager.py
+++ b/splitgraph/core/object_manager.py
@@ -378,6 +378,11 @@ class ObjectManager(FragmentManager, MetadataManager):
         remaining = set(objects).difference(set(claimed))
         remaining = remaining.difference(set(self.get_downloaded_objects(limit_to=list(remaining))))
 
+        # Since we send multiple queries, each claiming a single remaining object, we can deadlock here
+        # with another object manager instance. Hence, we sort the list of objects so that we claim them
+        # in a consistent order between all instances.
+        remaining = sorted(remaining)
+
         # Remaining: objects that are new to the cache and that we'll need to download. However, between us
         # running the first query and now, somebody else might have started downloading them. Hence, when
         # we try to insert them, we'll be blocked until the other engine finishes its download and commits

--- a/splitgraph/core/object_manager.py
+++ b/splitgraph/core/object_manager.py
@@ -141,7 +141,7 @@ class ObjectManager(FragmentManager, MetadataManager):
         # Resolve the table into a list of objects we want to fetch.
         # In the future, we can also take other things into account, such as how expensive it is to load a given object
         # (its size), location...
-        required_objects = list(reversed(self.get_all_required_objects(table.objects)))
+        required_objects = list(self.get_all_required_objects(table.objects))
         tracer.log("resolve_objects")
 
         # Filter to see if we can discard any objects with the quals

--- a/splitgraph/core/sql.py
+++ b/splitgraph/core/sql.py
@@ -2,12 +2,12 @@
 from pglast import Node, parse_sql
 from pglast.node import Scalar
 
-from splitgraph.exceptions import UnsupportedSQLException
+from splitgraph.exceptions import UnsupportedSQLError
 
 
 def _validate_range_var(node):
     if "schemaname" in node.attribute_names:
-        raise UnsupportedSQLException("Table names must not be schema-qualified!")
+        raise UnsupportedSQLError("Table names must not be schema-qualified!")
 
 
 # Whitelist of permitted AST nodes. When crawling the parse tree, a node not in this list fails validation. If a node
@@ -66,7 +66,7 @@ def _validate_node(node, permitted_nodes, node_validators):
         message = "Unsupported statement type %s" % node_class
         if isinstance(node["location"], Scalar):
             message += " near character %d" % node["location"].value
-        raise UnsupportedSQLException(message + "!")
+        raise UnsupportedSQLError(message + "!")
 
 
 def validate_splitfile_sql(sql):
@@ -102,9 +102,7 @@ def validate_import_sql(sql):
 
     tree = Node(parse_sql(sql))
     if len(tree) != 1:
-        raise UnsupportedSQLException(
-            "The query is supposed to consist of only one SELECT statement!"
-        )
+        raise UnsupportedSQLError("The query is supposed to consist of only one SELECT statement!")
 
     for node in tree.traverse():
         _validate_node(

--- a/splitgraph/engine/postgres/engine.py
+++ b/splitgraph/engine/postgres/engine.py
@@ -130,7 +130,7 @@ class PsycopgEngine(SQLEngine):
 
     def run_sql(self, statement, arguments=None, return_shape=ResultShape.MANY_MANY, named=False):
 
-        cursor_kwargs = { "cursor_factory": psycopg2.extras.NamedTupleCursor } if named else {}
+        cursor_kwargs = {"cursor_factory": psycopg2.extras.NamedTupleCursor} if named else {}
 
         with self.connection.cursor(**cursor_kwargs) as cur:
             try:

--- a/splitgraph/engine/postgres/engine.py
+++ b/splitgraph/engine/postgres/engine.py
@@ -144,15 +144,13 @@ class PsycopgEngine(SQLEngine):
                     # anything that sends queries to splitgraph_meta or audit schemas.
                     if "audit." in str(e):
                         raise UninitializedEngineError(
-                            "Audit triggers not found on the engine. Has the engine been initialized?",
-                            e,
-                        )
+                            "Audit triggers not found on the engine. Has the engine been initialized?"
+                        ) from e
                     for meta_table in META_TABLES:
                         if "splitgraph_meta.%s" % meta_table in str(e):
                             raise UninitializedEngineError(
-                                "splitgraph_meta not found on the engine. Has the engine been initialized?",
-                                e,
-                            )
+                                "splitgraph_meta not found on the engine. Has the engine been initialized?"
+                            ) from e
                     else:
                         raise ObjectNotFoundError(e)
                 raise

--- a/splitgraph/exceptions.py
+++ b/splitgraph/exceptions.py
@@ -3,12 +3,46 @@ Exceptions that can be raised by the Splitgraph library.
 """
 
 
-class SplitGraphException(Exception):
-    """
-    A generic Splitgraph exception
-    """
+class SplitGraphError(Exception):
+    """A generic Splitgraph exception."""
 
 
-class UnsupportedSQLException(SplitGraphException):
+class CheckoutError(SplitGraphError):
+    """Errors related to checking out/committing repositories"""
+
+
+class UnsupportedSQLError(SplitGraphError):
     """Raised for unsupported SQL statements, for example, containing schema-qualified tables when the statement
     is supposed to be used in an SQL/IMPORT Splitfile command."""
+
+
+class UninitializedEngineError(SplitGraphError):
+    """Raised when the engine isn't initialized (no splitgraph_meta schema or audit triggers)"""
+
+
+class ObjectCacheError(SplitGraphError):
+    """Issues with the object cache (not enough space)"""
+
+
+class ObjectNotFoundError(SplitGraphError):
+    """Raised when a physical object doesn't exist in the cache."""
+
+
+class RepositoryNotFoundError(SplitGraphError):
+    """A Splitgraph repository doesn't exist."""
+
+
+class ImageNotFoundError(SplitGraphError):
+    """A Splitgraph image doesn't exist."""
+
+
+class SplitfileError(SplitGraphError):
+    """Generic error class for Splitfile interpretation/execution errors."""
+
+
+class ExternalHandlerError(SplitGraphError):
+    """Exceptions raised by external object handlers."""
+
+
+class MountHandlerError(SplitGraphError):
+    """Exceptions raised by mount handlers."""

--- a/splitgraph/hooks/external_objects.py
+++ b/splitgraph/hooks/external_objects.py
@@ -4,7 +4,7 @@ Hooks for registering handlers to upload/download objects from external location
 from importlib import import_module
 
 from splitgraph.config import CONFIG
-from splitgraph.exceptions import SplitGraphException
+from splitgraph.exceptions import ExternalHandlerError
 
 _EXTERNAL_OBJECT_HANDLERS = {}
 
@@ -59,7 +59,7 @@ def get_external_object_handler(name, handler_params):
     except KeyError:
         external_handlers = CONFIG.get("external_handlers", {})
         if name not in external_handlers:
-            raise SplitGraphException("Protocol %s is not supported!" % name)
+            raise ExternalHandlerError("Protocol %s is not supported!" % name)
         else:
             handler_class_name = external_handlers[name]
             index = handler_class_name.rindex(".")
@@ -70,11 +70,11 @@ def get_external_object_handler(name, handler_params):
                 register_upload_download_handler(name, handler_class)
                 return handler_class(handler_params)
             except AttributeError as e:
-                raise SplitGraphException(
+                raise ExternalHandlerError(
                     "Error loading external object handler {0}".format(name)
                 ) from e
             except ImportError as e:
-                raise SplitGraphException(
+                raise ExternalHandlerError(
                     "Error loading external object handler {0}".format(name)
                 ) from e
 
@@ -84,7 +84,7 @@ def register_upload_download_handler(name, handler_class):
     signatures of the handler functions."""
     global _EXTERNAL_OBJECT_HANDLERS
     if name in _EXTERNAL_OBJECT_HANDLERS:
-        raise SplitGraphException(
+        raise ExternalHandlerError(
             "Cannot register a protocol handler %s as it already exists!" % name
         )
     _EXTERNAL_OBJECT_HANDLERS[name] = handler_class

--- a/splitgraph/ingestion/pandas.py
+++ b/splitgraph/ingestion/pandas.py
@@ -5,10 +5,9 @@ from io import StringIO
 import pandas as pd
 from pandas.io.sql import get_schema
 from psycopg2.sql import Identifier, SQL
-from sqlalchemy import create_engine
-
-from splitgraph import SplitGraphException
 from splitgraph.core.image import Image
+from splitgraph.exceptions import CheckoutError
+from sqlalchemy import create_engine
 
 
 def _get_sqlalchemy_engine(engine):
@@ -162,7 +161,7 @@ def df_to_table(df, repository, table, if_exists="patch"):
     schema = repository.to_schema()
 
     if not repository.head:
-        raise SplitGraphException("Repository %s isn't checked out!" % schema)
+        raise CheckoutError("Repository %s isn't checked out!" % schema)
 
     table_exists = repository.engine.table_exists(schema, table)
     if not table_exists or (table_exists and if_exists == "replace"):
@@ -191,7 +190,7 @@ def df_to_table(df, repository, table, if_exists="patch"):
         target_schema = repository.engine.get_full_table_schema(schema, table)
 
         if not _schema_compatible(source_schema, target_schema):
-            raise SplitGraphException(
+            raise ValueError(
                 "Schema changes are unsupported with if_exists='patch'!"
                 "\nSource schema: %r\nTarget schema: %r" % (source_schema, target_schema)
             )

--- a/splitgraph/resources/push_pull.sql
+++ b/splitgraph/resources/push_pull.sql
@@ -118,10 +118,10 @@ BEGIN
     -- Something weird happens if this function is invoked exactly five times and the execution
     -- time goes from ~6ms to ~100ms. Possibly something to do with the query planner?
     EXECUTE 'SELECT ARRAY(WITH RECURSIVE parents AS'
-        ' (SELECT object_id, parent_id FROM splitgraph_meta.objects WHERE object_id = ANY($1)'
-        '    UNION ALL SELECT o.object_id, o.parent_id'
+        ' (SELECT object_id, parent_id, 0 as depth FROM splitgraph_meta.objects WHERE object_id = ANY($1)'
+        '    UNION ALL SELECT o.object_id, o.parent_id, p.depth + 1'
         '    FROM parents p JOIN splitgraph_meta.objects o ON p.parent_id = o.object_id)'
-        ' SELECT object_id FROM parents)' USING object_ids INTO result;
+        ' SELECT object_id FROM parents ORDER BY depth DESC)' USING object_ids INTO result;
     RETURN result;
 END
 $$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = splitgraph_meta, pg_temp;

--- a/splitgraph/splitfile/_parsing.py
+++ b/splitgraph/splitfile/_parsing.py
@@ -6,8 +6,7 @@ import re
 import shlex
 
 from parsimonious import Grammar
-
-from splitgraph.exceptions import SplitGraphException
+from splitgraph.exceptions import SplitfileError
 
 SPLITFILE_GRAMMAR = Grammar(
     r"""
@@ -86,7 +85,7 @@ def preprocess(commands, params=None):
     # Search for any unreplaced $-parameters
     unreplaced = set(re.findall(r"[^\\](\${\S+})", commands, flags=re.MULTILINE))
     if unreplaced:
-        raise SplitGraphException("Unknown values for parameters " + ", ".join(unreplaced) + "!")
+        raise SplitfileError("Unknown values for parameters " + ", ".join(unreplaced) + "!")
     # Finally, replace the escaped $
     return commands.replace("\\$", "$")
 

--- a/test/resources/.sgconfig
+++ b/test/resources/.sgconfig
@@ -28,8 +28,6 @@ SG_REPO_LOOKUP_OVERRIDE=overridden/repo:LOCAL
 [remote: remote_engine]
 SG_ENGINE_HOST=remote_engine
 SG_ENGINE_PORT=5431
-SG_ENGINE_FDW_HOST=remote_engine
-SG_ENGINE_FDW_PORT=5431
 SG_ENGINE_DB_NAME=splitgraph
 SG_ENGINE_USER=sgr
 SG_ENGINE_PWD=supersecure

--- a/test/splitgraph/commands/test_commit_diff.py
+++ b/test/splitgraph/commands/test_commit_diff.py
@@ -8,7 +8,7 @@ from psycopg2.sql import SQL, Identifier
 
 from splitgraph import SPLITGRAPH_META_SCHEMA, ResultShape, select
 from splitgraph.core.fragment_manager import Digest
-from test.splitgraph.conftest import OUTPUT, PG_DATA
+from test.splitgraph.conftest import OUTPUT, PG_DATA, MIN_OBJECT_SIZE
 
 
 def test_diff_head(pg_repo_local):
@@ -104,7 +104,7 @@ def test_commit_chunking(local_engine_empty):
             "FRAG",  # fragment format
             None,  # no parent
             "",  # no namespace
-            8192,  # size reported by PG (can it change between platforms?)
+            MIN_OBJECT_SIZE,
             # Don't check the insertion hash in this test
             object_meta[obj].insertion_hash,
             # Object didn't delete anything, so the deletion hash is zero.
@@ -192,7 +192,7 @@ def test_commit_diff_splitting(local_engine_empty):
             "FRAG",
             None,
             "",
-            8192,
+            MIN_OBJECT_SIZE,
             "3cfbe8fa6fc546264936e29f402d7263510481c88a8d27190d82b3d5830cbcbf",
             # no deletions in this fragment
             "0000000000000000000000000000000000000000000000000000000000000000",
@@ -203,7 +203,7 @@ def test_commit_diff_splitting(local_engine_empty):
             "FRAG",
             base_objects[0],
             "",
-            8192,
+            MIN_OBJECT_SIZE,
             "470425e8c107fff67264f9f812dfe211c7e625edf651947b8476f60392c57281",
             "e3eb6db305d889d3a69e3d8efa0931853c00fca75c0aeddd8f2fa2d6fd2443d6",
             # for value_1 we have old values for k=4,5 ('d', 'e') and new value
@@ -215,7 +215,7 @@ def test_commit_diff_splitting(local_engine_empty):
             "FRAG",
             base_objects[1],
             "",
-            8192,
+            MIN_OBJECT_SIZE,
             # UPD + DEL conflated so nothing gets inserted by this fragment
             "0000000000000000000000000000000000000000000000000000000000000000",
             "d7df15e62c1c8799ef3a3677e3eb7661cedf898d73449a80251b93c501b5bdeb",
@@ -228,7 +228,7 @@ def test_commit_diff_splitting(local_engine_empty):
             "FRAG",
             None,
             "",
-            8192,
+            MIN_OBJECT_SIZE,
             "6950e38c81c51685d617e98c7e2cf98d34630940c33e9259bc01339cca9c9418",
             # No deletions here
             "0000000000000000000000000000000000000000000000000000000000000000",
@@ -239,7 +239,7 @@ def test_commit_diff_splitting(local_engine_empty):
             "FRAG",
             None,
             "",
-            8192,
+            MIN_OBJECT_SIZE,
             "96f0a7394f3839b048b492b789f7d57cf976345b04938a69d82b3512f72c3e9e",
             "0000000000000000000000000000000000000000000000000000000000000000",
             {"key": [12, 12], "value_1": ["l", "l"], "value_2": [22, 22]},
@@ -337,7 +337,7 @@ def test_commit_diff_splitting_composite(local_engine_empty):
         "FRAG",
         base_objects[0],
         "",
-        8192,
+        MIN_OBJECT_SIZE,
         # Hashes here just copypasted from the test output, see test_object_hashing for actual tests that
         # test each part of hash generation
         "00964b1b5db0d6e8d42b48462e9021ed626a773380345a1f4fee5c205d7d4beb",
@@ -357,7 +357,7 @@ def test_commit_diff_splitting_composite(local_engine_empty):
         "FRAG",
         None,
         "",
-        8192,
+        MIN_OBJECT_SIZE,
         "8c92b3ea89234b06cf53c2bad9d6e1d49dc561dc8c0100ee63c0b9ce1eeb0750",
         # Nothing deleted, so the deletion hash is 0
         "0000000000000000000000000000000000000000000000000000000000000000",

--- a/test/splitgraph/commands/test_layered_querying.py
+++ b/test/splitgraph/commands/test_layered_querying.py
@@ -6,6 +6,7 @@ from splitgraph import Repository
 from splitgraph.core import clone
 from splitgraph.core._common import META_TABLES
 from splitgraph.engine import ResultShape
+from test.splitgraph.conftest import MIN_OBJECT_SIZE
 
 
 def prepare_lq_repo(repo, commit_after_every, include_pk, snap_only=False):
@@ -311,7 +312,7 @@ def test_multiengine_flow(local_engine_empty, pg_repo_remote):
     assert result == [(3, "mayonnaise", 1, _DT), (4, "kumquat", 1, _DT)]
 
     # Test cache occupancy calculations work only using the object engine
-    assert pg_repo_local.objects.get_cache_occupancy() == 8192 * 2
+    assert pg_repo_local.objects.get_cache_occupancy() == MIN_OBJECT_SIZE * 2
 
     # 2 objects downloaded from S3 to satisfy the query -- on the local engine
     assert (

--- a/test/splitgraph/commands/test_misc.py
+++ b/test/splitgraph/commands/test_misc.py
@@ -1,6 +1,6 @@
 import pytest
 
-from splitgraph import SplitGraphException
+from splitgraph.exceptions import ImageNotFoundError
 
 
 @pytest.mark.parametrize("snap_only", [True, False])
@@ -96,18 +96,18 @@ def test_image_resolution(pg_repo_local):
     head = pg_repo_local.head
     assert pg_repo_local.images[head.image_hash[:10]] == head
     assert pg_repo_local.images["latest"] == head
-    with pytest.raises(SplitGraphException):
+    with pytest.raises(ImageNotFoundError):
         img = pg_repo_local.images["abcdef1234567890abcdef"]
-    with pytest.raises(SplitGraphException):
+    with pytest.raises(ImageNotFoundError):
         img = pg_repo_local.images["some_weird_tag"]
 
 
 def test_tag_errors(pg_repo_local):
     pg_repo_local.uncheckout()
-    with pytest.raises(SplitGraphException) as e:
+    with pytest.raises(ImageNotFoundError) as e:
         head = pg_repo_local.images.by_tag("HEAD")
     assert "No current checked out revision found" in str(e)
 
-    with pytest.raises(SplitGraphException) as e:
+    with pytest.raises(ImageNotFoundError) as e:
         tag = pg_repo_local.images.by_tag("notatag")
     assert "Tag notatag not found" in str(e)

--- a/test/splitgraph/conftest.py
+++ b/test/splitgraph/conftest.py
@@ -26,6 +26,12 @@ MG_MNT = R("test_mg_mount")
 MYSQL_MNT = R("test/mysql_mount")
 OUTPUT = R("output")
 
+# On-disk size taken up by an empty table.
+# Includes pg_relation_size(table).
+
+# Doesn't include all components, see PostgresEngine.get_table_size for explanation.
+MIN_OBJECT_SIZE = 8192
+
 
 def _mount_postgres(repository, tables=None):
     mount(

--- a/test/splitgraph/ingestion/test_pandas.py
+++ b/test/splitgraph/ingestion/test_pandas.py
@@ -5,8 +5,6 @@ import pandas as pd
 import pytest
 from pandas.compat import StringIO
 from pandas.util.testing import assert_frame_equal
-
-from splitgraph import SplitGraphException
 from splitgraph.ingestion.pandas import df_to_table, sql_to_df
 from test.splitgraph.conftest import load_csv, INGESTION_RESOURCES
 
@@ -131,7 +129,7 @@ def test_pandas_update_different_schema(ingestion_test_repo):
     # Delete the 'timestamp' column
     truncated_df = upd_df_1["timestamp"]
 
-    with pytest.raises(SplitGraphException) as e:
+    with pytest.raises(ValueError) as e:
         df_to_table(truncated_df, ingestion_test_repo, "test_table", if_exists="patch")
         assert "Schema changes are unsupported" in str(e)
 
@@ -139,7 +137,7 @@ def test_pandas_update_different_schema(ingestion_test_repo):
     renamed_df = upd_df_1.copy()
     renamed_df.columns = ["timestamp", "name_rename"]
 
-    with pytest.raises(SplitGraphException) as e:
+    with pytest.raises(ValueError) as e:
         df_to_table(renamed_df, ingestion_test_repo, "test_table", if_exists="patch")
         assert "Schema changes are unsupported" in str(e)
 

--- a/test/splitgraph/splitfile/test_custom_commands.py
+++ b/test/splitgraph/splitfile/test_custom_commands.py
@@ -7,7 +7,7 @@ try:
 except ImportError:
     from mock import patch
 from psycopg2.sql import Identifier, SQL
-from splitgraph.exceptions import SplitGraphException
+from splitgraph.exceptions import SplitfileError
 from splitgraph.splitfile import execute_commands
 from splitgraph.splitfile.execution import _combine_hashes
 from splitgraph.hooks.splitfile_commands import PluginCommand
@@ -95,20 +95,20 @@ def test_calc_hash_short_circuit(pg_repo_local):
 
 def test_custom_command_errors(pg_repo_local):
     # Test we raise for undefined commands
-    with pytest.raises(SplitGraphException) as e:
+    with pytest.raises(SplitfileError) as e:
         execute_commands(
             load_splitfile("custom_command_dummy.splitfile").replace("DUMMY", "NOP"), output=OUTPUT
         )
     assert "Custom command NOP not found in the config!" in str(e.value)
 
     # Test we raise for commands that can't be imported
-    with pytest.raises(SplitGraphException) as e:
+    with pytest.raises(SplitfileError) as e:
         execute_commands(
             load_splitfile("custom_command_dummy.splitfile").replace("DUMMY", "BROKEN1"),
             output=OUTPUT,
         )
     assert "Error loading custom command BROKEN1" in str(e.value)
-    with pytest.raises(SplitGraphException) as e:
+    with pytest.raises(SplitfileError) as e:
         execute_commands(
             load_splitfile("custom_command_dummy.splitfile").replace("DUMMY", "BROKEN2"),
             output=OUTPUT,

--- a/test/splitgraph/splitfile/test_execution.py
+++ b/test/splitgraph/splitfile/test_execution.py
@@ -2,7 +2,7 @@ import pytest
 
 from splitgraph.core.engine import get_current_repositories
 from splitgraph.core.repository import clone, Repository
-from splitgraph.exceptions import SplitGraphException
+from splitgraph.exceptions import SplitfileError
 from splitgraph.splitfile._parsing import preprocess
 from splitgraph.splitfile.execution import execute_commands
 from test.splitgraph.conftest import OUTPUT, SPLITFILE_ROOT, load_splitfile
@@ -12,7 +12,7 @@ R = Repository.from_schema
 
 
 def test_splitfile_preprocessor_missing_params():
-    with pytest.raises(SplitGraphException) as e:
+    with pytest.raises(SplitfileError) as e:
         preprocess(PARSING_TEST_SPLITFILE, params={})
     assert "${TAG}" in str(e.value)
     assert "${ESCAPED}" not in str(e.value)

--- a/test/splitgraph/test_misc.py
+++ b/test/splitgraph/test_misc.py
@@ -1,7 +1,6 @@
 import psycopg2
 import pytest
 
-from splitgraph import SplitGraphException
 from splitgraph.config import SPLITGRAPH_META_SCHEMA, REGISTRY_META_SCHEMA
 from splitgraph.core._common import ensure_metadata_schema
 from splitgraph.core.engine import get_current_repositories, lookup_repository, ResultShape
@@ -11,6 +10,7 @@ from splitgraph.core.registry import (
     _ensure_registry_schema,
 )
 from splitgraph.core.repository import Repository
+from splitgraph.exceptions import RepositoryNotFoundError
 
 try:
     from unittest import mock
@@ -50,7 +50,7 @@ def test_repo_lookup_override(remote_engine):
 
 
 def test_repo_lookup_override_fail():
-    with pytest.raises(SplitGraphException) as e:
+    with pytest.raises(RepositoryNotFoundError) as e:
         lookup_repository("does/not_exist")
     assert "Unknown repository" in str(e)
 

--- a/test/splitgraph/test_misc.py
+++ b/test/splitgraph/test_misc.py
@@ -73,6 +73,7 @@ def test_engine_retry(local_engine_empty):
         assert local_engine_empty.connection == conn
         assert pool.getconn.call_count == 2
 
+
 def test_run_sql_namedtuple(local_engine_empty):
     many_many_result = local_engine_empty.run_sql("SELECT 1 as foo, 2 as bar", named=True)
     assert len(many_many_result) == 1
@@ -81,7 +82,9 @@ def test_run_sql_namedtuple(local_engine_empty):
     assert many_many_result[0].bar == 2
     assert many_many_result[0][1] == 2
 
-    one_many_result = local_engine_empty.run_sql("SELECT 1 as foo, 2 as bar", named=True, return_shape=ResultShape.ONE_MANY)
+    one_many_result = local_engine_empty.run_sql(
+        "SELECT 1 as foo, 2 as bar", named=True, return_shape=ResultShape.ONE_MANY
+    )
     assert one_many_result.foo == 1
     assert one_many_result[0] == 1
     assert one_many_result.bar == 2

--- a/test/splitgraph/test_object_cache.py
+++ b/test/splitgraph/test_object_cache.py
@@ -9,7 +9,7 @@ from splitgraph.core.fragment_manager import _quals_to_clause
 from splitgraph.engine import ResultShape
 from splitgraph.exceptions import ObjectCacheError
 from test.splitgraph.commands.test_layered_querying import prepare_lq_repo
-from test.splitgraph.conftest import OUTPUT, _cleanup_minio
+from test.splitgraph.conftest import OUTPUT, _cleanup_minio, MIN_OBJECT_SIZE
 
 
 def _get_refcount(object_manager, object_id):
@@ -79,9 +79,9 @@ def test_object_cache_loading(local_engine_empty, pg_repo_remote):
     # Reported by Postgres itself and stored by the engine in object_tree. Might really backfire on us on different
     # Postgres versions.
     assert object_meta[fruit_diff].parent_id == fruit_snap
-    assert object_meta[fruit_diff].size == 8192
+    assert object_meta[fruit_diff].size == MIN_OBJECT_SIZE
     assert object_meta[fruit_snap].parent_id is None
-    assert object_meta[fruit_snap].size == 8192
+    assert object_meta[fruit_snap].size == MIN_OBJECT_SIZE
 
     # Resolve and download the old version: only one fragment should be downloaded.
     with object_manager.ensure_objects(fruits_v2) as required_objects:
@@ -157,19 +157,21 @@ def test_object_cache_eviction(local_engine_empty, pg_repo_remote):
     fruit_snap = fruits_v2.objects[0]
 
     # Check another test object has the same size
-    assert object_manager.get_object_meta([vegetables_snap])[vegetables_snap].size == 8192
+    assert (
+        object_manager.get_object_meta([vegetables_snap])[vegetables_snap].size == MIN_OBJECT_SIZE
+    )
 
     # Load the fruits objects into the cache
     with object_manager.ensure_objects(fruits_v3):
-        assert object_manager.get_cache_occupancy() == 8192 * 2
+        assert object_manager.get_cache_occupancy() == MIN_OBJECT_SIZE * 2
 
     # Pretend that the cache has no space and try getting a different table
     # Free space is now 0, so we need to run eviction.
-    object_manager.cache_size = 8192 * 2
+    object_manager.cache_size = MIN_OBJECT_SIZE * 2
     with object_manager.ensure_objects(vegetables_v2) as required_objects:
         current_objects = object_manager.get_downloaded_objects()
         assert len(current_objects) == 2  # vegetables_v2 downloaded
-        assert object_manager.get_cache_occupancy() == 8192 * 2
+        assert object_manager.get_cache_occupancy() == MIN_OBJECT_SIZE * 2
 
         # One of fruits' fragments remains: since they were both used at the same time and have
         # the same size, it's arbitrary which one gets evicted.
@@ -190,7 +192,7 @@ def test_object_cache_eviction(local_engine_empty, pg_repo_remote):
         pass
 
     # Now, let's try squeezing the cache even more so that there's only space for one object.
-    object_manager.cache_size = 8192
+    object_manager.cache_size = MIN_OBJECT_SIZE
     with object_manager.ensure_objects(vegetables_v2):
         assert not object_manager.object_engine.table_exists(SPLITGRAPH_META_SCHEMA, fruit_snap)
         assert object_manager.object_engine.table_exists(SPLITGRAPH_META_SCHEMA, vegetables_snap)
@@ -216,15 +218,15 @@ def test_object_cache_eviction_fraction(local_engine_empty, pg_repo_remote):
 
     # Load the fruits objects into the cache
     with object_manager.ensure_objects(fruits_v3):
-        assert object_manager.get_cache_occupancy() == 8192 * 2
+        assert object_manager.get_cache_occupancy() == MIN_OBJECT_SIZE * 2
 
     # Set the eviction fraction to 0.5 (clean out > half the cache in any case) and try downloading just one object.
-    object_manager.cache_size = 8192 * 2
+    object_manager.cache_size = MIN_OBJECT_SIZE * 2
     object_manager.eviction_min_fraction = 0.75
 
     with object_manager.ensure_objects(vegetables_v2):
         # Only one object should be in the cache since we evicted cache_size * 0.75 = 2 objects
-        assert object_manager.get_cache_occupancy() == 8192
+        assert object_manager.get_cache_occupancy() == MIN_OBJECT_SIZE
 
 
 def test_object_cache_locally_created_dont_get_evicted(local_engine_empty, pg_repo_remote):
@@ -246,8 +248,9 @@ def test_object_cache_locally_created_dont_get_evicted(local_engine_empty, pg_re
     # Despite that we have objects on the engine, they don't count towards the full cache occupancy.
     # 5 objects on the engine, 1 of them was created locally.
     assert len(object_manager.get_downloaded_objects()) == 5
-    assert object_manager.get_cache_occupancy() == 8192 * 4
-    assert object_manager.get_total_object_size() == 8192 * 5
+    assert object_manager.get_cache_occupancy() == MIN_OBJECT_SIZE * 4
+    assert object_manager._recalculate_cache_occupancy() == MIN_OBJECT_SIZE * 4
+    assert object_manager.get_total_object_size() == MIN_OBJECT_SIZE * 5
 
     # Evict all objects -- check to see the one we created still exists.
     object_manager.run_eviction(keep_objects=[], required_space=None)
@@ -264,8 +267,8 @@ def test_object_cache_eviction_orphaned(local_engine_empty, pg_repo_remote):
     fruits_v3 = pg_repo_local.images["latest"].get_table("fruits")
 
     with object_manager.ensure_objects(fruits_v3):
-        assert object_manager.get_cache_occupancy() == 8192 * 2
-        assert object_manager._recalculate_cache_occupancy() == 8192 * 2
+        assert object_manager.get_cache_occupancy() == MIN_OBJECT_SIZE * 2
+        assert object_manager._recalculate_cache_occupancy() == MIN_OBJECT_SIZE * 2
 
     # Delete the image and objects that it's made out of (outside of the normal ObjectManager.cleanup())
     pg_repo_local.images.delete([pg_repo_local.images["latest"].image_hash])
@@ -305,9 +308,9 @@ def test_object_cache_nested(local_engine_empty, pg_repo_remote):
     fruit_snap = fruits_v2.objects[0]
 
     with object_manager.ensure_objects(fruits_v3):
-        assert object_manager.get_cache_occupancy() == 8192 * 2
+        assert object_manager.get_cache_occupancy() == MIN_OBJECT_SIZE * 2
         with object_manager.ensure_objects(vegetables_v2):
-            assert object_manager.get_cache_occupancy() == 8192 * 3
+            assert object_manager.get_cache_occupancy() == MIN_OBJECT_SIZE * 3
             assert _get_refcount(object_manager, fruit_diff) == 1
             assert _get_refcount(object_manager, fruit_snap) == 1
             assert _get_refcount(object_manager, vegetables_snap) == 1
@@ -317,7 +320,7 @@ def test_object_cache_nested(local_engine_empty, pg_repo_remote):
     object_manager.run_eviction(keep_objects=[], required_space=None)
     assert len(object_manager.get_downloaded_objects()) == 0
 
-    object_manager.cache_size = 8192 * 2
+    object_manager.cache_size = MIN_OBJECT_SIZE * 2
     with object_manager.ensure_objects(fruits_v3):
         # Now the fruits objects are being used and so we can't reclaim that space and have to raise an error.
         with pytest.raises(ObjectCacheError) as ex:
@@ -342,7 +345,7 @@ def test_object_cache_eviction_priority(local_engine_empty, pg_repo_remote):
     vegetables_diff = vegetables_v3.objects[0]
 
     # Setup: the cache has enough space for 3 objects
-    object_manager.cache_size = 8192 * 3
+    object_manager.cache_size = MIN_OBJECT_SIZE * 3
 
     # Can't use time-freezing methods (e.g. freezegun) here since we interact with the Minio server which timestamps
     # everything with the actual current time and kindly tells us to go away when we show up from the past and ask
@@ -408,8 +411,8 @@ def test_object_cache_make_external(pg_repo_local, clean_minio):
 
     # Mark objects as external and upload them
     pg_repo_local.objects.make_objects_external(all_objects, handler="S3", handler_params={})
-    assert pg_repo_local.objects.get_cache_occupancy() == 8192 * 2
-    assert pg_repo_local.objects._recalculate_cache_occupancy() == 8192 * 2
+    assert pg_repo_local.objects.get_cache_occupancy() == MIN_OBJECT_SIZE * 2
+    assert pg_repo_local.objects._recalculate_cache_occupancy() == MIN_OBJECT_SIZE * 2
 
     pg_repo_local.objects.run_eviction(keep_objects=[], required_space=None)
     assert pg_repo_local.objects.get_cache_occupancy() == 0
@@ -423,8 +426,8 @@ def test_object_cache_make_external(pg_repo_local, clean_minio):
         with pg_repo_local.objects.ensure_objects(
             pg_repo_local.images["latest"].get_table("vegetables")
         ) as obs2:
-            assert pg_repo_local.objects.get_cache_occupancy() == 8192 * 2
-            assert pg_repo_local.objects._recalculate_cache_occupancy() == 8192 * 2
+            assert pg_repo_local.objects.get_cache_occupancy() == MIN_OBJECT_SIZE * 2
+            assert pg_repo_local.objects._recalculate_cache_occupancy() == MIN_OBJECT_SIZE * 2
             assert list(sorted(pg_repo_local.objects.get_downloaded_objects())) == all_objects
 
 

--- a/test/splitgraph/test_object_cache.py
+++ b/test/splitgraph/test_object_cache.py
@@ -1,7 +1,8 @@
 from datetime import datetime as dt
 
 import pytest
-from splitgraph.core import clone, select, SPLITGRAPH_META_SCHEMA
+from splitgraph import SPLITGRAPH_META_SCHEMA
+from splitgraph.core import clone, select
 from splitgraph.core.fragment_manager import _quals_to_clause
 from splitgraph.engine import ResultShape
 from splitgraph.exceptions import ObjectCacheError

--- a/test/splitgraph/test_object_cache.py
+++ b/test/splitgraph/test_object_cache.py
@@ -2,6 +2,7 @@ import itertools
 from datetime import datetime as dt
 
 import pytest
+
 from splitgraph import SPLITGRAPH_META_SCHEMA
 from splitgraph.core import clone, select
 from splitgraph.core.fragment_manager import _quals_to_clause
@@ -242,11 +243,11 @@ def test_object_cache_locally_created_dont_get_evicted(local_engine_empty, pg_re
     head.checkout()
     new_head.checkout()
 
-    # Despite that we have objects on the engine, they don't count towards the full cache occupancy
+    # Despite that we have objects on the engine, they don't count towards the full cache occupancy.
+    # 5 objects on the engine, 1 of them was created locally.
     assert len(object_manager.get_downloaded_objects()) == 5
-    assert (
-        object_manager.get_cache_occupancy() == 8192 * 4
-    )  # 5 objects on the engine, 1 of them was created locally.
+    assert object_manager.get_cache_occupancy() == 8192 * 4
+    assert object_manager.get_total_object_size() == 8192 * 5
 
     # Evict all objects -- check to see the one we created still exists.
     object_manager.run_eviction(keep_objects=[], required_space=None)

--- a/test/splitgraph/test_sql_validation.py
+++ b/test/splitgraph/test_sql_validation.py
@@ -1,7 +1,7 @@
 import pytest
 
 from splitgraph.core.sql import validate_splitfile_sql, validate_import_sql
-from splitgraph.exceptions import UnsupportedSQLException
+from splitgraph.exceptions import UnsupportedSQLError
 
 
 def succeeds_on_both(sql):
@@ -10,15 +10,15 @@ def succeeds_on_both(sql):
 
 
 def fails_on_both(sql):
-    with pytest.raises(UnsupportedSQLException) as e:
+    with pytest.raises(UnsupportedSQLError) as e:
         validate_splitfile_sql(sql)
-    with pytest.raises(UnsupportedSQLException) as e:
+    with pytest.raises(UnsupportedSQLError) as e:
         validate_import_sql(sql)
 
 
 def succeeds_on_sql_fails_on_import(sql):
     validate_splitfile_sql(sql)
-    with pytest.raises(UnsupportedSQLException) as e:
+    with pytest.raises(UnsupportedSQLError) as e:
         validate_import_sql(sql)
 
 


### PR DESCRIPTION
* Fixes to various race conditions and consistency issues with multiple sgr processes trying to create objects with the same contents/IDs
* Split up the single `SplitgraphException` into multiple exception classes based on module/component -- e.g. raise an UnitializedEngineError rather than a generic SQL exception