### PR TITLE
Post-commit indexing

### DIFF
--- a/examples/run_example.py
+++ b/examples/run_example.py
@@ -11,7 +11,6 @@ import yaml
 
 from splitgraph.commandline.common import Color
 
-
 _ANSI_CONTROL = re.compile(r"(\x1B[@-_][0-?]*[ -/]*[@-~])")
 _SPLIT = re.compile(r"(\x1B[@-_][0-?]*[ -/]*[@-~]|\s+|.)")
 

--- a/splitgraph/commandline/__init__.py
+++ b/splitgraph/commandline/__init__.py
@@ -12,7 +12,7 @@ import click_log
 from splitgraph.commandline.cloud import cloud_c
 from splitgraph.commandline.engine import engine_c
 from splitgraph.commandline.example import example
-from splitgraph.commandline.image_creation import checkout_c, commit_c, tag_c, import_c
+from splitgraph.commandline.image_creation import checkout_c, commit_c, tag_c, import_c, reindex_c
 from splitgraph.commandline.image_info import (
     log_c,
     diff_c,
@@ -67,6 +67,7 @@ cli.add_command(checkout_c)
 cli.add_command(commit_c)
 cli.add_command(tag_c)
 cli.add_command(import_c)
+cli.add_command(reindex_c)
 
 # Information
 cli.add_command(log_c)

--- a/splitgraph/commandline/push_pull.py
+++ b/splitgraph/commandline/push_pull.py
@@ -70,7 +70,22 @@ _REMOTES = list(CONFIG.get("remotes", []))
 )
 @click.option("-h", "--upload-handler", help="Upload handler", default="S3")
 @click.option("-o", "--upload-handler-options", help="Upload handler parameters", default="{}")
-def push_c(repository, remote_repository, remote, upload_handler, upload_handler_options):
+@click.option(
+    "-f",
+    "--overwrite-object-meta",
+    help="Overwrite metadata for existing remote objects",
+    default=False,
+    is_flag=True,
+    type=bool,
+)
+def push_c(
+    repository,
+    remote_repository,
+    remote,
+    upload_handler,
+    upload_handler_options,
+    overwrite_object_meta,
+):
     """
     Push changes from a local repository to the Splitgraph registry or another engine.
 
@@ -125,6 +140,7 @@ def push_c(repository, remote_repository, remote, upload_handler, upload_handler
         remote_repository,
         handler=upload_handler,
         handler_options=json.loads(upload_handler_options),
+        overwrite=overwrite_object_meta,
     )
 
 

--- a/splitgraph/core/fragment_manager.py
+++ b/splitgraph/core/fragment_manager.py
@@ -201,7 +201,7 @@ class FragmentManager(MetadataManager):
         super().__init__(metadata_engine)
         self.object_engine = object_engine
 
-    def _generate_object_index(
+    def generate_object_index(
         self,
         object_id: str,
         table_schema: TableSchema,
@@ -271,9 +271,7 @@ class FragmentManager(MetadataManager):
         :param extra_indexes: Dictionary of {index_type: column: index_specific_kwargs}.
         """
         object_size = self.object_engine.get_object_size(object_id)
-        object_index = self._generate_object_index(
-            object_id, table_schema, changeset, extra_indexes
-        )
+        object_index = self.generate_object_index(object_id, table_schema, changeset, extra_indexes)
         self.register_objects(
             [
                 Object(

--- a/splitgraph/core/image.py
+++ b/splitgraph/core/image.py
@@ -26,7 +26,7 @@ from splitgraph.exceptions import SplitGraphError, TableNotFoundError
 from splitgraph.hooks.mount_handlers import init_fdw
 from .common import set_tag, select, manage_audit, set_head
 from .table import Table
-from .types import TableSchema, TableColumn
+from .types import TableColumn
 
 if TYPE_CHECKING:
     from .repository import Repository

--- a/splitgraph/exceptions.py
+++ b/splitgraph/exceptions.py
@@ -28,6 +28,10 @@ class ObjectNotFoundError(SplitGraphError):
     """Raised when a physical object doesn't exist in the cache."""
 
 
+class ObjectIndexingError(SplitGraphError):
+    """Errors related to indexing objects"""
+
+
 class RepositoryNotFoundError(SplitGraphError):
     """A Splitgraph repository doesn't exist."""
 


### PR DESCRIPTION
* Add a command `sgr reindex` that reindexes tables with non-overlapping objects, this is useful to e.g. add a bloom filter on a column to speed up certain slow queries.
* Allow overwriting object metadata on push if an object already exists
  * currently we overwrite the whole row without checking that it's just the index that has been updated, allows users to be more flexible in fixing their own data but might be too lax.