### PR TITLE
Bugfix/object creation

### DIFF
--- a/splitgraph/commandline/__init__.py
+++ b/splitgraph/commandline/__init__.py
@@ -8,7 +8,15 @@ import click
 
 from splitgraph.commandline.example import example
 from splitgraph.commandline.image_creation import checkout_c, commit_c, tag_c, import_c
-from splitgraph.commandline.image_info import log_c, diff_c, show_c, sql_c, status_c, object_c
+from splitgraph.commandline.image_info import (
+    log_c,
+    diff_c,
+    show_c,
+    sql_c,
+    status_c,
+    object_c,
+    objects_c,
+)
 from splitgraph.commandline.ingestion import csv
 from splitgraph.commandline.misc import rm_c, init_c, cleanup_c, config_c, prune_c, dump_c
 from splitgraph.commandline.mount import mount_c
@@ -54,6 +62,7 @@ cli.add_command(import_c)
 cli.add_command(log_c)
 cli.add_command(diff_c)
 cli.add_command(object_c)
+cli.add_command(objects_c)
 cli.add_command(show_c)
 cli.add_command(sql_c)
 cli.add_command(status_c)

--- a/splitgraph/commandline/image_info.py
+++ b/splitgraph/commandline/image_info.py
@@ -234,6 +234,25 @@ def object_c(object_id):
             print("Location: " + original_location)
 
 
+@click.command(name="objects")
+@click.option(
+    "--local", is_flag=True, help="Show only objects that are physically present on this engine"
+)
+def objects_c(local):
+    """
+    List objects known to this engine.
+    """
+
+    om = ObjectManager(get_engine())
+
+    if local:
+        objects = om.get_downloaded_objects()
+    else:
+        objects = om.get_all_objects()
+
+    print("\n".join(sorted(objects)))
+
+
 @click.command(name="sql")
 @click.argument("sql")
 @click.option("-s", "--schema", help="Run SQL against this schema.")

--- a/splitgraph/core/_common.py
+++ b/splitgraph/core/_common.py
@@ -63,7 +63,7 @@ def manage_audit_triggers(engine, object_engine=None):
         if head is not None
         for t in set(object_engine.get_all_tables(r.to_schema())) & set(head.get_tables())
     ]
-    tracked_tables = engine.get_tracked_tables()
+    tracked_tables = object_engine.get_tracked_tables()
 
     to_untrack = [t for t in tracked_tables if t not in repos_tables]
     to_track = [t for t in repos_tables if t not in tracked_tables]

--- a/splitgraph/core/object_manager.py
+++ b/splitgraph/core/object_manager.py
@@ -264,7 +264,7 @@ class ObjectManager(FragmentManager, MetadataManager):
         now = dt.now()
         self.object_engine.run_sql_batch(
             insert("object_cache_status", ("object_id", "ready", "refcount", "last_used"))
-            + SQL("ON CONFLICT DO NOTHING"),
+            + SQL("ON CONFLICT (object_id) DO UPDATE SET ready = 'f'"),
             [(object_id, False, 1, now) for object_id in new_objects],
         )
 

--- a/splitgraph/hooks/s3.py
+++ b/splitgraph/hooks/s3.py
@@ -22,6 +22,34 @@ S3_SECRET_KEY = CONFIG["SG_S3_PWD"]
 # just exist on a hard drive somewhere.
 
 
+def delete_objects(client, object_ids):
+    """
+    Delete objects stored in Minio
+
+    :param client: Minio client
+    :param object_ids: List of Splitgraph object IDs to delete
+    """
+
+    # Expand the list of objects into actual files we store in Minio
+    all_object_ids = [o + suffix for o in object_ids for suffix in ("", ".schema", ".footer")]
+    list(client.remove_objects(S3_ACCESS_KEY, all_object_ids))
+
+
+def list_objects(client):
+    """
+    List objects stored in Minio
+
+    :param client: Minio client
+    :return: List of Splitgraph object IDs
+    """
+
+    return [
+        o.object_name
+        for o in client.list_objects(bucket_name=S3_ACCESS_KEY)
+        if not o.object_name.endswith(".footer") and not o.object_name.endswith(".schema")
+    ]
+
+
 class S3ExternalObjectHandler(ExternalObjectHandler):
     """Uploads/downloads the objects to/from S3/S3-compatible host using the Minio client.
         The parameters for this handler (overriding the .sgconfig) are:

--- a/test/splitgraph/conftest.py
+++ b/test/splitgraph/conftest.py
@@ -270,6 +270,9 @@ def unprivileged_pg_repo(pg_repo_remote, unprivileged_remote_engine):
 
 
 SPLITFILE_ROOT = os.path.join(os.path.dirname(__file__), "../resources/")
+MINIO = Minio(
+    "%s:%s" % (S3_HOST, S3_PORT), access_key=S3_ACCESS_KEY, secret_key=S3_SECRET_KEY, secure=False
+)
 
 
 def load_splitfile(name):
@@ -278,23 +281,17 @@ def load_splitfile(name):
 
 
 def _cleanup_minio():
-    client = Minio(
-        "%s:%s" % (S3_HOST, S3_PORT),
-        access_key=S3_ACCESS_KEY,
-        secret_key=S3_SECRET_KEY,
-        secure=False,
-    )
-    if client.bucket_exists(S3_ACCESS_KEY):
-        objects = [o.object_name for o in client.list_objects(bucket_name=S3_ACCESS_KEY)]
+    if MINIO.bucket_exists(S3_ACCESS_KEY):
+        objects = [o.object_name for o in MINIO.list_objects(bucket_name=S3_ACCESS_KEY)]
         # remove_objects is an iterator, so we force evaluate it
-        list(client.remove_objects(bucket_name=S3_ACCESS_KEY, objects_iter=objects))
+        list(MINIO.remove_objects(bucket_name=S3_ACCESS_KEY, objects_iter=objects))
 
 
 @pytest.fixture
 def clean_minio():
     # Make sure to delete extra objects in the remote Minio bucket
     _cleanup_minio()
-    yield
+    yield MINIO
     # Comment this out if tests fail and you want to see what the hell went on in the bucket.
     _cleanup_minio()
 

--- a/test/splitgraph/test_commandline.py
+++ b/test/splitgraph/test_commandline.py
@@ -9,7 +9,7 @@ from splitgraph import ResultShape, get_engine
 from splitgraph.commandline import *
 from splitgraph.commandline._common import ImageType
 from splitgraph.commandline.example import generate_c, alter_c, splitfile_c
-from splitgraph.commandline.image_info import object_c
+from splitgraph.commandline.image_info import object_c, objects_c
 from splitgraph.config import PG_PWD, PG_USER
 from splitgraph.core._common import parse_connection_string, serialize_connection_string, insert
 from splitgraph.core.engine import repository_exists, init_engine
@@ -279,6 +279,14 @@ Original location: example.com/objects/base_1.tgz (HTTP)
     result = runner.invoke(object_c, ["patch_2"])
     assert result.exit_code == 0
     assert "Location: created locally" in result.output
+
+    result = runner.invoke(objects_c)
+    assert result.exit_code == 0
+    assert result.output == "base_1\npatch_1\npatch_2\n"
+
+    result = runner.invoke(objects_c, ["--local"])
+    assert result.exit_code == 0
+    assert result.output == "base_1\npatch_2\n"
 
 
 def test_upstream_management(pg_repo_local):

--- a/test/splitgraph/test_commandline.py
+++ b/test/splitgraph/test_commandline.py
@@ -59,13 +59,12 @@ def test_conn_string_serialization():
     )
 
 
-def test_commandline_basics(pg_repo_local, mg_repo_local):
+def test_commandline_basics(pg_repo_local):
     runner = CliRunner()
 
     # sgr status
     result = runner.invoke(status_c, [])
     assert pg_repo_local.to_schema() in result.output
-    assert mg_repo_local.to_schema() in result.output
     old_head = pg_repo_local.head
     assert old_head.image_hash in result.output
 

--- a/test/splitgraph/test_drawing.py
+++ b/test/splitgraph/test_drawing.py
@@ -3,7 +3,7 @@ from splitgraph.splitfile.execution import execute_commands, rebuild_image
 from test.splitgraph.conftest import OUTPUT, load_splitfile
 
 
-def test_drawing(pg_repo_local, mg_repo_local):
+def test_drawing(pg_repo_local):
     # Doesn't really check anything, mostly used to make sure the tree drawing code doesn't throw.
     execute_commands(load_splitfile("import_local.splitfile"), output=OUTPUT)
 


### PR DESCRIPTION
Fixes for the corner case where we have different metadata and object engines, an object gets deleted from the metadata engine but still stays in the cache on the object engine and then gets recreated again -- in this case, the object creation routine sees that the object already exists in the cache and skips re-registering it. Fix this to try doing both creation and registration in any case.

Also, add a command to list all objects on the metadata and the object engine as well as cleanup a couple of tests.