### PR TITLE
`sgr` UX/API fixes and speedups

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -104,7 +104,7 @@ jobs:
         - provider: script
           # Remove -r testpypi to publish to the real PyPI
           # NB PyPI is write-once: once we've published a version, we can't overwrite it!
-          script: poetry publish -r testpypi
+          script: echo "skip pypi" #poetry publish -r testpypi
           skip_cleanup: true
           on:
             repo: splitgraph/splitgraph

--- a/.travis.yml
+++ b/.travis.yml
@@ -98,7 +98,10 @@ jobs:
         - poetry run coveralls
 
       before_deploy:
-        - './.ci/before_deploy.sh'
+        # Travis runs before_deploy for every deploy provider (of which we have three)
+        # and we don't want to re-record asciinema examples every time.
+        - test -z "$CI_BEFORE_DEPLOY_RUN" && ./.ci/before_deploy.sh
+        - export CI_BEFORE_DEPLOY_RUN=1
       deploy:
         # Push Splitgraph package to PyPI
         - provider: script

--- a/.travis.yml
+++ b/.travis.yml
@@ -100,7 +100,7 @@ jobs:
       before_deploy:
         # Travis runs before_deploy for every deploy provider (of which we have three)
         # and we don't want to re-record asciinema examples every time.
-        - test -z "$CI_BEFORE_DEPLOY_RUN" && ./.ci/before_deploy.sh
+        - test -z "$CI_BEFORE_DEPLOY_RUN" && ./.ci/before_deploy.sh || echo "before_deploy already run, skipping"
         - export CI_BEFORE_DEPLOY_RUN=1
       deploy:
         # Push Splitgraph package to PyPI

--- a/engine/Dockerfile
+++ b/engine/Dockerfile
@@ -171,11 +171,11 @@ RUN /build/build_splitgraph.sh
 # package itself without dependencies (deps are libc>=2.14 -- we have 2.24 -- and libpython3.7
 # which we compiled earlier)
 
-RUN wget http://http.us.debian.org/debian/pool/main/p/postgresql-11/postgresql-plpython3-11_11.6-2~sid1_amd64.deb && \
-    echo "59980cdd6b7e30187ba851fbc3123c47b9a8ff99fd1327a1531f07dcc93dbefb  postgresql-plpython3-11_11.6-2~sid1_amd64.deb" | sha256sum -c - && \
-    dpkg --force-all -i postgresql-plpython3-11_11.6-2~sid1_amd64.deb
+RUN wget http://security.debian.org/debian-security/pool/updates/main/p/postgresql-11/postgresql-plpython3-11_11.7-0+deb10u1_amd64.deb && \
+    echo "f25eea162ffcc1c0fd3c5295fe29b7127ca01c45fc27fd0149aa5ffe31a769bf  postgresql-plpython3-11_11.7-0+deb10u1_amd64.deb" | sha256sum -c - && \
+    dpkg --force-all -i postgresql-plpython3-11_11.7-0+deb10u1_amd64.deb
 # Fix to make the dpkg status file usable (so that APT doesn't fail on future installs in the container)
-RUN sed -i "s/postgresql-11 (= 11.6-2~sid1), libc6 (>= 2.14), libpython3.7 (>= 3.7.0)/Depends: /" -i /var/lib/dpkg/status
+RUN sed -i "s/Depends: postgresql-11 (= 11.7-0+deb10u1), libc6 (>= 2.14), libpython3.7 (>= 3.7.0)/Depends: /" -i /var/lib/dpkg/status
 
 # Copy the actual Splitgraph code over at this point.
 COPY ./splitgraph /splitgraph/splitgraph

--- a/poetry.lock
+++ b/poetry.lock
@@ -141,8 +141,8 @@ category = "main"
 description = "Composable command line interface toolkit"
 name = "click"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "7.0"
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+version = "7.1.1"
 
 [[package]]
 category = "main"
@@ -324,8 +324,20 @@ description = "Read resources from Python packages"
 marker = "python_version < \"3.7\""
 name = "importlib-resources"
 optional = false
-python-versions = ">=2.7,!=3.0,!=3.1,!=3.2,!=3.3"
-version = "1.0.2"
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
+version = "1.3.1"
+
+[package.dependencies]
+[package.dependencies.importlib-metadata]
+python = "<3.8"
+version = "*"
+
+[package.dependencies.zipp]
+python = "<3.8"
+version = ">=0.4"
+
+[package.extras]
+docs = ["sphinx", "docutils (0.12)", "rst.linker"]
 
 [[package]]
 category = "dev"
@@ -408,7 +420,7 @@ description = "Optional static typing for Python"
 name = "mypy"
 optional = false
 python-versions = ">=3.5"
-version = "0.761"
+version = "0.770"
 
 [package.dependencies]
 mypy-extensions = ">=0.4.3,<0.5.0"
@@ -448,7 +460,7 @@ description = "Core utilities for Python packages"
 name = "packaging"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "20.1"
+version = "20.3"
 
 [package.dependencies]
 pyparsing = ">=2.0.2"
@@ -568,15 +580,15 @@ description = "pyfakefs implements a fake file system that mocks the Python file
 name = "pyfakefs"
 optional = false
 python-versions = "*"
-version = "3.7.1"
+version = "3.7.2"
 
 [[package]]
 category = "dev"
 description = "Pygments is a syntax highlighting package written in Python."
 name = "pygments"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
-version = "2.5.2"
+python-versions = ">=3.5"
+version = "2.6.1"
 
 [[package]]
 category = "dev"
@@ -761,7 +773,7 @@ description = "Python documentation generator"
 name = "sphinx"
 optional = false
 python-versions = ">=3.5"
-version = "2.4.3"
+version = "2.4.4"
 
 [package.dependencies]
 Jinja2 = ">=2.3"
@@ -799,25 +811,27 @@ sphinx = "*"
 
 [[package]]
 category = "dev"
-description = ""
+description = "sphinxcontrib-applehelp is a sphinx extension which outputs Apple help books"
 name = "sphinxcontrib-applehelp"
 optional = false
-python-versions = "*"
-version = "1.0.1"
+python-versions = ">=3.5"
+version = "1.0.2"
 
 [package.extras]
-test = ["pytest", "flake8", "mypy"]
+lint = ["flake8", "mypy", "docutils-stubs"]
+test = ["pytest"]
 
 [[package]]
 category = "dev"
-description = ""
+description = "sphinxcontrib-devhelp is a sphinx extension which outputs Devhelp document."
 name = "sphinxcontrib-devhelp"
 optional = false
-python-versions = "*"
-version = "1.0.1"
+python-versions = ">=3.5"
+version = "1.0.2"
 
 [package.extras]
-test = ["pytest", "flake8", "mypy"]
+lint = ["flake8", "mypy", "docutils-stubs"]
+test = ["pytest"]
 
 [[package]]
 category = "dev"
@@ -844,25 +858,27 @@ test = ["pytest", "flake8", "mypy"]
 
 [[package]]
 category = "dev"
-description = ""
+description = "sphinxcontrib-qthelp is a sphinx extension which outputs QtHelp document."
 name = "sphinxcontrib-qthelp"
 optional = false
-python-versions = "*"
-version = "1.0.2"
+python-versions = ">=3.5"
+version = "1.0.3"
 
 [package.extras]
-test = ["pytest", "flake8", "mypy"]
+lint = ["flake8", "mypy", "docutils-stubs"]
+test = ["pytest"]
 
 [[package]]
 category = "dev"
-description = ""
+description = "sphinxcontrib-serializinghtml is a sphinx extension which outputs \"serialized\" HTML files (json and pickle)."
 name = "sphinxcontrib-serializinghtml"
 optional = false
-python-versions = "*"
-version = "1.1.3"
+python-versions = ">=3.5"
+version = "1.1.4"
 
 [package.extras]
-test = ["pytest", "flake8", "mypy"]
+lint = ["flake8", "mypy", "docutils-stubs"]
+test = ["pytest"]
 
 [[package]]
 category = "main"
@@ -870,7 +886,7 @@ description = "Database Abstraction Library"
 name = "sqlalchemy"
 optional = true
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "1.3.13"
+version = "1.3.15"
 
 [package.extras]
 mssql = ["pyodbc"]
@@ -938,7 +954,7 @@ description = "Virtual Python Environment builder"
 name = "virtualenv"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,>=2.7"
-version = "20.0.7"
+version = "20.0.10"
 
 [package.dependencies]
 appdirs = ">=1.4.3,<2"
@@ -956,7 +972,7 @@ version = ">=1.0,<2"
 
 [package.extras]
 docs = ["sphinx (>=2.0.0,<3)", "sphinx-argparse (>=0.2.5,<1)", "sphinx-rtd-theme (>=0.4.3,<1)", "towncrier (>=19.9.0rc1)", "proselint (>=0.10.2,<1)"]
-testing = ["pytest (>=4.0.0,<6)", "coverage (>=4.5.1,<6)", "pytest-mock (>=2.0.0,<3)", "pytest-env (>=0.6.2,<1)", "packaging (>=20.0)", "xonsh (>=0.9.13,<1)"]
+testing = ["pytest (>=4.0.0,<6)", "coverage (>=4.5.1,<6)", "pytest-mock (>=2.0.0,<3)", "pytest-env (>=0.6.2,<1)", "pytest-timeout (>=1.3.4,<2)", "packaging (>=20.0)", "xonsh (>=0.9.13,<1)"]
 
 [[package]]
 category = "dev"
@@ -992,7 +1008,7 @@ marker = "python_version < \"3.8\""
 name = "zipp"
 optional = false
 python-versions = ">=3.6"
-version = "3.0.0"
+version = "3.1.0"
 
 [package.extras]
 docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
@@ -1059,8 +1075,8 @@ chardet = [
     {file = "chardet-3.0.4.tar.gz", hash = "sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae"},
 ]
 click = [
-    {file = "Click-7.0-py2.py3-none-any.whl", hash = "sha256:2335065e6395b9e67ca716de5f7526736bfa6ceead690adf616d925bdc622b13"},
-    {file = "Click-7.0.tar.gz", hash = "sha256:5b94b49521f6456670fdb30cd82a4eca9412788a93fa6dd6df72c94d5a8ff2d7"},
+    {file = "click-7.1.1-py2.py3-none-any.whl", hash = "sha256:e345d143d80bf5ee7534056164e5e112ea5e22716bbb1ce727941f4c8b471b9a"},
+    {file = "click-7.1.1.tar.gz", hash = "sha256:8a18b4ea89d8820c5d0c7da8a64b2c324b4dabb695804dbfea19b9be9d88c0cc"},
 ]
 click-log = [
     {file = "click-log-0.3.2.tar.gz", hash = "sha256:16fd1ca3fc6b16c98cea63acf1ab474ea8e676849dc669d86afafb0ed7003124"},
@@ -1154,8 +1170,8 @@ importlib-metadata = [
     {file = "importlib_metadata-1.5.0.tar.gz", hash = "sha256:06f5b3a99029c7134207dd882428a66992a9de2bef7c2b699b5641f9886c3302"},
 ]
 importlib-resources = [
-    {file = "importlib_resources-1.0.2-py2.py3-none-any.whl", hash = "sha256:6e2783b2538bd5a14678284a3962b0660c715e5a0f10243fd5e00a4b5974f50b"},
-    {file = "importlib_resources-1.0.2.tar.gz", hash = "sha256:d3279fd0f6f847cced9f7acc19bd3e5df54d34f93a2e7bb5f238f81545787078"},
+    {file = "importlib_resources-1.3.1-py2.py3-none-any.whl", hash = "sha256:1dff36d42d94bd523eeb847c25c7dd327cb56686d74a26dfcc8d67c504922d59"},
+    {file = "importlib_resources-1.3.1.tar.gz", hash = "sha256:7f0e1b2b5f3981e39c52da0f99b2955353c5a139c314994d1126c2551ace9bdf"},
 ]
 isort = [
     {file = "isort-4.3.21-py2.py3-none-any.whl", hash = "sha256:6e811fcb295968434526407adb8796944f1988c5b65e8139058f2014cbe100fd"},
@@ -1232,20 +1248,20 @@ more-itertools = [
     {file = "more_itertools-8.2.0-py3-none-any.whl", hash = "sha256:5dd8bcf33e5f9513ffa06d5ad33d78f31e1931ac9a18f33d37e77a180d393a7c"},
 ]
 mypy = [
-    {file = "mypy-0.761-cp35-cp35m-macosx_10_6_x86_64.whl", hash = "sha256:7f672d02fffcbace4db2b05369142e0506cdcde20cea0e07c7c2171c4fd11dd6"},
-    {file = "mypy-0.761-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:87c556fb85d709dacd4b4cb6167eecc5bbb4f0a9864b69136a0d4640fdc76a36"},
-    {file = "mypy-0.761-cp35-cp35m-win_amd64.whl", hash = "sha256:c6d27bd20c3ba60d5b02f20bd28e20091d6286a699174dfad515636cb09b5a72"},
-    {file = "mypy-0.761-cp36-cp36m-macosx_10_6_x86_64.whl", hash = "sha256:4b9365ade157794cef9685791032521233729cb00ce76b0ddc78749abea463d2"},
-    {file = "mypy-0.761-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:634aef60b4ff0f650d3e59d4374626ca6153fcaff96ec075b215b568e6ee3cb0"},
-    {file = "mypy-0.761-cp36-cp36m-win_amd64.whl", hash = "sha256:53ea810ae3f83f9c9b452582261ea859828a9ed666f2e1ca840300b69322c474"},
-    {file = "mypy-0.761-cp37-cp37m-macosx_10_6_x86_64.whl", hash = "sha256:0a9a45157e532da06fe56adcfef8a74629566b607fa2c1ac0122d1ff995c748a"},
-    {file = "mypy-0.761-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:7eadc91af8270455e0d73565b8964da1642fe226665dd5c9560067cd64d56749"},
-    {file = "mypy-0.761-cp37-cp37m-win_amd64.whl", hash = "sha256:e2bb577d10d09a2d8822a042a23b8d62bc3b269667c9eb8e60a6edfa000211b1"},
-    {file = "mypy-0.761-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:2c35cae79ceb20d47facfad51f952df16c2ae9f45db6cb38405a3da1cf8fc0a7"},
-    {file = "mypy-0.761-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:f97a605d7c8bc2c6d1172c2f0d5a65b24142e11a58de689046e62c2d632ca8c1"},
-    {file = "mypy-0.761-cp38-cp38-win_amd64.whl", hash = "sha256:a6bd44efee4dc8c3324c13785a9dc3519b3ee3a92cada42d2b57762b7053b49b"},
-    {file = "mypy-0.761-py3-none-any.whl", hash = "sha256:7e396ce53cacd5596ff6d191b47ab0ea18f8e0ec04e15d69728d530e86d4c217"},
-    {file = "mypy-0.761.tar.gz", hash = "sha256:85baab8d74ec601e86134afe2bcccd87820f79d2f8d5798c889507d1088287bf"},
+    {file = "mypy-0.770-cp35-cp35m-macosx_10_6_x86_64.whl", hash = "sha256:a34b577cdf6313bf24755f7a0e3f3c326d5c1f4fe7422d1d06498eb25ad0c600"},
+    {file = "mypy-0.770-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:86c857510a9b7c3104cf4cde1568f4921762c8f9842e987bc03ed4f160925754"},
+    {file = "mypy-0.770-cp35-cp35m-win_amd64.whl", hash = "sha256:a8ffcd53cb5dfc131850851cc09f1c44689c2812d0beb954d8138d4f5fc17f65"},
+    {file = "mypy-0.770-cp36-cp36m-macosx_10_6_x86_64.whl", hash = "sha256:7687f6455ec3ed7649d1ae574136835a4272b65b3ddcf01ab8704ac65616c5ce"},
+    {file = "mypy-0.770-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:3beff56b453b6ef94ecb2996bea101a08f1f8a9771d3cbf4988a61e4d9973761"},
+    {file = "mypy-0.770-cp36-cp36m-win_amd64.whl", hash = "sha256:15b948e1302682e3682f11f50208b726a246ab4e6c1b39f9264a8796bb416aa2"},
+    {file = "mypy-0.770-cp37-cp37m-macosx_10_6_x86_64.whl", hash = "sha256:b90928f2d9eb2f33162405f32dde9f6dcead63a0971ca8a1b50eb4ca3e35ceb8"},
+    {file = "mypy-0.770-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:c56ffe22faa2e51054c5f7a3bc70a370939c2ed4de308c690e7949230c995913"},
+    {file = "mypy-0.770-cp37-cp37m-win_amd64.whl", hash = "sha256:8dfb69fbf9f3aeed18afffb15e319ca7f8da9642336348ddd6cab2713ddcf8f9"},
+    {file = "mypy-0.770-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:219a3116ecd015f8dca7b5d2c366c973509dfb9a8fc97ef044a36e3da66144a1"},
+    {file = "mypy-0.770-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:7ec45a70d40ede1ec7ad7f95b3c94c9cf4c186a32f6bacb1795b60abd2f9ef27"},
+    {file = "mypy-0.770-cp38-cp38-win_amd64.whl", hash = "sha256:f91c7ae919bbc3f96cd5e5b2e786b2b108343d1d7972ea130f7de27fdd547cf3"},
+    {file = "mypy-0.770-py3-none-any.whl", hash = "sha256:3b1fc683fb204c6b4403a1ef23f0b1fac8e4477091585e0c8c54cbdf7d7bb164"},
+    {file = "mypy-0.770.tar.gz", hash = "sha256:8a627507ef9b307b46a1fea9513d5c98680ba09591253082b4c48697ba05a4ae"},
 ]
 mypy-extensions = [
     {file = "mypy_extensions-0.4.3-py2.py3-none-any.whl", hash = "sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d"},
@@ -1278,8 +1294,8 @@ numpy = [
     {file = "numpy-1.18.1.zip", hash = "sha256:b6ff59cee96b454516e47e7721098e6ceebef435e3e21ac2d6c3b8b02628eb77"},
 ]
 packaging = [
-    {file = "packaging-20.1-py2.py3-none-any.whl", hash = "sha256:170748228214b70b672c581a3dd610ee51f733018650740e98c7df862a583f73"},
-    {file = "packaging-20.1.tar.gz", hash = "sha256:e665345f9eef0c621aa0bf2f8d78cf6d21904eef16a93f020240b704a57f1334"},
+    {file = "packaging-20.3-py2.py3-none-any.whl", hash = "sha256:82f77b9bee21c1bafbf35a84905d604d5d1223801d639cf3ed140bd651c08752"},
+    {file = "packaging-20.3.tar.gz", hash = "sha256:3c292b474fda1671ec57d46d739d072bfd495a4f51ad01a055121d81e952b7a3"},
 ]
 pandas = [
     {file = "pandas-0.25.3-cp35-cp35m-macosx_10_6_intel.whl", hash = "sha256:df8864824b1fe488cf778c3650ee59c3a0d8f42e53707de167ba6b4f7d35f133"},
@@ -1375,12 +1391,12 @@ py = [
     {file = "py-1.8.1.tar.gz", hash = "sha256:5e27081401262157467ad6e7f851b7aa402c5852dbcb3dae06768434de5752aa"},
 ]
 pyfakefs = [
-    {file = "pyfakefs-3.7.1-py2.py3-none-any.whl", hash = "sha256:52caa73b474d2aed34fc0e5fa6c5b4abdb8b17405c56dc8fee500009af56496c"},
-    {file = "pyfakefs-3.7.1.tar.gz", hash = "sha256:1eb68bb250cc14310a6e33c197cbe2c8d93832b543f534e29b58286712f7e2b2"},
+    {file = "pyfakefs-3.7.2-py2.py3-none-any.whl", hash = "sha256:f415f38fe488b46974700af95f22b37e951a51159403eb9011ca37db0fde8b97"},
+    {file = "pyfakefs-3.7.2.tar.gz", hash = "sha256:735ce6a71f26ead335df8a1f2c1cc8355ef091d98ffdc3bf73a5a3b0214e055e"},
 ]
 pygments = [
-    {file = "Pygments-2.5.2-py2.py3-none-any.whl", hash = "sha256:2a3fe295e54a20164a9df49c75fa58526d3be48e14aceba6d6b1e8ac0bfd6f1b"},
-    {file = "Pygments-2.5.2.tar.gz", hash = "sha256:98c8aa5a9f778fcd1026a17361ddaf7330d1b7c62ae97c3bb0ae73e0b9b6b0fe"},
+    {file = "Pygments-2.6.1-py3-none-any.whl", hash = "sha256:ff7a40b4860b727ab48fad6360eb351cc1b33cbf9b15a0f689ca5353e9463324"},
+    {file = "Pygments-2.6.1.tar.gz", hash = "sha256:647344a061c249a3b74e230c739f434d7ea4d8b1d5f3721bc0f3558049b38f44"},
 ]
 pyinstaller = [
     {file = "PyInstaller-3.6.tar.gz", hash = "sha256:3730fa80d088f8bb7084d32480eb87cbb4ddb64123363763cf8f2a1378c1c4b7"},
@@ -1479,20 +1495,20 @@ snowballstemmer = [
     {file = "snowballstemmer-2.0.0.tar.gz", hash = "sha256:df3bac3df4c2c01363f3dd2cfa78cce2840a79b9f1c2d2de9ce8d31683992f52"},
 ]
 sphinx = [
-    {file = "Sphinx-2.4.3-py3-none-any.whl", hash = "sha256:776ff8333181138fae52df65be733127539623bb46cc692e7fa0fcfc80d7aa88"},
-    {file = "Sphinx-2.4.3.tar.gz", hash = "sha256:ca762da97c3b5107cbf0ab9e11d3ec7ab8d3c31377266fd613b962ed971df709"},
+    {file = "Sphinx-2.4.4-py3-none-any.whl", hash = "sha256:fc312670b56cb54920d6cc2ced455a22a547910de10b3142276495ced49231cb"},
+    {file = "Sphinx-2.4.4.tar.gz", hash = "sha256:b4c750d546ab6d7e05bdff6ac24db8ae3e8b8253a3569b754e445110a0a12b66"},
 ]
 sphinx-rtd-theme = [
     {file = "sphinx_rtd_theme-0.4.3-py2.py3-none-any.whl", hash = "sha256:00cf895504a7895ee433807c62094cf1e95f065843bf3acd17037c3e9a2becd4"},
     {file = "sphinx_rtd_theme-0.4.3.tar.gz", hash = "sha256:728607e34d60456d736cc7991fd236afb828b21b82f956c5ea75f94c8414040a"},
 ]
 sphinxcontrib-applehelp = [
-    {file = "sphinxcontrib-applehelp-1.0.1.tar.gz", hash = "sha256:edaa0ab2b2bc74403149cb0209d6775c96de797dfd5b5e2a71981309efab3897"},
-    {file = "sphinxcontrib_applehelp-1.0.1-py2.py3-none-any.whl", hash = "sha256:fb8dee85af95e5c30c91f10e7eb3c8967308518e0f7488a2828ef7bc191d0d5d"},
+    {file = "sphinxcontrib-applehelp-1.0.2.tar.gz", hash = "sha256:a072735ec80e7675e3f432fcae8610ecf509c5f1869d17e2eecff44389cdbc58"},
+    {file = "sphinxcontrib_applehelp-1.0.2-py2.py3-none-any.whl", hash = "sha256:806111e5e962be97c29ec4c1e7fe277bfd19e9652fb1a4392105b43e01af885a"},
 ]
 sphinxcontrib-devhelp = [
-    {file = "sphinxcontrib-devhelp-1.0.1.tar.gz", hash = "sha256:6c64b077937330a9128a4da74586e8c2130262f014689b4b89e2d08ee7294a34"},
-    {file = "sphinxcontrib_devhelp-1.0.1-py2.py3-none-any.whl", hash = "sha256:9512ecb00a2b0821a146736b39f7aeb90759834b07e81e8cc23a9c70bacb9981"},
+    {file = "sphinxcontrib-devhelp-1.0.2.tar.gz", hash = "sha256:ff7f1afa7b9642e7060379360a67e9c41e8f3121f2ce9164266f61b9f4b338e4"},
+    {file = "sphinxcontrib_devhelp-1.0.2-py2.py3-none-any.whl", hash = "sha256:8165223f9a335cc1af7ffe1ed31d2871f325254c0423bc0c4c7cd1c1e4734a2e"},
 ]
 sphinxcontrib-htmlhelp = [
     {file = "sphinxcontrib-htmlhelp-1.0.3.tar.gz", hash = "sha256:e8f5bb7e31b2dbb25b9cc435c8ab7a79787ebf7f906155729338f3156d93659b"},
@@ -1503,15 +1519,15 @@ sphinxcontrib-jsmath = [
     {file = "sphinxcontrib_jsmath-1.0.1-py2.py3-none-any.whl", hash = "sha256:2ec2eaebfb78f3f2078e73666b1415417a116cc848b72e5172e596c871103178"},
 ]
 sphinxcontrib-qthelp = [
-    {file = "sphinxcontrib-qthelp-1.0.2.tar.gz", hash = "sha256:79465ce11ae5694ff165becda529a600c754f4bc459778778c7017374d4d406f"},
-    {file = "sphinxcontrib_qthelp-1.0.2-py2.py3-none-any.whl", hash = "sha256:513049b93031beb1f57d4daea74068a4feb77aa5630f856fcff2e50de14e9a20"},
+    {file = "sphinxcontrib-qthelp-1.0.3.tar.gz", hash = "sha256:4c33767ee058b70dba89a6fc5c1892c0d57a54be67ddd3e7875a18d14cba5a72"},
+    {file = "sphinxcontrib_qthelp-1.0.3-py2.py3-none-any.whl", hash = "sha256:bd9fc24bcb748a8d51fd4ecaade681350aa63009a347a8c14e637895444dfab6"},
 ]
 sphinxcontrib-serializinghtml = [
-    {file = "sphinxcontrib-serializinghtml-1.1.3.tar.gz", hash = "sha256:c0efb33f8052c04fd7a26c0a07f1678e8512e0faec19f4aa8f2473a8b81d5227"},
-    {file = "sphinxcontrib_serializinghtml-1.1.3-py2.py3-none-any.whl", hash = "sha256:db6615af393650bf1151a6cd39120c29abaf93cc60db8c48eb2dddbfdc3a9768"},
+    {file = "sphinxcontrib-serializinghtml-1.1.4.tar.gz", hash = "sha256:eaa0eccc86e982a9b939b2b82d12cc5d013385ba5eadcc7e4fed23f4405f77bc"},
+    {file = "sphinxcontrib_serializinghtml-1.1.4-py2.py3-none-any.whl", hash = "sha256:f242a81d423f59617a8e5cf16f5d4d74e28ee9a66f9e5b637a18082991db5a9a"},
 ]
 sqlalchemy = [
-    {file = "SQLAlchemy-1.3.13.tar.gz", hash = "sha256:64a7b71846db6423807e96820993fa12a03b89127d278290ca25c0b11ed7b4fb"},
+    {file = "SQLAlchemy-1.3.15.tar.gz", hash = "sha256:c4cca4aed606297afbe90d4306b49ad3a4cd36feb3f87e4bfd655c57fd9ef445"},
 ]
 toml = [
     {file = "toml-0.10.0-py2.7.egg", hash = "sha256:f1db651f9657708513243e61e6cc67d101a39bad662eaa9b5546f789338e07a3"},
@@ -1555,8 +1571,8 @@ urllib3 = [
     {file = "urllib3-1.25.8.tar.gz", hash = "sha256:87716c2d2a7121198ebcb7ce7cccf6ce5e9ba539041cfbaeecfb641dc0bf6acc"},
 ]
 virtualenv = [
-    {file = "virtualenv-20.0.7-py2.py3-none-any.whl", hash = "sha256:30ea90b21dabd11da5f509710ad3be2ae47d40ccbc717dfdd2efe4367c10f598"},
-    {file = "virtualenv-20.0.7.tar.gz", hash = "sha256:4a36a96d785428278edd389d9c36d763c5755844beb7509279194647b1ef47f1"},
+    {file = "virtualenv-20.0.10-py2.py3-none-any.whl", hash = "sha256:10750cac3b5a9e6eed54d0f1f8222c550dc47f84609c95cbc504d44a58a048b8"},
+    {file = "virtualenv-20.0.10.tar.gz", hash = "sha256:8512e83f1d90f8e481024d58512ac9c053bf16f54d9138520a0929396820dd78"},
 ]
 wcwidth = [
     {file = "wcwidth-0.1.8-py2.py3-none-any.whl", hash = "sha256:8fd29383f539be45b20bd4df0dc29c20ba48654a41e661925e612311e9f3c603"},
@@ -1570,6 +1586,6 @@ wrapt = [
     {file = "wrapt-1.11.2.tar.gz", hash = "sha256:565a021fd19419476b9362b05eeaa094178de64f8361e44468f9e9d7843901e1"},
 ]
 zipp = [
-    {file = "zipp-3.0.0-py3-none-any.whl", hash = "sha256:12248a63bbdf7548f89cb4c7cda4681e537031eda29c02ea29674bc6854460c2"},
-    {file = "zipp-3.0.0.tar.gz", hash = "sha256:7c0f8e91abc0dc07a5068f315c52cb30c66bfbc581e5b50704c8a2f6ebae794a"},
+    {file = "zipp-3.1.0-py3-none-any.whl", hash = "sha256:aa36550ff0c0b7ef7fa639055d797116ee891440eac1a56f378e2d3179e0320b"},
+    {file = "zipp-3.1.0.tar.gz", hash = "sha256:c599e4d75c98f6798c509911d08a22e6c021d074469042177c8c86fb92eefd96"},
 ]

--- a/splitgraph/commandline/common.py
+++ b/splitgraph/commandline/common.py
@@ -1,6 +1,7 @@
 """
 Various common functions used by the command line interface.
 """
+import json
 from typing import Optional, Tuple, List, TYPE_CHECKING
 
 import click
@@ -61,6 +62,16 @@ class RepositoryType(click.ParamType):
             if not repository_exists(result):
                 raise RepositoryNotFoundError("Unknown repository %s" % result)
         return result
+
+
+class JsonType(click.ParamType):
+    """Parser for Json -- a wrapper around json.loads because without specifying
+    the name Click shows the type for the option/arg as LOADS."""
+
+    name = "Json"
+
+    def convert(self, value: str, param: Optional[Parameter], ctx: Optional[Context]):
+        return json.loads(value)
 
 
 class Color:

--- a/splitgraph/commandline/image_creation.py
+++ b/splitgraph/commandline/image_creation.py
@@ -232,7 +232,7 @@ def tag_c(image_spec, tag, remove):
 
 
 @click.command(name="import")
-@click.argument("image_spec", type=ImageType(get_image=True))
+@click.argument("image_spec", type=ImageType())
 @click.argument("table_or_query")
 @click.argument("target_repository", type=RepositoryType())
 @click.argument("target_table", required=False)
@@ -273,6 +273,7 @@ def import_c(image_spec, table_or_query, target_repository, target_table):
 
     if repository_exists(repository):
         foreign_table = False
+        image = repository.images[image]
         # If the source table doesn't exist in the image, we'll treat it as a query instead.
         try:
             image.get_table(table_or_query)
@@ -283,7 +284,7 @@ def import_c(image_spec, table_or_query, target_repository, target_table):
         # If the source schema isn't actually a Splitgraph repo, we'll be copying the table verbatim.
         foreign_table = True
         is_query = table_or_query not in repository.engine.get_all_tables(repository.to_schema())
-        assert image is None
+        image = None
 
     if is_query and not target_table:
         click.echo("TARGET_TABLE is required when the source is a query!")

--- a/splitgraph/commandline/image_info.py
+++ b/splitgraph/commandline/image_info.py
@@ -255,6 +255,12 @@ def object_c(object_id):
         click.echo("Bloom index: ")
         for col_name, col_bloom in sg_object.object_index["bloom"].items():
             click.echo("  %s: %s" % (col_name, describe(col_bloom)))
+
+    if object_manager.object_engine.registry:
+        # Don't try to figure out the object's location if we're talking
+        # to the registry.
+        return
+
     click.echo()
     object_in_cache = object_manager.object_engine.run_sql(
         select("object_cache_status", "1", "object_id = %s"),

--- a/splitgraph/commandline/misc.py
+++ b/splitgraph/commandline/misc.py
@@ -53,7 +53,7 @@ def rm_c(image_spec, remote, yes):
 
     Deletes ``temporary_schema`` from the local engine.
 
-    ``sgr rm --remote splitgraph.com username/repo``
+    ``sgr rm --remote data.splitgraph.com username/repo``
 
     Deletes ``username/repo`` from the Splitgraph registry.
 

--- a/splitgraph/commandline/push_pull.py
+++ b/splitgraph/commandline/push_pull.py
@@ -13,9 +13,7 @@ from splitgraph.config.config import get_from_subsection
 
 
 @click.command(name="pull")
-@click.argument(
-    "repository_or_image", type=ImageType(repository_exists=True, image_exists=False, default=None)
-)
+@click.argument("repository_or_image", type=ImageType(repository_exists=True, default=None))
 @click.option(
     "-d",
     "--download-all",
@@ -74,7 +72,7 @@ _REMOTES = list(CONFIG.get("remotes", []))
 
 
 @click.command(name="push")
-@click.argument("repository_or_image", type=ImageType(image_exists=True, default=None))
+@click.argument("repository_or_image", type=ImageType(default=None))
 @click.argument("remote_repository", required=False, type=RepositoryType())
 @click.option(
     "-r",

--- a/splitgraph/commandline/splitfile.py
+++ b/splitgraph/commandline/splitfile.py
@@ -52,7 +52,7 @@ def build_c(splitfile, args, output_repository):
 
 
 @click.command(name="provenance")
-@click.argument("image_spec", type=ImageType())
+@click.argument("image_spec", type=ImageType(get_image=True))
 @click.option(
     "-f",
     "--full",
@@ -115,7 +115,6 @@ def provenance_c(image_spec, full, error_on_end):
         FROM noaa/climate:[hash_3] IMPORT {SELECT * FROM rainfall_data WHERE state = 'AZ'}
     """
     repository, image = image_spec
-    image = repository.images[image]
 
     if full:
         splitfile_commands = image.to_splitfile(err_on_end=error_on_end)
@@ -130,7 +129,7 @@ def provenance_c(image_spec, full, error_on_end):
 
 
 @click.command(name="rebuild")
-@click.argument("image_spec", type=ImageType())
+@click.argument("image_spec", type=ImageType(get_image=True))
 @click.option(
     "-u",
     "--update",
@@ -167,7 +166,6 @@ def rebuild_c(image_spec, update, against):
     out.
     """
     repository, image = image_spec
-    image = repository.images[image]
 
     # Replace the sources used to construct the image with either the latest ones or the images specified by the user.
     # This doesn't require us at this point to have pulled all the dependencies: the Splitfile executor will do it

--- a/splitgraph/config/keys.py
+++ b/splitgraph/config/keys.py
@@ -31,7 +31,7 @@ DEFAULTS: ConfigDict = {
     "SG_ENGINE_POSTGRES_DB_NAME": "postgres",
     "SG_ENGINE_OBJECT_PATH": "/var/lib/splitgraph/objects",
     # Size of the connection pool used to download/upload objects + talk to the engine
-    "SG_ENGINE_POOL": "5",
+    "SG_ENGINE_POOL": "16",
     "SG_CONFIG_FILE": "",
     "SG_META_SCHEMA": "splitgraph_meta",
     "SG_CONFIG_DIRS": "",

--- a/splitgraph/core/common.py
+++ b/splitgraph/core/common.py
@@ -252,7 +252,11 @@ def gather_sync_metadata(
 
     # Get the tags too
     existing_tags = [t for s, t in target.get_all_hashes_tags()]
-    tags = {t: s for s, t in source.get_all_hashes_tags() if t not in existing_tags}
+    tags = {
+        t: s
+        for s, t in source.get_all_hashes_tags()
+        if t not in existing_tags and s in new_image_hashes
+    }
 
     # Get objects that don't exist on the target
     table_objects = list({o for table in table_meta for o in table[3]})

--- a/splitgraph/core/common.py
+++ b/splitgraph/core/common.py
@@ -227,7 +227,7 @@ def gather_sync_metadata(
             ),
             (source.namespace, source.repository),
         )
-        if t[0] in new_images
+        if t[0] in new_image_hashes
     ]
 
     # Get the tags too

--- a/splitgraph/core/fragment_manager.py
+++ b/splitgraph/core/fragment_manager.py
@@ -562,7 +562,7 @@ class FragmentManager(MetadataManager):
 
         result = {
             r[0]: (r[1], r[2])
-            for r in self.metadata_engine.run_sql(
+            for r in self.metadata_engine.run_chunked_sql(
                 select(
                     "get_object_meta",
                     fields.as_string(self.metadata_engine.connection),
@@ -570,6 +570,7 @@ class FragmentManager(MetadataManager):
                     schema=SPLITGRAPH_API_SCHEMA,
                 ),
                 (fragments,),
+                chunk_position=0,
             )
         }
 

--- a/splitgraph/core/fragment_manager.py
+++ b/splitgraph/core/fragment_manager.py
@@ -679,6 +679,11 @@ class FragmentManager(MetadataManager):
         in_fragment_order: Optional[List[str]] = None,
         table_schema: Optional[TableSchema] = None,
     ) -> str:
+        if source_schema == "pg_temp" and not table_schema:
+            raise ValueError(
+                "Cannot infer the schema of temporary tables, " "pass in table_schema!"
+            )
+
         # Get schema (apart from the chunk ID column)
         # Fragments can't be reused in tables with different schemas
         # even if the contents match (e.g. '1' vs 1). Hence, include the table schema

--- a/splitgraph/core/image_manager.py
+++ b/splitgraph/core/image_manager.py
@@ -105,13 +105,12 @@ class ImageManager:
         """
         result = self.engine.run_sql(
             select(
-                "get_images",
+                "get_image",
                 ",".join(IMAGE_COLS),
                 schema=SPLITGRAPH_API_SCHEMA,
-                table_args="(%s, %s)",
-                where="image_hash LIKE %s",
+                table_args="(%s, %s, %s)",
             ),
-            (self.repository.namespace, self.repository.repository, image_hash.lower() + "%"),
+            (self.repository.namespace, self.repository.repository, image_hash.lower()),
             return_shape=ResultShape.MANY_MANY,
         )
         if not result:

--- a/splitgraph/core/indexing/bloom.py
+++ b/splitgraph/core/indexing/bloom.py
@@ -5,15 +5,17 @@ import struct
 from datetime import datetime
 from hashlib import sha256
 from math import ceil, log, exp
-from typing import Any, Dict, List, Optional, Tuple, Union, cast
+from typing import Any, Dict, List, Optional, Tuple, Union, cast, TYPE_CHECKING
 
 from psycopg2.sql import SQL, Identifier
 
 from splitgraph.config import SPLITGRAPH_META_SCHEMA
 from splitgraph.core.common import pretty_size
 from splitgraph.core.types import Changeset
-from splitgraph.engine.postgres.engine import PostgresEngine
 from splitgraph.engine.postgres.engine import SG_UD_FLAG
+
+if TYPE_CHECKING:
+    from splitgraph.engine.postgres.engine import PsycopgEngine
 
 
 def _hash_value(value: Union[datetime, int, str]) -> Tuple[bytes, bytes]:
@@ -28,7 +30,7 @@ def _hash_value(value: Union[datetime, int, str]) -> Tuple[bytes, bytes]:
 
 
 def generate_bloom_index(
-    engine: PostgresEngine,
+    engine: "PsycopgEngine",
     object_id: str,
     changeset: Optional[Changeset],
     column: str,
@@ -234,7 +236,7 @@ def _match(qual: Tuple[str, int, int], bloom_index: Dict[str, Tuple[int, bytes]]
     return True
 
 
-def filter_bloom_index(engine: PostgresEngine, object_ids: List[str], quals: Any) -> List[str]:
+def filter_bloom_index(engine: "PsycopgEngine", object_ids: List[str], quals: Any) -> List[str]:
     """
     Runs a bloom filter on given qualifiers using the given objects' previously-generated
     fingerprints.

--- a/splitgraph/core/indexing/range.py
+++ b/splitgraph/core/indexing/range.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any, Callable, Dict, List, Optional, Tuple, TypeVar, cast
+from typing import Any, Callable, Dict, List, Optional, Tuple, TypeVar, cast, TYPE_CHECKING
 
 from psycopg2.sql import Composed, SQL, Composable
 from psycopg2.sql import Identifier
@@ -9,7 +9,9 @@ from splitgraph.core.common import adapt, coerce_val_to_json
 from splitgraph.core.sql import select
 from splitgraph.core.types import Quals, Changeset, TableSchema
 from splitgraph.engine import ResultShape
-from splitgraph.engine.postgres.engine import PostgresEngine
+
+if TYPE_CHECKING:
+    from splitgraph.engine.postgres.engine import PsycopgEngine
 
 # PG types we can run max/min on
 _PG_INDEXABLE_TYPES = [
@@ -135,7 +137,7 @@ def quals_to_sql(quals: Optional[Quals], column_types: Dict[str, str]) -> Tuple[
     return _quals_to_clause(quals, column_types, qual_to_clause=_qual_to_sql_clause)
 
 
-def extract_min_max_pks(engine: PostgresEngine, fragments: List[str], table_pks: List[str]) -> Any:
+def extract_min_max_pks(engine: "PsycopgEngine", fragments: List[str], table_pks: List[str]) -> Any:
     """
     Extract minimum/maximum PK values for given fragments.
 
@@ -187,7 +189,7 @@ def extract_min_max_pks(engine: PostgresEngine, fragments: List[str], table_pks:
 
 
 def generate_range_index(
-    object_engine: PostgresEngine,
+    object_engine: "PsycopgEngine",
     object_id: str,
     table_schema: "TableSchema",
     changeset: Optional[Changeset],
@@ -269,7 +271,10 @@ def generate_range_index(
 
 
 def filter_range_index(
-    metadata_engine: PostgresEngine, object_ids: List[str], quals: Any, column_types: Dict[str, str]
+    metadata_engine: "PsycopgEngine",
+    object_ids: List[str],
+    quals: Any,
+    column_types: Dict[str, str],
 ) -> List[str]:
     clause, args = _quals_to_clause(quals, column_types)
     query = (

--- a/splitgraph/core/indexing/range.py
+++ b/splitgraph/core/indexing/range.py
@@ -272,7 +272,7 @@ def filter_range_index(
 
     return cast(
         List[str],
-        metadata_engine.run_sql(
-            query, [object_ids] + list(args), return_shape=ResultShape.MANY_ONE
+        metadata_engine.run_chunked_sql(
+            query, [object_ids] + list(args), return_shape=ResultShape.MANY_ONE, chunk_position=0
         ),
     )

--- a/splitgraph/core/metadata_manager.py
+++ b/splitgraph/core/metadata_manager.py
@@ -16,7 +16,7 @@ from .sql import select
 
 if TYPE_CHECKING:
     from splitgraph.core.repository import Repository
-    from splitgraph.engine.postgres.engine import PostgresEngine
+    from splitgraph.engine.postgres.engine import PsycopgEngine
 
 OBJECT_COLS = [
     "object_id",
@@ -49,7 +49,7 @@ class MetadataManager:
     with image, table and object information.
     """
 
-    def __init__(self, metadata_engine: "PostgresEngine") -> None:
+    def __init__(self, metadata_engine: "PsycopgEngine") -> None:
         self.metadata_engine = metadata_engine
 
     def register_objects(self, objects: List[Object], namespace: Optional[str] = None) -> None:

--- a/splitgraph/core/object_manager.py
+++ b/splitgraph/core/object_manager.py
@@ -38,7 +38,7 @@ from .sql import select, insert
 
 if TYPE_CHECKING:
     from splitgraph.core.table import Table
-    from splitgraph.engine.postgres.engine import PostgresEngine
+    from splitgraph.engine.postgres.engine import PsycopgEngine, PostgresEngine
 
 
 class ObjectManager(FragmentManager):
@@ -807,7 +807,7 @@ class ObjectManager(FragmentManager):
 
 def _fetch_external_objects(
     engine: "PostgresEngine",
-    source_engine: "PostgresEngine",
+    source_engine: "PsycopgEngine",
     object_locations: List[Tuple[str, str, str]],
     handler_params: Dict[str, Any],
 ) -> List[str]:

--- a/splitgraph/core/repository.py
+++ b/splitgraph/core/repository.py
@@ -34,6 +34,7 @@ from .common import (
     aggregate_changes,
     slow_diff,
     gather_sync_metadata,
+    set_tags_batch,
 )
 from .engine import lookup_repository, get_engine
 from .object_manager import ObjectManager
@@ -504,10 +505,12 @@ class Repository:
 
         :param tags: List of (image_hash, tag)
         """
+        args = []
         for tag, image_id in tags.items():
             if tag != "HEAD":
                 assert image_id is not None
-                self.images.by_hash(image_id).tag(tag)
+                args.append((image_id, tag))
+        set_tags_batch(self, args)
 
     def run_sql(
         self,

--- a/splitgraph/core/repository.py
+++ b/splitgraph/core/repository.py
@@ -167,7 +167,7 @@ class Repository:
         """
         # Make sure to discard changes to this repository if they exist, otherwise they might
         # be applied/recorded if a new repository with the same name appears.
-        if uncheckout and not self.engine.registry:
+        if uncheckout and not self.object_engine.registry:
             self.object_engine.discard_pending_changes(self.to_schema())
 
             # Dispose of the foreign servers (LQ FDW, other FDWs) for this schema if it exists

--- a/splitgraph/engine/__init__.py
+++ b/splitgraph/engine/__init__.py
@@ -10,7 +10,7 @@ from abc import ABC
 from contextlib import contextmanager
 from datetime import datetime
 from enum import Enum
-from typing import Any, Dict, Iterator, List, Optional, Tuple, Union, TYPE_CHECKING, cast
+from typing import Any, Dict, Iterator, List, Optional, Tuple, Union, TYPE_CHECKING, cast, Sequence
 
 from psycopg2.sql import Composed
 from psycopg2.sql import SQL, Identifier
@@ -613,16 +613,21 @@ class ObjectEngine:
         """
         raise NotImplementedError()
 
-    def store_object(self, object_id, source_schema, source_table):
+    def store_object(
+        self,
+        object_id: str,
+        source_query: Union[bytes, Composed, str, SQL],
+        schema_spec: TableSchema,
+        source_query_args: Optional[Sequence[Any]],
+    ):
         """
-        Stores a Splitgraph object located in a staging table in the actual format
+        Stores a Splitgraph object using a source query in the actual format
         implemented by this engine.
 
-        At the end of this operation, the staging table must be deleted.
-
-        :param source_schema: Schema the staging table is located in.
-        :param source_table: Name of the staging table
         :param object_id: Name of the object
+        :param source_query: SELECT query that produces data required by the object
+        :param schema_spec: Schema of the source table
+        :param source_query_args: Arguments to mogrify into the source query.
         """
 
 

--- a/splitgraph/engine/postgres/engine.py
+++ b/splitgraph/engine/postgres/engine.py
@@ -1063,9 +1063,7 @@ class PostgresEngine(AuditTriggerChangeEngine, ObjectEngine):
         )
 
         # Try mounting the object
-        try:
-            self.mount_object(object_id, schema_spec=schema_spec)
-        except DuplicateTable:
+        if self.table_exists(SPLITGRAPH_META_SCHEMA, object_id):
             # Foreign table with that name already exists. If it does exist but there's no
             # physical object file, we'll have to write into the table anyway.
             if not object_exists:
@@ -1077,6 +1075,8 @@ class PostgresEngine(AuditTriggerChangeEngine, ObjectEngine):
             # parameters (e.g. object path in /var/lib/splitgraph/objects has changed)
             # and we want that to be overwritten in any case, so we remount the object.
             self.unmount_objects([object_id])
+            self.mount_object(object_id, schema_spec=schema_spec)
+        else:
             self.mount_object(object_id, schema_spec=schema_spec)
 
         if object_exists:

--- a/splitgraph/engine/postgres/engine.py
+++ b/splitgraph/engine/postgres/engine.py
@@ -84,12 +84,12 @@ _API_VERSION = "0.0.1"
 # footprint more predictable. We hence chunk some heavy queries like object
 # index uploading to allow registering multiple objects at the same time whilst
 # also limiting the query's maximum size.
-API_MAX_QUERY_LENGTH = 32768
+API_MAX_QUERY_LENGTH = 65000
 
 # In addition, some API calls (like get_object_meta) allow variadic arguments
 # to decrease the number of roundtrips the client has to do -- limit this to a sane
-# number (in the standard config 400 objects is about 4-10M rows).
-API_MAX_VARIADIC_ARGS = 400
+# number (in the standard config 800 objects is 8M rows).
+API_MAX_VARIADIC_ARGS = 800
 
 
 def _handle_fatal(e):

--- a/splitgraph/engine/postgres/engine.py
+++ b/splitgraph/engine/postgres/engine.py
@@ -67,10 +67,7 @@ STM_TRIGGER_NAME = "audit_trigger_stm"
 REMOTE_TMP_SCHEMA = "tmp_remote_data"
 SG_UD_FLAG = "sg_ud_flag"
 
-# Max number of retries before failing
-POOL_RETRY_AMOUNT = 20
-
-# Retry policy for other connection errors
+# Retry policy for connection errors
 RETRY_DELAY = 5
 RETRY_AMOUNT = 12
 
@@ -964,10 +961,7 @@ class PostgresEngine(AuditTriggerChangeEngine, ObjectEngine):
         non_ri_cols = [c.name for c in schema_spec if not c.is_pk]
         all_cols = ri_cols + non_ri_cols
         self.create_table(
-            schema,
-            table,
-            schema_spec=([TableColumn(0, SG_UD_FLAG, "boolean", False)] + schema_spec),
-            temporary=temporary,
+            schema, table, schema_spec=add_ud_flag_column(schema_spec), temporary=temporary,
         )
 
         # Store upserts
@@ -1420,3 +1414,7 @@ def _generate_where_clause(table: str, cols: List[str], table_2: str) -> Compose
         )
         for c in cols
     )
+
+
+def add_ud_flag_column(table_schema: TableSchema) -> TableSchema:
+    return table_schema + [TableColumn(table_schema[-1].ordinal + 1, SG_UD_FLAG, "boolean", False)]

--- a/splitgraph/engine/postgres/engine.py
+++ b/splitgraph/engine/postgres/engine.py
@@ -481,16 +481,14 @@ class PsycopgEngine(SQLEngine):
                 if schema:
                     cur.execute("SET search_path to %s;", (schema,))
 
-                batches = (
-                    _paginate_by_size(
-                        cur,
-                        statement,
-                        [_convert_vals(a) for a in arguments],
-                        max_size=API_MAX_QUERY_LENGTH,
-                    ),
+                batches = _paginate_by_size(
+                    cur,
+                    statement,
+                    [_convert_vals(a) for a in arguments],
+                    max_size=API_MAX_QUERY_LENGTH,
                 )
                 for batch in batches:
-                    cur.execute(b";".join(batch))
+                    cur.execute(batch)
                 if schema:
                     cur.execute("SET search_path to public")
             except DatabaseError:

--- a/splitgraph/hooks/external_objects.py
+++ b/splitgraph/hooks/external_objects.py
@@ -9,7 +9,7 @@ from splitgraph.config.config import get_from_section
 from splitgraph.exceptions import ExternalHandlerError
 
 if TYPE_CHECKING:
-    from splitgraph.engine import PostgresEngine
+    from splitgraph.engine.postgres.engine import PsycopgEngine
 
 
 class ExternalObjectHandler:
@@ -40,7 +40,7 @@ class ExternalObjectHandler:
         self.params = params
 
     def upload_objects(
-        self, objects: List[str], remote_engine: "PostgresEngine"
+        self, objects: List[str], remote_engine: "PsycopgEngine"
     ) -> Sequence[Tuple[str, str]]:
         """Upload objects from the Splitgraph cache to an external location
 
@@ -50,7 +50,7 @@ class ExternalObjectHandler:
         """
 
     def download_objects(
-        self, objects: List[Tuple[str, str]], remote_engine: "PostgresEngine"
+        self, objects: List[Tuple[str, str]], remote_engine: "PsycopgEngine"
     ) -> Sequence[str]:
         """Download objects from the external location into the Splitgraph cache.
 

--- a/splitgraph/hooks/s3.py
+++ b/splitgraph/hooks/s3.py
@@ -3,18 +3,18 @@ Plugin for uploading Splitgraph objects from the cache to an external S3-like ob
 """
 import logging
 from concurrent.futures import ThreadPoolExecutor
-from typing import List, Tuple
+from typing import List, Tuple, TYPE_CHECKING
 
 from psycopg2 import DatabaseError
-from psycopg2.errors import DuplicateTable
 from tqdm import tqdm
 
 from splitgraph.config import CONFIG, get_singleton
 from splitgraph.engine import get_engine, ResultShape
-from splitgraph.engine.postgres.engine import PostgresEngine
 from splitgraph.exceptions import IncompleteObjectUploadError, IncompleteObjectDownloadError
 from splitgraph.hooks.external_objects import ExternalObjectHandler
 
+if TYPE_CHECKING:
+    from splitgraph.engine.postgres.engine import PsycopgEngine
 
 # Downloading/uploading objects to/from S3.
 # In the beginning, let's say that we just mount all objects as soon as they are downloaded -- otherwise
@@ -53,7 +53,7 @@ class S3ExternalObjectHandler(ExternalObjectHandler):
     """
 
     def upload_objects(
-        self, objects: List[str], remote_engine: PostgresEngine
+        self, objects: List[str], remote_engine: "PsycopgEngine"
     ) -> List[Tuple[str, str]]:
         """
         Upload objects to Minio
@@ -116,7 +116,7 @@ class S3ExternalObjectHandler(ExternalObjectHandler):
             local_engine.close_others()
 
     def download_objects(
-        self, objects: List[Tuple[str, str]], remote_engine: PostgresEngine
+        self, objects: List[Tuple[str, str]], remote_engine: "PsycopgEngine"
     ) -> List[str]:
         """
         Download objects from Minio.

--- a/splitgraph/ingestion/pandas.py
+++ b/splitgraph/ingestion/pandas.py
@@ -131,8 +131,6 @@ def _df_to_empty_table(
             ).format(Identifier(target_table), Identifier(table_schema[-1].name)),
         )
 
-    engine.commit()
-
 
 def df_to_table_fast(
     engine: PostgresEngine, df: DataFrame, target_schema: str, target_table: str
@@ -165,7 +163,6 @@ def df_to_table_fast(
             ),
             buffer,
         )
-    engine.commit()
 
 
 def _schema_compatible(source_schema: TableSchema, target_schema: TableSchema) -> bool:

--- a/splitgraph/resources/splitgraph_meta/splitgraph_meta--0.0.1.sql
+++ b/splitgraph/resources/splitgraph_meta/splitgraph_meta--0.0.1.sql
@@ -5,8 +5,7 @@ CREATE TABLE splitgraph_meta.images (
     namespace varchar NOT NULL,
     repository varchar NOT NULL,
     image_hash varchar(64) NOT NULL CHECK (image_hash ~ '^[a-f0-9]{64}$'),
-    parent_id varchar(64) CHECK (parent_id ~ '^[a-f0-9]{64}$' AND parent_id
-	!= image_hash),
+    parent_id varchar(64) CHECK (parent_id ~ '^[a-f0-9]{64}$' AND parent_id != image_hash),
     created timestamp,
     comment varchar(4096),
     provenance_type varchar(10),

--- a/splitgraph/resources/static/audit_trigger.sql
+++ b/splitgraph/resources/static/audit_trigger.sql
@@ -110,7 +110,7 @@ BEGIN
         audit_row.row_data = row_to_json(NEW)::jsonb;
     ELSE
         RAISE EXCEPTION '[audit.if_modified_func] - Trigger func added as
-  	    trigger for unhandled case: %, %', TG_OP, TG_LEVEL;
+   	    trigger for unhandled case: %, %', TG_OP, TG_LEVEL;
         RETURN NULL;
     END IF;
     INSERT INTO audit.logged_actions
@@ -144,8 +144,8 @@ DECLARE
 BEGIN
     EXECUTE 'DROP TRIGGER IF EXISTS audit_trigger_row ON ' || target_table;
     _q_txt = 'CREATE TRIGGER audit_trigger_row AFTER INSERT OR UPDATE OR DELETE
-  	ON ' || target_table || ' FOR EACH ROW EXECUTE PROCEDURE
-  	audit.if_modified_func();';
+   	ON ' || target_table || ' FOR EACH ROW EXECUTE PROCEDURE
+   	audit.if_modified_func();';
     RAISE NOTICE '%', _q_txt;
     EXECUTE _q_txt;
 END;

--- a/splitgraph/resources/static/cstore.sql
+++ b/splitgraph/resources/static/cstore.sql
@@ -182,7 +182,11 @@ CREATE OR REPLACE FUNCTION splitgraph_api.object_exists (
 
     SG_ENGINE_OBJECT_PATH = CONFIG["SG_ENGINE_OBJECT_PATH"]
 
-    return os.path.exists(os.path.join(SG_ENGINE_OBJECT_PATH, object_id))
+    # Make sure to check for all 3 files to guard against partially failed writes.
+    return all(
+        os.path.exists(os.path.join(SG_ENGINE_OBJECT_PATH, object_id + suffix))
+        for suffix in ("", ".footer", ".schema")
+    )
 $BODY$
 LANGUAGE plpython3u
 VOLATILE;

--- a/splitgraph/resources/static/splitgraph_api.sql
+++ b/splitgraph/resources/static/splitgraph_api.sql
@@ -402,6 +402,33 @@ $$
 LANGUAGE plpgsql
 SECURITY DEFINER SET search_path = splitgraph_meta, pg_temp;
 
+-- get_tables(namespace, repository): list all tables in a given repository together with
+-- images they belong to.
+CREATE OR REPLACE FUNCTION splitgraph_api.get_all_tables (
+    _namespace varchar,
+    _repository varchar
+)
+    RETURNS TABLE (
+            image_hash varchar,
+            table_name varchar,
+            table_schema jsonb,
+            object_ids varchar[]
+        )
+        AS $$
+BEGIN
+    RETURN QUERY
+    SELECT t.image_hash,
+        t.table_name,
+        t.table_schema,
+        t.object_ids
+    FROM splitgraph_meta.tables t
+    WHERE t.namespace = _namespace
+        AND t.repository = _repository;
+END
+$$
+LANGUAGE plpgsql
+SECURITY DEFINER SET search_path = splitgraph_meta, pg_temp;
+
 -- add_table(namespace, repository, table_name, table_schema, object_ids) -- add a table to an existing image.
 -- Technically, we shouldn't allow this to be done once the image has been created (so maybe that idea with only having
 -- two API calls: once to register the objects and one to register the images+tables might work?)

--- a/test/splitgraph/commandline/test_cloud.py
+++ b/test/splitgraph/commandline/test_cloud.py
@@ -287,13 +287,20 @@ def _make_dummy_config_dict():
 @pytest.mark.parametrize(
     "test_case",
     [
-        ("ns/repo/image/table?id=eq.5", "http://some-query-service/ns/repo/image/table?id=eq.5"),
-        ("ns/repo/latest/table?id=eq.5", "http://some-query-service/ns/repo/latest/table?id=eq.5"),
+        (
+            ["ns/repo", "table?id=eq.5"],
+            "http://some-query-service/ns/repo/latest/-/rest/table?id=eq.5",
+        ),
+        (
+            ["ns/repo:image", "/table?id=eq.5"],
+            "http://some-query-service/ns/repo/image/-/rest/table?id=eq.5",
+        ),
+        (["ns/repo"], "http://some-query-service/ns/repo/latest/-/rest",),
     ],
 )
 def test_commandline_curl_normal(test_case):
     runner = CliRunner()
-    request, result_url = test_case
+    args, result_url = test_case
 
     with patch(
         "splitgraph.cloud.AuthAPIClient.access_token",
@@ -303,7 +310,7 @@ def test_commandline_curl_normal(test_case):
         with patch("splitgraph.commandline.cloud.subprocess.call") as sc:
             result = runner.invoke(
                 curl_c,
-                ["--remote", _REMOTE, request, "--some-curl-arg", "-Ssl"],
+                ["--remote", _REMOTE] + args + ["-c", "--some-curl-arg", "-c", "-Ssl"],
                 catch_exceptions=False,
             )
             assert result.exit_code == 0

--- a/test/splitgraph/commandline/test_commit_checkout.py
+++ b/test/splitgraph/commandline/test_commit_checkout.py
@@ -11,7 +11,16 @@ def test_commandline_commit_chunk(pg_repo_local):
     pg_repo_local.run_sql("ALTER TABLE fruits ADD PRIMARY KEY (fruit_id)")
     pg_repo_local.run_sql("ALTER TABLE vegetables ADD PRIMARY KEY (vegetable_id)")
 
-    result = runner.invoke(commit_c, [str(pg_repo_local), "--snap", "--chunk-size=1"])
+    result = runner.invoke(
+        commit_c,
+        [
+            str(pg_repo_local),
+            "--snap",
+            "--chunk-size=1",
+            "--chunk-sort-keys",
+            '{"fruits": ["fruit_id", "name"], "vegetables": ["vegetable_id", "name"]}',
+        ],
+    )
     assert result.exit_code == 0
 
     original_objects = pg_repo_local.head.get_table("fruits").objects

--- a/test/splitgraph/commandline/test_push_pull.py
+++ b/test/splitgraph/commandline/test_push_pull.py
@@ -178,7 +178,7 @@ def test_reindex_and_force_push(pg_repo_local, pg_repo_remote):
     assert result.exit_code == 0
     assert "Reindexed 1 object(s)" in result.output
 
-    result = runner.invoke(push_c, [str(pg_repo_local), "-f"], mix_stderr=False)
+    result = runner.invoke(push_c, [str(pg_repo_local), "-f"], catch_exceptions=False)
     assert result.exit_code == 0
 
     obj = pg_repo_remote.images["latest"].get_table("fruits").objects[0]

--- a/test/splitgraph/commands/test_commit_diff.py
+++ b/test/splitgraph/commands/test_commit_diff.py
@@ -257,17 +257,17 @@ def test_commit_diff_splitting(local_engine_empty):
 
     # Check the contents of the newly created objects.
     assert OUTPUT.run_sql(select(added_objects[0])) == [
-        (True, 0, "zero", -1)
+        (0, "zero", -1, True)
     ]  # upserted=True, key, new_value_1, new_value_2
     assert OUTPUT.run_sql(select(added_objects[1])) == [
-        (True, 5, "UPDATED", 8),  # upserted=True, key, new_value_1, new_value_2
-        (False, 4, None, None),
+        (5, "UPDATED", 8, True),  # upserted=True, key, new_value_1, new_value_2
+        (4, None, None, False),
     ]  # upserted=False, key, None, None
     assert OUTPUT.run_sql(select(added_objects[2])) == [
-        (False, 6, None, None)
+        (6, None, None, False)
     ]  # upserted=False, key, None, None
     assert OUTPUT.run_sql(select(added_objects[3])) == [
-        (True, 12, "l", 22)
+        (12, "l", 22, True)
     ]  # upserted=True, key, new_value_1, new_value_2
 
     object_meta = OUTPUT.objects.get_object_meta(added_objects)
@@ -484,11 +484,11 @@ def test_commit_mode_change(pg_repo_local):
 
     # Check object contents
     assert OUTPUT.run_sql(select(table.objects[2])) == [
-        (True, -1, "UPDATED", -4),
-        (True, 6, "UPDATED", 10),
+        (-1, "UPDATED", -4, True),
+        (6, "UPDATED", 10, True),
     ]
 
-    assert OUTPUT.run_sql(select(table.objects[3])) == [(True, 8, "something", 42)]
+    assert OUTPUT.run_sql(select(table.objects[3])) == [(8, "something", 42, True)]
 
 
 def test_drop_recreate(pg_repo_local):

--- a/test/splitgraph/commands/test_external_objects.py
+++ b/test/splitgraph/commands/test_external_objects.py
@@ -34,7 +34,7 @@ def test_s3_presigned_url(local_engine_empty, unprivileged_pg_repo, clean_minio)
     assert len(urls_local) == 1
     assert len(urls_local[0]) == 3
 
-    urls = unprivileged_pg_repo.run_sql(
+    urls = unprivileged_pg_repo.engine.run_sql(
         "SELECT * FROM splitgraph_api.get_object_upload_urls(%s, %s)",
         ("%s:%s" % (S3_HOST, S3_PORT), [object_id]),
         return_shape=ResultShape.ONE_ONE,

--- a/test/splitgraph/commands/test_schema_changes.py
+++ b/test/splitgraph/commands/test_schema_changes.py
@@ -81,8 +81,8 @@ def test_schema_changes(pg_repo_local, test_case):
     assert len(new_head.get_table("fruits").objects) == 1
     new_snap = new_head.get_table("fruits").objects[0]
     assert pg_repo_local.engine.get_object_schema(new_snap) == _drop_comments(
-        _reassign_ordinals(expected_new_schema)
-        + [TableColumn(len(expected_new_schema) + 1, SG_UD_FLAG, "boolean", False)]
+        expected_new_schema
+        + [TableColumn(expected_new_schema[-1].ordinal + 1, SG_UD_FLAG, "boolean", False)]
     )
 
     head.checkout()

--- a/test/splitgraph/conftest.py
+++ b/test/splitgraph/conftest.py
@@ -5,6 +5,7 @@ import docker
 import docker.errors
 import pytest
 from minio.error import BucketAlreadyExists, BucketAlreadyOwnedByYou
+from psycopg2.sql import Identifier, SQL
 
 from splitgraph.commandline.engine import copy_to_container
 from splitgraph.config import SPLITGRAPH_META_SCHEMA, CONFIG
@@ -233,6 +234,10 @@ def clean_out_engine(engine):
         mountpoint.delete()
     for mountpoint in TEST_MOUNTPOINTS:
         Repository.from_template(mountpoint, engine=engine).delete()
+        # Make sure schemata, not only repositories, are deleted on the engine.
+        engine.run_sql(
+            SQL("DROP SCHEMA IF EXISTS {} CASCADE").format(Identifier(mountpoint.to_schema()))
+        )
     ObjectManager(engine).cleanup()
     engine.commit()
 

--- a/test/splitgraph/splitfile/test_execution.py
+++ b/test/splitgraph/splitfile/test_execution.py
@@ -177,7 +177,7 @@ def test_import_updating_splitfile_with_uploading(
 
 @pytest.mark.mounting
 def test_splitfile_end_to_end_with_uploading(
-    local_engine_empty, remote_engine, pg_repo_remote_multitag, mg_repo_remote
+    local_engine_empty, remote_engine, pg_repo_remote_multitag, mg_repo_remote, clean_minio
 ):
     # An end-to-end test:
     #   * Create a derived dataset from some tables imported from the remote engine

--- a/test/splitgraph/test_misc.py
+++ b/test/splitgraph/test_misc.py
@@ -191,28 +191,6 @@ def test_metadata_constraints_table_objects(local_engine_empty):
         assert "Some objects in the object_ids array aren''t registered!" in str(e)
 
 
-def test_remove_with_no_audit_triggers(local_engine_empty):
-    # Test deleting a repository with uncheckout=True doesn't fail if the engine
-    # doesn't support checkouts to begin with: used if someone does "sgr rm -r [registry]"
-    try:
-        repo = Repository("some", "repo")
-        repo.init()
-        local_engine_empty.run_sql("DROP SCHEMA audit CASCADE")
-        local_engine_empty.commit()
-        # This still raises
-        with pytest.raises(EngineInitializationError):
-            local_engine_empty.discard_pending_changes("some/repo")
-
-        # This doesn't.
-        assert repository_exists(repo)
-        Repository("some", "repo").delete()
-        assert not repository_exists(repo)
-
-    finally:
-        local_engine_empty.initialize()
-        local_engine_empty.commit()
-
-
 @pytest.mark.registry
 def test_large_api_calls(unprivileged_pg_repo):
     # Test query chunking for API calls that exceed length/vararg limits

--- a/test/splitgraph/test_misc.py
+++ b/test/splitgraph/test_misc.py
@@ -9,6 +9,7 @@ from splitgraph.core.engine import lookup_repository, repository_exists
 from splitgraph.core.metadata_manager import Object
 from splitgraph.core.repository import Repository
 from splitgraph.exceptions import RepositoryNotFoundError, EngineInitializationError
+from splitgraph.hooks.s3 import get_object_upload_urls
 
 
 def test_repo_lookup_override(remote_engine):
@@ -210,3 +211,77 @@ def test_remove_with_no_audit_triggers(local_engine_empty):
     finally:
         local_engine_empty.initialize()
         local_engine_empty.commit()
+
+
+@pytest.mark.registry
+def test_large_api_calls(unprivileged_pg_repo):
+    # Test query chunking for API calls that exceed length/vararg limits
+
+    # Make a fake object with 64KB of bloom index data (doesn't fit into the min query size
+    # at all)
+    fake_object = Object(
+        object_id="o%062d" % 0,
+        format="FRAG",
+        namespace=unprivileged_pg_repo.namespace,
+        size=42,
+        created=datetime.now(),
+        insertion_hash="0" * 64,
+        deletion_hash="0" * 64,
+        object_index={"bloom": [42, "A" * 65536]},
+    )
+
+    with pytest.raises(ValueError) as e:
+        unprivileged_pg_repo.objects.register_objects(
+            [fake_object], namespace=unprivileged_pg_repo.namespace
+        )
+    assert "exceeds maximum query size" in str(e.value)
+
+    # Make a bunch of fake objects and try registering them
+    # Each object has 1KB of bloom index data (+ a few bytes of misc metadata) and we're
+    # making 1000 objects -- check that queries get chunked up.
+    objects = [
+        Object(
+            object_id="o%062d" % i,
+            format="FRAG",
+            namespace=unprivileged_pg_repo.namespace,
+            size=42,
+            created=datetime.now(),
+            insertion_hash="0" * 64,
+            deletion_hash="0" * 64,
+            object_index={"bloom": [42, "A" * 1024]},
+        )
+        for i in range(1000)
+    ]
+    all_ids = [o.object_id for o in objects]
+    # Check objects don't exist (query should also get chunked up) and register them
+    new_objects = unprivileged_pg_repo.objects.get_new_objects(all_ids)
+    assert new_objects == all_ids
+    unprivileged_pg_repo.objects.register_objects(objects, namespace=unprivileged_pg_repo.namespace)
+
+    # Get presigned URLs for these objects
+    urls = get_object_upload_urls(unprivileged_pg_repo.engine, all_ids)
+    assert len(urls) == 1000
+
+    # Get our objects back
+    meta = unprivileged_pg_repo.objects.get_object_meta(all_ids)
+    assert len(meta) == 1000
+
+    # Now make an image with a lot of objects
+    image_hash = "0" * 63 + "1"
+    unprivileged_pg_repo.images.add(parent_id=None, image=image_hash)
+
+    # Two tables to test that register_tables chunks correctly with multiple tables
+    unprivileged_pg_repo.objects.register_tables(
+        unprivileged_pg_repo,
+        [
+            (image_hash, "small_table", [(1, "key", "integer", True)], [all_ids[0]]),
+            (image_hash, "table", [(1, "key", "integer", True)], all_ids,),
+        ],
+    )
+
+    # Get table back and check that it has the same objects (multiple add_table calls
+    # add new objects to the table)
+    table = unprivileged_pg_repo.images[image_hash].get_table("table")
+    assert table.objects == all_ids
+    small_table = unprivileged_pg_repo.images[image_hash].get_table("small_table")
+    assert small_table.objects == [all_ids[0]]

--- a/test/splitgraph/test_security.py
+++ b/test/splitgraph/test_security.py
@@ -1,3 +1,4 @@
+import psycopg2
 import pytest
 from psycopg2._psycopg import ProgrammingError
 from psycopg2.sql import SQL, Identifier
@@ -144,14 +145,12 @@ def test_impersonate_external_object(readonly_pg_repo):
 def test_no_direct_table_access(unprivileged_pg_repo):
     # Canary to check users can't manipulate splitgraph_meta tables directly
     for table in META_TABLES:
-        with pytest.raises(ProgrammingError) as e:
+        with pytest.raises(psycopg2.Error) as e:
             unprivileged_pg_repo.engine.run_sql(select(table, "1"))
-        assert "permission denied for table" in str(e.value)
 
-        with pytest.raises(ProgrammingError) as e:
+        with pytest.raises(psycopg2.Error) as e:
             unprivileged_pg_repo.engine.run_sql(
                 SQL("DELETE FROM {}.{} WHERE 1 = 2").format(
                     Identifier(SPLITGRAPH_META_SCHEMA), Identifier(table)
                 )
             )
-        assert "permission denied for table" in str(e.value)


### PR DESCRIPTION
  * Chunk up API calls (max size 64kb)
  * Speed up `sgr push/pull` by batch calls
  * Speed up chunking large tables by 4x
  * Speed up object uploads/downloads (bigger pool, smaller Python imports)
  * Add new API calls:
    * `get_image`
    * `delete_image`
  * Add ability to push/pull single images.
  * Change `sgr cloud curl` endpoint to the new location for Postgrest API