### PR TITLE
Feature/s3 presigned urls

### DIFF
--- a/splitgraph/hooks/s3.py
+++ b/splitgraph/hooks/s3.py
@@ -40,7 +40,7 @@ class S3ExternalObjectHandler(ExternalObjectHandler):
         :return: List of object IDs on Minio
         """
         worker_threads = self.params.get("threads", int(CONFIG["SG_ENGINE_POOL"]) - 1)
-        s3_host = self.params.get("host", CONFIG["SG_S3_HOST"])
+        s3_host = self.params.get("host", "%s:%s" % (CONFIG["SG_S3_HOST"], CONFIG["SG_S3_PORT"]))
 
         # Determine upload URLs
         logging.info("Getting upload URLs from the registry...")
@@ -76,7 +76,7 @@ class S3ExternalObjectHandler(ExternalObjectHandler):
         # By default, take up the whole connection pool with downloaders (less one connection for the main
         # thread that handles metadata)
         worker_threads = self.params.get("threads", int(CONFIG["SG_ENGINE_POOL"]) - 1)
-        s3_host = self.params.get("host", CONFIG["SG_S3_HOST"])
+        s3_host = self.params.get("host", "%s:%s" % (CONFIG["SG_S3_HOST"], CONFIG["SG_S3_PORT"]))
 
         logging.info("Getting download URLs from the registry...")
         object_ids = [o[0] for o in objects]

--- a/splitgraph/hooks/s3.py
+++ b/splitgraph/hooks/s3.py
@@ -43,15 +43,11 @@ class S3ExternalObjectHandler(ExternalObjectHandler):
 
         # Determine upload URLs
         logging.info("Getting upload URLs from the registry...")
-        urls = []
-        for object_id in objects:
-            urls.append(
-                remote_engine.run_sql(
-                    "SELECT splitgraph_api.get_object_upload_url(%s)",
-                    (object_id,),
-                    return_shape=ResultShape.ONE_ONE,
-                )
-            )
+        urls = remote_engine.run_sql(
+            "SELECT splitgraph_api.get_object_upload_urls(%s)",
+            (objects,),
+            return_shape=ResultShape.ONE_ONE,
+        )
 
         logging.info("Uploading %d object(s)...", len(objects))
         local_engine = get_engine()
@@ -81,17 +77,13 @@ class S3ExternalObjectHandler(ExternalObjectHandler):
         worker_threads = self.params.get("threads", int(CONFIG["SG_ENGINE_POOL"]) - 1)
 
         logging.info("Getting download URLs from the registry...")
-        urls = []
-        object_ids = []
-        for object_id, remote_object_id in objects:
-            urls.append(
-                remote_engine.run_sql(
-                    "SELECT splitgraph_api.get_object_download_url(%s)",
-                    (remote_object_id,),
-                    return_shape=ResultShape.ONE_ONE,
-                )
-            )
-            object_ids.append(object_id)
+        object_ids = [o[0] for o in objects]
+        remote_object_ids = [o[1] for o in objects]
+        urls = remote_engine.run_sql(
+            "SELECT splitgraph_api.get_object_download_urls(%s)",
+            (remote_object_ids,),
+            return_shape=ResultShape.ONE_ONE,
+        )
         logging.info("Downloading %d object(s)...", len(objects))
 
         local_engine = get_engine()

--- a/splitgraph/hooks/s3.py
+++ b/splitgraph/hooks/s3.py
@@ -40,12 +40,13 @@ class S3ExternalObjectHandler(ExternalObjectHandler):
         :return: List of object IDs on Minio
         """
         worker_threads = self.params.get("threads", int(CONFIG["SG_ENGINE_POOL"]) - 1)
+        s3_host = self.params.get("host", CONFIG["SG_S3_HOST"])
 
         # Determine upload URLs
         logging.info("Getting upload URLs from the registry...")
         urls = remote_engine.run_sql(
-            "SELECT splitgraph_api.get_object_upload_urls(%s)",
-            (objects,),
+            "SELECT splitgraph_api.get_object_upload_urls(%s, %s)",
+            (s3_host, objects),
             return_shape=ResultShape.ONE_ONE,
         )
 
@@ -75,13 +76,14 @@ class S3ExternalObjectHandler(ExternalObjectHandler):
         # By default, take up the whole connection pool with downloaders (less one connection for the main
         # thread that handles metadata)
         worker_threads = self.params.get("threads", int(CONFIG["SG_ENGINE_POOL"]) - 1)
+        s3_host = self.params.get("host", CONFIG["SG_S3_HOST"])
 
         logging.info("Getting download URLs from the registry...")
         object_ids = [o[0] for o in objects]
         remote_object_ids = [o[1] for o in objects]
         urls = remote_engine.run_sql(
-            "SELECT splitgraph_api.get_object_download_urls(%s)",
-            (remote_object_ids,),
+            "SELECT splitgraph_api.get_object_download_urls(%s, %s)",
+            (s3_host, remote_object_ids),
             return_shape=ResultShape.ONE_ONE,
         )
         logging.info("Downloading %d object(s)...", len(objects))

--- a/splitgraph/hooks/s3_server.py
+++ b/splitgraph/hooks/s3_server.py
@@ -28,7 +28,7 @@ def get_object_upload_urls(s3_host, object_ids):
     :param object_ids: List of object IDs
     :return: A list of lists [(object URL, object footer URL, object schema URL)]
     """
-    if s3_host != S3_HOST:
+    if s3_host != "%s:%s" % (S3_HOST, S3_PORT):
         raise ValueError("Cannot access S3 host %s!" % s3_host)
     return [
         [
@@ -49,7 +49,7 @@ def get_object_download_urls(s3_host, object_ids):
     :param object_ids: List of object IDs
     :return: A list of lists [(object URL, object footer URL, object schema URL)]
     """
-    if s3_host != S3_HOST:
+    if s3_host != "%s:%s" % (S3_HOST, S3_PORT):
         raise ValueError("Cannot access S3 host %s!" % s3_host)
     return [
         [

--- a/splitgraph/hooks/s3_server.py
+++ b/splitgraph/hooks/s3_server.py
@@ -20,22 +20,41 @@ MINIO = Minio(
 _EXP = timedelta(seconds=60)
 
 
-def get_object_upload_url(object_id):
-    return tuple(
-        MINIO.presigned_put_object(
-            bucket_name=S3_BUCKET, object_name=object_id + suffix, expires=_EXP
-        )
-        for suffix in ("", ".footer", ".schema")
-    )
+def get_object_upload_urls(object_ids):
+    """
+    Return a list of pre-signed URLs that each part of an object can be downloaded from.
+
+    :param object_ids: List of object IDs
+    :return: A list of lists [(object URL, object footer URL, object schema URL)]
+    """
+    return [
+        [
+            MINIO.presigned_put_object(
+                bucket_name=S3_BUCKET, object_name=object_id + suffix, expires=_EXP
+            )
+            for suffix in ("", ".footer", ".schema")
+        ]
+        for object_id in object_ids
+    ]
 
 
-def get_object_download_url(object_id):
-    return tuple(
-        MINIO.presigned_get_object(
-            bucket_name=S3_BUCKET, object_name=object_id + suffix, expires=_EXP
-        )
-        for suffix in ("", ".footer", ".schema")
-    )
+def get_object_download_urls(object_ids):
+    """
+    Return a list of pre-signed URLs that each part of an object can be downloaded from.
+
+    :param object_ids: List of object IDs
+    :return: A list of lists [(object URL, object footer URL, object schema URL)]
+    """
+
+    return [
+        [
+            MINIO.presigned_get_object(
+                bucket_name=S3_BUCKET, object_name=object_id + suffix, expires=_EXP
+            )
+            for suffix in ("", ".footer", ".schema")
+        ]
+        for object_id in object_ids
+    ]
 
 
 def delete_objects(client, object_ids):

--- a/splitgraph/hooks/s3_server.py
+++ b/splitgraph/hooks/s3_server.py
@@ -20,13 +20,16 @@ MINIO = Minio(
 _EXP = timedelta(seconds=60)
 
 
-def get_object_upload_urls(object_ids):
+def get_object_upload_urls(s3_host, object_ids):
     """
     Return a list of pre-signed URLs that each part of an object can be downloaded from.
 
+    :param s3_host: S3 host that the objects are stored on
     :param object_ids: List of object IDs
     :return: A list of lists [(object URL, object footer URL, object schema URL)]
     """
+    if s3_host != S3_HOST:
+        raise ValueError("Cannot access S3 host %s!" % s3_host)
     return [
         [
             MINIO.presigned_put_object(
@@ -38,14 +41,16 @@ def get_object_upload_urls(object_ids):
     ]
 
 
-def get_object_download_urls(object_ids):
+def get_object_download_urls(s3_host, object_ids):
     """
     Return a list of pre-signed URLs that each part of an object can be downloaded from.
 
+    :param s3_host: S3 host that the objects are stored on
     :param object_ids: List of object IDs
     :return: A list of lists [(object URL, object footer URL, object schema URL)]
     """
-
+    if s3_host != S3_HOST:
+        raise ValueError("Cannot access S3 host %s!" % s3_host)
     return [
         [
             MINIO.presigned_get_object(

--- a/splitgraph/resources/push_pull.sql
+++ b/splitgraph/resources/push_pull.sql
@@ -281,13 +281,13 @@ CREATE EXTENSION IF NOT EXISTS plpython3u;
 
 -- Importing splitgraph.config isn't much slower than importing that + minio
 -- (300ms vs 500ms) -- basically no matter what, we can't do it for every object.
-CREATE OR REPLACE FUNCTION splitgraph_api.get_object_upload_urls(object_ids varchar[]) RETURNS varchar[][] AS $$
+CREATE OR REPLACE FUNCTION splitgraph_api.get_object_upload_urls(s3_host varchar, object_ids varchar[]) RETURNS varchar[][] AS $$
     from splitgraph.hooks.s3_server import get_object_upload_urls
-    return get_object_upload_urls(object_ids)
+    return get_object_upload_urls(s3_host, object_ids)
 $$ LANGUAGE plpython3u SECURITY DEFINER;
 
 -- get_object_download_url(object_id)
-CREATE OR REPLACE FUNCTION splitgraph_api.get_object_download_urls(object_ids varchar[]) RETURNS varchar[][] AS $$
+CREATE OR REPLACE FUNCTION splitgraph_api.get_object_download_urls(s3_host varchar, object_ids varchar[]) RETURNS varchar[][] AS $$
     from splitgraph.hooks.s3_server import get_object_download_urls
-    return get_object_download_urls(object_ids)
+    return get_object_download_urls(s3_host, object_ids)
 $$ LANGUAGE plpython3u SECURITY DEFINER;

--- a/splitgraph/resources/push_pull.sql
+++ b/splitgraph/resources/push_pull.sql
@@ -281,13 +281,13 @@ CREATE EXTENSION IF NOT EXISTS plpython3u;
 
 -- Importing splitgraph.config isn't much slower than importing that + minio
 -- (300ms vs 500ms) -- basically no matter what, we can't do it for every object.
-CREATE OR REPLACE FUNCTION splitgraph_api.get_object_upload_url(object_id varchar) RETURNS varchar[] AS $$
-    from splitgraph.hooks.s3_server import get_object_upload_url
-    return get_object_upload_url(object_id)
+CREATE OR REPLACE FUNCTION splitgraph_api.get_object_upload_urls(object_ids varchar[]) RETURNS varchar[][] AS $$
+    from splitgraph.hooks.s3_server import get_object_upload_urls
+    return get_object_upload_urls(object_ids)
 $$ LANGUAGE plpython3u SECURITY DEFINER;
 
 -- get_object_download_url(object_id)
-CREATE OR REPLACE FUNCTION splitgraph_api.get_object_download_url(object_id varchar) RETURNS varchar[] AS $$
-    from splitgraph.hooks.s3_server import get_object_download_url
-    return get_object_download_url(object_id)
+CREATE OR REPLACE FUNCTION splitgraph_api.get_object_download_urls(object_ids varchar[]) RETURNS varchar[][] AS $$
+    from splitgraph.hooks.s3_server import get_object_download_urls
+    return get_object_download_urls(object_ids)
 $$ LANGUAGE plpython3u SECURITY DEFINER;

--- a/test/splitgraph/commands/test_external_objects.py
+++ b/test/splitgraph/commands/test_external_objects.py
@@ -5,7 +5,12 @@ from minio.error import MinioError
 
 from splitgraph import ResultShape
 from splitgraph.core.repository import clone
-from splitgraph.hooks.s3_server import get_object_upload_urls, get_object_download_urls, S3_HOST
+from splitgraph.hooks.s3_server import (
+    get_object_upload_urls,
+    get_object_download_urls,
+    S3_HOST,
+    S3_PORT,
+)
 from test.splitgraph.conftest import PG_MNT
 
 
@@ -19,16 +24,16 @@ def test_s3_presigned_url(local_engine_empty, pg_repo_remote, clean_minio):
 
     # Do a test calling the signer locally (the tests currently have access
     # to the S3 credentials on the host they're running on)
-    urls_local = get_object_upload_urls(S3_HOST, [object_id])
+    urls_local = get_object_upload_urls("%s:%s" % (S3_HOST, S3_PORT), [object_id])
     assert len(urls_local) == 1
     assert len(urls_local[0]) == 3
-    urls_local = get_object_download_urls(S3_HOST, [object_id])
+    urls_local = get_object_download_urls("%s:%s" % (S3_HOST, S3_PORT), [object_id])
     assert len(urls_local) == 1
     assert len(urls_local[0]) == 3
 
     urls = pg_repo_remote.run_sql(
         "SELECT * FROM splitgraph_api.get_object_upload_urls(%s, %s)",
-        (S3_HOST, [object_id]),
+        ("%s:%s" % (S3_HOST, S3_PORT), [object_id]),
         return_shape=ResultShape.ONE_ONE,
     )
     assert len(urls) == 1

--- a/test/splitgraph/commands/test_external_objects.py
+++ b/test/splitgraph/commands/test_external_objects.py
@@ -5,7 +5,7 @@ from minio.error import MinioError
 
 from splitgraph import ResultShape
 from splitgraph.core.repository import clone
-from splitgraph.hooks.s3_server import get_object_upload_url, get_object_download_url
+from splitgraph.hooks.s3_server import get_object_upload_urls, get_object_download_urls
 from test.splitgraph.conftest import PG_MNT
 
 
@@ -19,17 +19,20 @@ def test_s3_presigned_url(local_engine_empty, pg_repo_remote, clean_minio):
 
     # Do a test calling the signer locally (the tests currently have access
     # to the S3 credentials on the host they're running on)
-    urls_local = get_object_upload_url(object_id)
-    assert len(urls_local) == 3
-    urls_local = get_object_download_url(object_id)
-    assert len(urls_local) == 3
+    urls_local = get_object_upload_urls([object_id])
+    assert len(urls_local) == 1
+    assert len(urls_local[0]) == 3
+    urls_local = get_object_download_urls([object_id])
+    assert len(urls_local) == 1
+    assert len(urls_local[0]) == 3
 
     urls = pg_repo_remote.run_sql(
-        "SELECT splitgraph_api.get_object_upload_url(%s)",
-        (object_id,),
+        "SELECT * FROM splitgraph_api.get_object_upload_urls(%s)",
+        ([object_id],),
         return_shape=ResultShape.ONE_ONE,
     )
-    assert len(urls) == 3
+    assert len(urls) == 1
+    assert len(urls[0]) == 3
 
 
 def test_s3_push_pull(local_engine_empty, pg_repo_remote, clean_minio):

--- a/test/splitgraph/commands/test_external_objects.py
+++ b/test/splitgraph/commands/test_external_objects.py
@@ -5,7 +5,7 @@ from minio.error import MinioError
 
 from splitgraph import ResultShape
 from splitgraph.core.repository import clone
-from splitgraph.hooks.s3_server import get_object_upload_urls, get_object_download_urls
+from splitgraph.hooks.s3_server import get_object_upload_urls, get_object_download_urls, S3_HOST
 from test.splitgraph.conftest import PG_MNT
 
 
@@ -19,16 +19,16 @@ def test_s3_presigned_url(local_engine_empty, pg_repo_remote, clean_minio):
 
     # Do a test calling the signer locally (the tests currently have access
     # to the S3 credentials on the host they're running on)
-    urls_local = get_object_upload_urls([object_id])
+    urls_local = get_object_upload_urls(S3_HOST, [object_id])
     assert len(urls_local) == 1
     assert len(urls_local[0]) == 3
-    urls_local = get_object_download_urls([object_id])
+    urls_local = get_object_download_urls(S3_HOST, [object_id])
     assert len(urls_local) == 1
     assert len(urls_local[0]) == 3
 
     urls = pg_repo_remote.run_sql(
-        "SELECT * FROM splitgraph_api.get_object_upload_urls(%s)",
-        ([object_id],),
+        "SELECT * FROM splitgraph_api.get_object_upload_urls(%s, %s)",
+        (S3_HOST, [object_id]),
         return_shape=ResultShape.ONE_ONE,
     )
     assert len(urls) == 1

--- a/test/splitgraph/test_object_cache.py
+++ b/test/splitgraph/test_object_cache.py
@@ -635,10 +635,10 @@ def test_sync_object_mounts(pg_repo_local, clean_minio):
     _, s3_id, _ = pg_repo_local.objects.get_external_object_locations([object_id])[0]
 
     url = pg_repo_local.engine.run_sql(
-        "SELECT splitgraph_api.get_object_download_url(%s)",
-        (s3_id,),
+        "SELECT splitgraph_api.get_object_download_urls(%s)",
+        ([s3_id],),
         return_shape=ResultShape.ONE_ONE,
-    )
+    )[0]
 
     pg_repo_local.engine.run_sql("SELECT splitgraph_api.download_object(%s, %s)", (object_id, url))
     assert object_id in pg_repo_local.objects.get_downloaded_objects()

--- a/test/splitgraph/test_object_cache.py
+++ b/test/splitgraph/test_object_cache.py
@@ -8,6 +8,7 @@ from splitgraph.core import clone, select
 from splitgraph.core.fragment_manager import _quals_to_clause
 from splitgraph.engine import ResultShape
 from splitgraph.exceptions import ObjectCacheError
+from splitgraph.hooks.s3_server import S3_HOST
 from test.splitgraph.commands.test_layered_querying import prepare_lq_repo
 from test.splitgraph.conftest import (
     OUTPUT,
@@ -635,8 +636,8 @@ def test_sync_object_mounts(pg_repo_local, clean_minio):
     _, s3_id, _ = pg_repo_local.objects.get_external_object_locations([object_id])[0]
 
     url = pg_repo_local.engine.run_sql(
-        "SELECT splitgraph_api.get_object_download_urls(%s)",
-        ([s3_id],),
+        "SELECT splitgraph_api.get_object_download_urls(%s, %s)",
+        (S3_HOST, [s3_id]),
         return_shape=ResultShape.ONE_ONE,
     )[0]
 

--- a/test/splitgraph/test_object_cache.py
+++ b/test/splitgraph/test_object_cache.py
@@ -8,7 +8,7 @@ from splitgraph.core import clone, select
 from splitgraph.core.fragment_manager import _quals_to_clause
 from splitgraph.engine import ResultShape
 from splitgraph.exceptions import ObjectCacheError
-from splitgraph.hooks.s3_server import S3_HOST
+from splitgraph.hooks.s3_server import S3_HOST, S3_PORT
 from test.splitgraph.commands.test_layered_querying import prepare_lq_repo
 from test.splitgraph.conftest import (
     OUTPUT,
@@ -637,7 +637,7 @@ def test_sync_object_mounts(pg_repo_local, clean_minio):
 
     url = pg_repo_local.engine.run_sql(
         "SELECT splitgraph_api.get_object_download_urls(%s, %s)",
-        (S3_HOST, [s3_id]),
+        ("%s:%s" % (S3_HOST, S3_PORT), [s3_id]),
         return_shape=ResultShape.ONE_ONE,
     )[0]
 


### PR DESCRIPTION
* Allow batch presigning (pass in an array of object IDs, get back an array of arrays of URLs)
* Allow passing a custom S3 host into the signers (since it's supposed to be part of the signature and the client might access the same Minio server by a different route)