### PR TITLE
Feature/direct s3 fixtures

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -5,3 +5,6 @@ test=pytest
 addopts = --cov splitgraph --cov-branch --cov-report term --cov-report html
 env =
     SG_CONFIG_FILE = test/resources/.sgconfig
+markers =
+    mounting: Requires one of the databases in mounting.yml to be up (testing FDW mounting for Mongo/MySQL/Postgres)
+    registry: Tests that use a remote engine and that can be run against the registry instead (run as an unprivileged user and don't require object storage or checkouts to work)

--- a/splitgraph/core/fdw_checkout.py
+++ b/splitgraph/core/fdw_checkout.py
@@ -79,14 +79,19 @@ class QueryingForeignDataWrapper(ForeignDataWrapper):
 
         # Try using a UNIX socket if the engine is local to us
         engine = get_engine(
-            self.fdw_options["engine"], bool(self.fdw_options.get("use_socket", False))
+            self.fdw_options["engine"],
+            bool(self.fdw_options.get("use_socket", False)),
+            use_fdw_params=True,
         )
         if "object_engine" in self.fdw_options:
             object_engine = get_engine(
-                self.fdw_options["object_engine"], bool(self.fdw_options.get("use_socket", False))
+                self.fdw_options["object_engine"],
+                bool(self.fdw_options.get("use_socket", False)),
+                use_fdw_params=True,
             )
         else:
             object_engine = engine
+
         repository = Repository(
             fdw_options["namespace"],
             self.fdw_options["repository"],

--- a/splitgraph/core/image.py
+++ b/splitgraph/core/image.py
@@ -56,13 +56,14 @@ class Image(namedtuple("Image", IMAGE_COLS + ["repository", "engine", "object_en
         """
         Gets the names of all tables inside of an image.
         """
-        return self.engine.run_sql(
+        result = self.engine.run_sql(
             select(
-                "tables", "table_name", "namespace = %s AND repository = %s AND image_hash = %s"
+                "get_tables", "table_name", table_args="(%s,%s,%s)", schema=SPLITGRAPH_API_SCHEMA
             ),
             (self.repository.namespace, self.repository.repository, self.image_hash),
             return_shape=ResultShape.MANY_ONE,
         )
+        return result or []
 
     def get_table(self, table_name):
         """

--- a/splitgraph/engine/__init__.py
+++ b/splitgraph/engine/__init__.py
@@ -27,6 +27,7 @@ _ENGINE_SPECIFIC_CONFIG = [
     "SG_ENGINE_FDW_HOST",
     "SG_ENGINE_FDW_PORT",
     "SG_ENGINE_OBJECT_PATH",
+    "SG_NAMESPACE",
 ]
 
 # Some engine config keys default to values of other keys if unspecified.

--- a/splitgraph/engine/__init__.py
+++ b/splitgraph/engine/__init__.py
@@ -571,7 +571,7 @@ _ENGINE = CONFIG["SG_ENGINE"] or "LOCAL"
 _ENGINES = {}
 
 
-def get_engine(name=None, use_socket=False):
+def get_engine(name=None, use_socket=False, use_fdw_params=False):
     """
     Get the current global engine or a named remote engine
 
@@ -596,6 +596,9 @@ def get_engine(name=None, use_socket=False):
                 conn_params["SG_ENGINE_PORT"] = None
         else:
             conn_params = _prepare_engine_config(CONFIG["remotes"][name])
+        if use_fdw_params:
+            conn_params["SG_ENGINE_HOST"] = conn_params["SG_ENGINE_FDW_HOST"]
+            conn_params["SG_ENGINE_PORT"] = conn_params["SG_ENGINE_FDW_PORT"]
         _ENGINES[name] = PostgresEngine(conn_params=conn_params, name=name)
     return _ENGINES[name]
 

--- a/test/resources/.sgconfig
+++ b/test/resources/.sgconfig
@@ -52,6 +52,7 @@ SG_ENGINE_ADMIN_USER=
 SG_ENGINE_ADMIN_PWD=
 SG_ENGINE_POSTGRES_DB_NAME=postgres
 SG_META_SCHEMA=splitgraph_meta
+SG_NAMESPACE=testuser
 
 [commands]
 DUMMY=test.splitgraph.splitfile.test_custom_commands.DummyCommand

--- a/test/resources/external_sql.splitfile
+++ b/test/resources/external_sql.splitfile
@@ -1,3 +1,3 @@
-FROM testuser/pg_mount:latest IMPORT fruits AS my_fruits, vegetables
+FROM otheruser/pg_mount:latest IMPORT fruits AS my_fruits, vegetables
 
 SQL FILE ${EXTERNAL_SQL_FILE}

--- a/test/resources/external_sql.splitfile
+++ b/test/resources/external_sql.splitfile
@@ -1,3 +1,3 @@
-FROM test/pg_mount:latest IMPORT fruits AS my_fruits, vegetables
+FROM testuser/pg_mount:latest IMPORT fruits AS my_fruits, vegetables
 
 SQL FILE ${EXTERNAL_SQL_FILE}

--- a/test/splitgraph/commands/test_layered_querying.py
+++ b/test/splitgraph/commands/test_layered_querying.py
@@ -176,7 +176,6 @@ def test_lq_external(local_engine_empty, unprivileged_pg_repo, pg_repo_remote_re
     assert len(pg_repo_local.objects.get_all_objects()) == 0
     assert len(pg_repo_local.objects.get_downloaded_objects()) == 0
     assert len(pg_repo_remote_registry.objects.get_all_objects()) == 6
-    assert len(pg_repo_remote_registry.objects.get_downloaded_objects()) == 0
 
     # Proceed as per the previous test
     pg_repo_local = clone(unprivileged_pg_repo, download_all=False)
@@ -362,13 +361,3 @@ def test_multiengine_flow(local_engine_empty, unprivileged_pg_repo, pg_repo_remo
                 )
                 == 0
             )
-
-    assert len(pg_repo_remote_registry.objects.get_downloaded_objects()) == 0
-    assert (
-        len(
-            set(pg_repo_remote_registry.engine.get_all_tables("splitgraph_meta")).difference(
-                set(META_TABLES)
-            )
-        )
-        == 0
-    )

--- a/test/splitgraph/commands/test_layered_querying.py
+++ b/test/splitgraph/commands/test_layered_querying.py
@@ -157,42 +157,41 @@ def test_lq_remote(local_engine_empty, pg_repo_remote):
     _test_lazy_lq_checkout(pg_repo_local)
 
 
-def test_lq_external(local_engine_empty, pg_repo_remote):
+@pytest.mark.registry
+def test_lq_external(local_engine_empty, unprivileged_pg_repo, pg_repo_remote_registry):
     # Test layered querying works when we initialize it on a cloned repo that doesn't have any
     # cached objects (all are on S3 or other external location).
 
-    pg_repo_local = clone(pg_repo_remote)
+    pg_repo_local = clone(unprivileged_pg_repo)
     pg_repo_local.images["latest"].checkout()
     prepare_lq_repo(pg_repo_local, commit_after_every=False, include_pk=True)
 
     # Setup: upstream has the same repository as in the previous test but with no cached objects (all are external).
-    remote = pg_repo_local.push(handler="S3", handler_options={})
+    # In addition, we check that LQ works against an unprivileged upstream (where we don't actually have
+    # admin access).
+    pg_repo_local.push(unprivileged_pg_repo, handler="S3", handler_options={})
     pg_repo_local.delete()
-    pg_repo_remote.objects.delete_objects(remote.objects.get_downloaded_objects())
-    pg_repo_remote.commit_engines()
     pg_repo_local.objects.cleanup()
 
     assert len(pg_repo_local.objects.get_all_objects()) == 0
     assert len(pg_repo_local.objects.get_downloaded_objects()) == 0
-    assert len(remote.objects.get_all_objects()) == 6
-    assert len(remote.objects.get_downloaded_objects()) == 0
+    assert len(pg_repo_remote_registry.objects.get_all_objects()) == 6
+    assert len(pg_repo_remote_registry.objects.get_downloaded_objects()) == 0
 
     # Proceed as per the previous test
-    pg_repo_local = clone(pg_repo_remote, download_all=False)
+    pg_repo_local = clone(unprivileged_pg_repo, download_all=False)
     _test_lazy_lq_checkout(pg_repo_local)
 
 
-def _prepare_fully_remote_repo(local_engine_empty, pg_repo_remote):
+def _prepare_fully_remote_repo(local_engine_empty, pg_repo_remote_registry):
     # Setup: same as external, with an extra patch on top of the fruits table.
-    pg_repo_local = clone(pg_repo_remote)
+    pg_repo_local = clone(pg_repo_remote_registry)
     pg_repo_local.images["latest"].checkout()
     prepare_lq_repo(pg_repo_local, commit_after_every=True, include_pk=True)
     pg_repo_local.run_sql("INSERT INTO fruits VALUES (4, 'kumquat')")
     pg_repo_local.commit()
-    remote = pg_repo_local.push(handler="S3", handler_options={})
+    pg_repo_local.push(handler="S3", handler_options={})
     pg_repo_local.delete()
-    pg_repo_remote.objects.delete_objects(remote.objects.get_downloaded_objects())
-    pg_repo_remote.commit_engines()
     pg_repo_local.objects.cleanup()
     pg_repo_local.commit_engines()
 
@@ -234,12 +233,13 @@ def _prepare_fully_remote_repo(local_engine_empty, pg_repo_remote):
         ("SELECT * FROM fruits WHERE name = 'apple'", [], (True, False, True, False, False)),
     ],
 )
-def test_lq_qual_filtering(local_engine_empty, pg_repo_remote, test_case):
+@pytest.mark.registry
+def test_lq_qual_filtering(local_engine_empty, unprivileged_pg_repo, test_case):
     # Test that LQ prunes the object list based on quals
     # We can't really see that directly, so we check to see which objects it tries to download.
-    _prepare_fully_remote_repo(local_engine_empty, pg_repo_remote)
+    _prepare_fully_remote_repo(local_engine_empty, unprivileged_pg_repo)
 
-    pg_repo_local = clone(pg_repo_remote, download_all=False)
+    pg_repo_local = clone(unprivileged_pg_repo, download_all=False)
     pg_repo_local.images["latest"].checkout(layered=True)
     assert len(pg_repo_local.objects.get_downloaded_objects()) == 0
 
@@ -270,15 +270,16 @@ def test_lq_qual_filtering(local_engine_empty, pg_repo_remote, test_case):
     assert set(expected_objects) == set(used_objects)
 
 
-def test_lq_single_non_snap_object(local_engine_empty, pg_repo_remote):
+@pytest.mark.registry
+def test_lq_single_non_snap_object(local_engine_empty, unprivileged_pg_repo):
     # The object produced by
     # "DELETE FROM vegetables WHERE vegetable_id = 1;INSERT INTO vegetables VALUES (3, 'celery')"
     # has a deletion and an insertion. Check that an LQ that only uses that object
     # doesn't return the extra upserted/deleted flag column.
 
-    _prepare_fully_remote_repo(local_engine_empty, pg_repo_remote)
+    _prepare_fully_remote_repo(local_engine_empty, unprivileged_pg_repo)
 
-    pg_repo_local = clone(pg_repo_remote, download_all=False)
+    pg_repo_local = clone(unprivileged_pg_repo, download_all=False)
     pg_repo_local.images["latest"].checkout(layered=True)
 
     assert pg_repo_local.run_sql(
@@ -318,12 +319,17 @@ def test_direct_table_lq(pg_repo_local, test_case):
     assert list(table.query(columns=["name", "timestamp"], quals=quals)) == expected
 
 
-def test_multiengine_flow(local_engine_empty, pg_repo_remote):
+@pytest.mark.registry
+def test_multiengine_flow(local_engine_empty, unprivileged_pg_repo, pg_repo_remote_registry):
     # Test querying by using the remote engine as a metadata store and the local engine as an object store.
-    _prepare_fully_remote_repo(local_engine_empty, pg_repo_remote)
-    pg_repo_local = Repository.from_template(pg_repo_remote, object_engine=local_engine_empty)
+    _prepare_fully_remote_repo(local_engine_empty, unprivileged_pg_repo)
+    pg_repo_local = Repository.from_template(unprivileged_pg_repo, object_engine=local_engine_empty)
 
-    pg_repo_local.images["latest"].checkout(layered=True)
+    # Checkout currently requires the engine connection to be privileged
+    # (since it does manage_audit_triggers()) -- so we bypass all bookkeeping and call the
+    # actual LQ routine directly.
+    local_engine_empty.create_schema(pg_repo_local.to_schema())
+    pg_repo_local.images["latest"]._lq_checkout()
 
     # Take one of the test cases we ran in test_lq_qual_filtering that exercises index lookups,
     # LQs, object downloads and make sure that the correct engines are used
@@ -357,18 +363,10 @@ def test_multiengine_flow(local_engine_empty, pg_repo_remote):
                 == 0
             )
 
-    # remote engine untouched
-    assert (
-        pg_repo_remote.engine.run_sql(
-            "SELECT COUNT(1) FROM splitgraph_meta.object_cache_status",
-            return_shape=ResultShape.ONE_ONE,
-        )
-        == 0
-    )
-    assert len(pg_repo_remote.objects.get_downloaded_objects()) == 0
+    assert len(pg_repo_remote_registry.objects.get_downloaded_objects()) == 0
     assert (
         len(
-            set(pg_repo_remote.engine.get_all_tables("splitgraph_meta")).difference(
+            set(pg_repo_remote_registry.engine.get_all_tables("splitgraph_meta")).difference(
                 set(META_TABLES)
             )
         )

--- a/test/splitgraph/splitfile/test_execution.py
+++ b/test/splitgraph/splitfile/test_execution.py
@@ -393,15 +393,16 @@ def test_from_local(pg_repo_local):
     ]
 
 
-@pytest.mark.mounting
 @pytest.mark.registry
-def test_splitfile_with_external_sql(unprivileged_pg_repo, mg_repo_local):
+def test_splitfile_with_external_sql(readonly_pg_repo):
+
     # Tests are running from root so we pass in the path to the SQL manually to the splitfile.
     execute_commands(
         load_splitfile("external_sql.splitfile"),
         params={"EXTERNAL_SQL_FILE": SPLITFILE_ROOT + "external_sql.sql"},
         output=OUTPUT,
     )
+
     assert OUTPUT.run_sql("SELECT id, fruit, vegetable FROM join_table") == [
         (1, "apple", "potato"),
         (2, "orange", "carrot"),

--- a/test/splitgraph/splitfile/test_execution.py
+++ b/test/splitgraph/splitfile/test_execution.py
@@ -394,7 +394,8 @@ def test_from_local(pg_repo_local):
 
 
 @pytest.mark.mounting
-def test_splitfile_with_external_sql(pg_repo_local, pg_repo_remote, mg_repo_local):
+@pytest.mark.registry
+def test_splitfile_with_external_sql(unprivileged_pg_repo, mg_repo_local):
     # Tests are running from root so we pass in the path to the SQL manually to the splitfile.
     execute_commands(
         load_splitfile("external_sql.splitfile"),

--- a/test/splitgraph/test_security.py
+++ b/test/splitgraph/test_security.py
@@ -6,13 +6,14 @@ from splitgraph import SPLITGRAPH_META_SCHEMA
 from splitgraph.core._common import META_TABLES, select
 from splitgraph.core.registry import get_published_info, unpublish_repository
 from splitgraph.core.repository import Repository, clone
-from test.splitgraph.conftest import PG_MNT
 
 
-def test_pull_public(local_engine_empty, unprivileged_pg_repo):
-    clone(unprivileged_pg_repo)
+@pytest.mark.registry
+def test_pull_public(local_engine_empty, readonly_pg_repo):
+    clone(readonly_pg_repo)
 
 
+@pytest.mark.registry
 def test_push_own_delete_own(local_engine_empty, unprivileged_pg_repo):
     destination = Repository.from_template(unprivileged_pg_repo, engine=local_engine_empty)
     clone(unprivileged_pg_repo, local_repository=destination)
@@ -36,19 +37,20 @@ def test_push_own_delete_own(local_engine_empty, unprivileged_pg_repo):
     assert len(remote_destination.images()) == 0
 
 
-def test_push_own_delete_own_different_namespaces(local_engine_empty, unprivileged_pg_repo):
-    # Same as previous but we clone into test/pg_mount and push to our own namespace
+@pytest.mark.registry
+def test_push_own_delete_own_different_namespaces(local_engine_empty, readonly_pg_repo):
+    # Same as previous but we clone the read-only repo and push to our own namespace
     # to check that the objects we push get their namespaces rewritten to be the unprivileged user, not test.
-    destination = clone(unprivileged_pg_repo)
+    destination = clone(readonly_pg_repo)
 
     destination.images["latest"].checkout()
     destination.run_sql("""UPDATE fruits SET name = 'banana' WHERE fruit_id = 1""")
     destination.commit()
 
     remote_destination = Repository.from_template(
-        unprivileged_pg_repo,
-        namespace=unprivileged_pg_repo.engine.conn_params["SG_NAMESPACE"],
-        engine=unprivileged_pg_repo.engine,
+        readonly_pg_repo,
+        namespace=readonly_pg_repo.engine.conn_params["SG_NAMESPACE"],
+        engine=readonly_pg_repo.engine,
     )
     destination.upstream = remote_destination
 
@@ -57,7 +59,7 @@ def test_push_own_delete_own_different_namespaces(local_engine_empty, unprivileg
     object_id = destination.head.get_table("fruits").objects[0]
     assert (
         remote_destination.objects.get_object_meta([object_id])[object_id].namespace
-        == unprivileged_pg_repo.engine.conn_params["SG_NAMESPACE"]
+        == readonly_pg_repo.engine.conn_params["SG_NAMESPACE"]
     )
 
     # Test we can delete our own repo once we've pushed it
@@ -65,53 +67,53 @@ def test_push_own_delete_own_different_namespaces(local_engine_empty, unprivileg
     assert len(remote_destination.images()) == 0
 
 
-def test_push_others(local_engine_empty, unprivileged_pg_repo):
-    clone(unprivileged_pg_repo)
-    PG_MNT.images["latest"].checkout()
-    PG_MNT.run_sql("""UPDATE fruits SET name = 'banana' WHERE fruit_id = 1""")
-    PG_MNT.commit()
+@pytest.mark.registry
+def test_push_others(local_engine_empty, readonly_pg_repo):
+    destination = clone(readonly_pg_repo)
+    destination.images["latest"].checkout()
+    destination.run_sql("""UPDATE fruits SET name = 'banana' WHERE fruit_id = 1""")
+    destination.commit()
 
     with pytest.raises(ProgrammingError) as e:
-        PG_MNT.push(remote_repository=unprivileged_pg_repo, handler="S3")
+        destination.push(remote_repository=readonly_pg_repo, handler="S3")
     assert "You do not have access to this namespace!" in str(e.value)
 
 
-def test_delete_others(unprivileged_pg_repo):
+@pytest.mark.registry
+def test_delete_others(readonly_pg_repo):
     with pytest.raises(ProgrammingError) as e:
-        unprivileged_pg_repo.delete(uncheckout=False)
+        readonly_pg_repo.delete(uncheckout=False)
     assert "You do not have access to this namespace!" in str(e.value)
 
     # Check the repository still exists on the remote.
-    assert len(unprivileged_pg_repo.images()) > 0
+    assert len(readonly_pg_repo.images()) > 0
 
 
-def test_impersonate_external_object(unprivileged_pg_repo):
-    sample_object = unprivileged_pg_repo.images["latest"].get_table("fruits").objects[0]
+@pytest.mark.registry
+def test_impersonate_external_object(readonly_pg_repo):
+    sample_object = readonly_pg_repo.images["latest"].get_table("fruits").objects[0]
     assert sample_object is not None
 
-    # Try to impersonate the owner of the "test" namespace and add a different external link to
+    # Try to impersonate the owner of the "otheruser" namespace and add a different external link to
     # an object that they own.
     with pytest.raises(ProgrammingError) as e:
-        unprivileged_pg_repo.objects.register_object_locations(
-            [(sample_object, "fake_location", "S3")]
-        )
+        readonly_pg_repo.objects.register_object_locations([(sample_object, "fake_location", "S3")])
     assert "You do not have access to this namespace!" in str(e.value)
 
 
-def test_publish_unpublish_own(
-    local_engine_empty, pg_repo_remote_registry, unprivileged_remote_engine
-):
-    clone(pg_repo_remote_registry, download_all=True)
-    PG_MNT.images["latest"].tag("my_tag")
+@pytest.mark.registry
+def test_publish_unpublish_own(local_engine_empty, readonly_pg_repo, unprivileged_remote_engine):
+    destination = clone(readonly_pg_repo, download_all=True)
+    destination.images["latest"].tag("my_tag")
     target_repo = Repository.from_template(
-        pg_repo_remote_registry,
+        readonly_pg_repo,
         namespace=unprivileged_remote_engine.conn_params["SG_NAMESPACE"],
         engine=unprivileged_remote_engine,
     )
 
-    PG_MNT.push(remote_repository=target_repo)
+    destination.push(remote_repository=target_repo)
 
-    PG_MNT.publish(
+    destination.publish(
         "my_tag",
         remote_repository=target_repo,
         readme="my_readme",
@@ -123,30 +125,33 @@ def test_publish_unpublish_own(
     assert get_published_info(target_repo, "my_tag") is None
 
 
-def test_publish_unpublish_others(
-    local_engine_empty, pg_repo_remote_registry, unprivileged_pg_repo
-):
+@pytest.mark.registry
+def test_publish_unpublish_others(local_engine_empty, remote_engine_registry, readonly_pg_repo):
     # Tag the remote repo as an admin user and try to publish as an unprivileged one
-    pg_repo_remote_registry.images["latest"].tag("my_tag")
-    pg_repo_remote_registry.commit_engines()
+    readonly_pg_repo_superuser = Repository.from_template(
+        readonly_pg_repo, engine=remote_engine_registry
+    )
+    readonly_pg_repo_superuser.images["latest"].tag("my_tag")
+    readonly_pg_repo_superuser.commit_engines()
 
-    clone(unprivileged_pg_repo, download_all=True)
+    destination = clone(readonly_pg_repo, download_all=True)
 
     # Publish into the "test" namespace as someone who doesn't have access to it.
     with pytest.raises(ProgrammingError) as e:
-        PG_MNT.publish("my_tag", remote_repository=unprivileged_pg_repo, readme="my_readme")
+        destination.publish("my_tag", remote_repository=readonly_pg_repo, readme="my_readme")
     assert "You do not have access to this namespace!" in str(e.value)
 
     # Publish as the admin user
-    PG_MNT.publish("my_tag", remote_repository=pg_repo_remote_registry, readme="my_readme")
+    destination.publish("my_tag", remote_repository=readonly_pg_repo_superuser, readme="my_readme")
 
     # Try to delete as the remote user -- should fail
     with pytest.raises(ProgrammingError) as e:
-        unpublish_repository(unprivileged_pg_repo)
+        unpublish_repository(readonly_pg_repo)
     assert "You do not have access to this namespace!" in str(e.value)
-    assert get_published_info(unprivileged_pg_repo, "my_tag") is not None
+    assert get_published_info(readonly_pg_repo, "my_tag") is not None
 
 
+@pytest.mark.registry
 def test_no_direct_table_access(unprivileged_pg_repo):
     # Canary to check users can't manipulate splitgraph_meta tables directly
     for table in META_TABLES:

--- a/test/splitgraph/test_security.py
+++ b/test/splitgraph/test_security.py
@@ -25,7 +25,7 @@ def test_push_own_delete_own(local_engine_empty, unprivileged_pg_repo):
     # tables there
     remote_destination = Repository.from_template(
         destination,
-        namespace=unprivileged_pg_repo.engine.conn_params["SG_ENGINE_USER"],
+        namespace=unprivileged_pg_repo.engine.conn_params["SG_NAMESPACE"],
         engine=unprivileged_pg_repo.engine,
     )
     destination.upstream = remote_destination
@@ -47,7 +47,7 @@ def test_push_own_delete_own_different_namespaces(local_engine_empty, unprivileg
 
     remote_destination = Repository.from_template(
         unprivileged_pg_repo,
-        namespace=unprivileged_pg_repo.engine.conn_params["SG_ENGINE_USER"],
+        namespace=unprivileged_pg_repo.engine.conn_params["SG_NAMESPACE"],
         engine=unprivileged_pg_repo.engine,
     )
     destination.upstream = remote_destination
@@ -57,7 +57,7 @@ def test_push_own_delete_own_different_namespaces(local_engine_empty, unprivileg
     object_id = destination.head.get_table("fruits").objects[0]
     assert (
         remote_destination.objects.get_object_meta([object_id])[object_id].namespace
-        == unprivileged_pg_repo.engine.conn_params["SG_ENGINE_USER"]
+        == unprivileged_pg_repo.engine.conn_params["SG_NAMESPACE"]
     )
 
     # Test we can delete our own repo once we've pushed it
@@ -105,7 +105,7 @@ def test_publish_unpublish_own(
     PG_MNT.images["latest"].tag("my_tag")
     target_repo = Repository.from_template(
         pg_repo_remote_registry,
-        namespace=unprivileged_remote_engine.conn_params["SG_ENGINE_USER"],
+        namespace=unprivileged_remote_engine.conn_params["SG_NAMESPACE"],
         engine=unprivileged_remote_engine,
     )
 


### PR DESCRIPTION
Reorganize some test fixtures: add unprivileged_pg_repo (unprivileged user talking to their own remote repo) and readonly_pg_repo (unprivileged user talking to someone else's remote repo) and get some tests to use them;

also reorganize/make fixtures nicer in general