### PR TITLE
Push image/table size into the SQL API

### DIFF
--- a/splitgraph/core/image.py
+++ b/splitgraph/core/image.py
@@ -264,17 +264,10 @@ class Image(NamedTuple):
 
         :return: Size of the image in bytes.
         """
-        query = (
-            "WITH iob AS(SELECT DISTINCT image_hash, unnest(object_ids) AS object_id "
-            "FROM splitgraph_meta.tables t "
-            "WHERE t.namespace = %s AND t.repository = %s AND t.image_hash = %s) "
-            "SELECT SUM(o.size) FROM iob JOIN splitgraph_meta.objects o "
-            "ON iob.object_id = o.object_id "
-        )
         return cast(
             int,
             self.engine.run_sql(
-                query,
+                select("get_image_size", table_args="(%s,%s,%s)", schema=SPLITGRAPH_API_SCHEMA),
                 (self.repository.namespace, self.repository.repository, self.image_hash),
                 return_shape=ResultShape.ONE_ONE,
             ),

--- a/test/splitgraph/test_security.py
+++ b/test/splitgraph/test_security.py
@@ -38,6 +38,14 @@ def test_push_own_delete_own(local_engine_empty, unprivileged_pg_repo):
 
 
 @pytest.mark.registry
+def test_api_funcs(readonly_pg_repo):
+    # Test some image-reading API functions work over non-superuser connections.
+    readonly_pg_repo.images["latest"].get_size()
+
+    readonly_pg_repo.images["latest"].get_table("fruits").get_size()
+
+
+@pytest.mark.registry
 def test_push_own_delete_own_different_namespaces(local_engine_empty, readonly_pg_repo):
     # Same as previous but we clone the read-only repo and push to our own namespace
     # to check that the objects we push get their namespaces rewritten to be the unprivileged user, not test.


### PR DESCRIPTION
Was using a join query on splitgraph_meta making it impossible to use on non-privileged connections, e.g. doing `SG_ENGINE=data.splitgraph.com sgr table some/repo:latest table`) -- should we get the client to use other API funcs and then do a join in-app instead?