### PR TITLE
Feature/run example

### DIFF
--- a/engine/Dockerfile
+++ b/engine/Dockerfile
@@ -12,10 +12,7 @@
 ##### toolchain
 #####
 
-FROM postgres:12.2 AS toolchain
-
-# Add Debian bullseye (testing) repo since it has Python 3.8 and postgresql-plpython3-12
-RUN echo "deb http://deb.debian.org/debian bullseye main" >> /etc/apt/sources.list.d/debian-bullseye.list
+FROM postgres:12.3 AS toolchain
 
 RUN apt-get update -qq && \
     apt-get install -y --allow-downgrades \
@@ -36,8 +33,8 @@ RUN apt-get update -qq && \
         libmongoc-dev \
         protobuf-c-compiler \
         libprotobuf-c-dev \
-        libpython3.8-dev \
-        python3.8 \
+        libpython3.7-dev \
+        python3.7 \
         python3-setuptools \
         cmake \
         clang-7 && \
@@ -102,32 +99,24 @@ RUN /build/build_mysql_fdw.sh
 ##### splitgraph/engine
 #####
 
-FROM postgres:12.2
+FROM postgres:12.3
 
 # We still have to install some runtime libraries here, but no dev.
 
-RUN echo "deb http://deb.debian.org/debian bullseye main" >> /etc/apt/sources.list.d/debian-bullseye.list
 RUN apt-get update -qq && \
     apt-get install -y \
         curl \
         libprotobuf-c1 \
         libmongoc-1.0-0 \
-        libpython3.8 \
-        python3.8 \
+        libpython3.7 \
+        python3.7 \
+        python3-setuptools \
+        postgresql-plpython3-12 \
         wget && \
-    # Featuring a hack to install distutils + pip in a way that doesn't pull in all of py3.7 and apparmor
-    # (even though we get python3-distutils_3.8.2-2_all.deb, an actual install grabs all of that)
-    apt-get download python3-distutils && \
-    dpkg-deb -x python3-distutils*.deb / && \
-    curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && \
-    python3.8 get-pip.py && \
-    rm python3-distutils*.deb get-pip.py && \
 
-    # Same hack for plpython3 for pg12 that uses 3.8 rather than 3.7:
-    # normal apt install causes compat issues.
-    apt-get download -t bullseye postgresql-plpython3-12 && \
-    dpkg-deb -x postgresql-plpython3-12*.deb / && \
-    rm postgresql-plpython3-12*.deb && \
+        curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && \
+        python3.7 get-pip.py && \
+        rm get-pip.py && \
     rm -rf /var/lib/apt/lists/*
 
 # Set locale to C instead of en-US, Postgres initdb breaks with default
@@ -166,11 +155,11 @@ RUN mkdir ~/.gnupg && echo "disable-ipv6" >> ~/.gnupg/dirmngr.conf && \
 
 COPY --from=builder_cstore_multicorn /output/root /
 COPY --from=builder_cstore_multicorn \
-    /usr/local/lib/python3.8/dist-packages/easy-install.pth \
-    /usr/local/lib/python3.8/dist-packages/easy-install.pth
+    /usr/local/lib/python3.7/dist-packages/easy-install.pth \
+    /usr/local/lib/python3.7/dist-packages/easy-install.pth
 COPY --from=builder_cstore_multicorn \
-    /usr/local/lib/python3.8/dist-packages/multicorn-1.4.0.dev0-py3.8-linux-x86_64.egg \
-    /usr/local/lib/python3.8/dist-packages/multicorn-1.4.0.dev0-py3.8-linux-x86_64.egg
+    /usr/local/lib/python3.7/dist-packages/multicorn-1.4.0.dev0-py3.7-linux-x86_64.egg \
+    /usr/local/lib/python3.7/dist-packages/multicorn-1.4.0.dev0-py3.7-linux-x86_64.egg
 
 COPY --from=builder_mongo_fdw /output/root /
 COPY --from=builder_mysql_fdw /output/root /
@@ -185,10 +174,6 @@ ENV POSTGRES_USER sgr
 
 COPY ./engine/etc /etc/
 COPY ./engine/init_scripts /docker-entrypoint-initdb.d/
-
-# Delete bullseye from the apt sources list -- it can break things that inherit from
-# this image (and definitely breaks postgis install).
-RUN rm /etc/apt/sources.list.d/debian-bullseye.list
 
 ENV PYTHONPATH "${PYTHONPATH}:/splitgraph"
 

--- a/engine/build_scripts/build_splitgraph.sh
+++ b/engine/build_scripts/build_splitgraph.sh
@@ -5,10 +5,10 @@ cd /splitgraph
 
 export POETRY_VERSION=1.0.5
 
-curl -sSL https://raw.githubusercontent.com/sdispater/poetry/master/get-poetry.py | python3.8
+curl -sSL https://raw.githubusercontent.com/sdispater/poetry/master/get-poetry.py | python3.7
 
 # Install globally (otherwise we'll need to find a way to get Multicorn to see the venv)
-ln -s /usr/bin/python3.8 /usr/bin/python
+ln -s /usr/bin/python3.7 /usr/bin/python
 # shellcheck disable=SC1090
 source "$HOME"/.poetry/env
 poetry config virtualenvs.create false

--- a/engine/build_scripts/fdws/multicorn/build_multicorn.sh
+++ b/engine/build_scripts/fdws/multicorn/build_multicorn.sh
@@ -6,12 +6,12 @@ cd /src/Multicorn
 # fragments rather than passing data through python.
 
 export DESTDIR=/output/root
-export PYTHON_OVERRIDE=python3.8
-export PYTHON_CONFIG=x86_64-linux-gnu-python3.8-config
+export PYTHON_OVERRIDE=python3.7
+export PYTHON_CONFIG=x86_64-linux-gnu-python3.7-config
 
 # Do "make CFLAGS=-DDEBUG install" instead to enable debug output for scans.
 # Include and dynamically link to cstore_fdw
 make \
   CPPFLAGS="-I ../cstore_fdw" \
-  SHLIB_LINK="-L/output/root/usr/local/lib -lcstore_fdw -lpython3.8" \
+  SHLIB_LINK="-L/output/root/usr/local/lib -lcstore_fdw -lpython3.7m" \
   install

--- a/examples/example_to_md.py
+++ b/examples/example_to_md.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python
+import json
+import re
+from typing import List, Dict, Any
+
+import click
+
+try:
+    import pyte
+except ImportError:
+    raise click.UsageError("pyte is required (pip install pyte)!")
+
+
+def _terminal_buffer_to_str(buffer: List[str]) -> str:
+    result = []
+    found_data = False
+
+    # Iterate from the bottom of the screen to drop empty lines
+    for line in reversed(buffer):
+        # Strip hanging spaces
+        line = re.sub(r"(\S*)\s+$", r"\1", line)
+
+        # Strip empty commands that the recorder put there
+        if line == "$":
+            line = ""
+
+        # Skip empty lines until we reach some data
+        if line:
+            found_data = True
+        if found_data or line:
+            result.append(line)
+    return "\n".join(reversed(result))
+
+
+def emit_command_output(chars, screen_width=110, screen_height=120):
+    screen = pyte.Screen(columns=screen_width, lines=screen_height)
+    stream = pyte.Stream(screen)
+    stream.feed(chars)
+    return _terminal_buffer_to_str(screen.display)
+
+
+def emit_screen(screen: Dict[str, Any], output_markdown_language="shell-session"):
+    result = ""
+    if not screen:
+        return result
+
+    comment = screen.get("comment")
+    if comment:
+        result += "\n\n" + "".join(comment) + "\n"
+
+    code_block = ""
+    for command, output in zip(screen.get("command", []), screen.get("output", [])):
+
+        if command:
+            actual_output = emit_command_output(command).strip()
+            if actual_output.startswith("$ #"):
+                continue
+            if "\\" in actual_output:
+                # Hack since prisma shell-session / bash breaks on backslashes
+                # (I tried escaping them and it breaks on 2, 4 and 8 backslashes).
+                output_markdown_language = "python"
+            code_block += actual_output + "\n"
+
+        if output:
+            actual_output = emit_command_output(output).strip()
+            if "\\" in actual_output:
+                output_markdown_language = "python"
+            code_block += actual_output + "\n"
+        code_block += "\n\n"
+
+    code_block = code_block.strip()
+    if code_block:
+        result += f"\n```{output_markdown_language}\n{code_block}\n```\n"
+
+    return result
+
+
+@click.command(name="to_markdown")
+@click.argument("file", type=click.File("r"))
+@click.argument("output", type=click.File("w"))
+def to_markdown(file, output):
+    """Convert the screen.json file produced by run_example.py --dump-screens
+    into Markdown.
+    """
+    screens = json.load(file)
+
+    for screen in screens:
+        output.write(emit_screen(screen))
+
+
+if __name__ == "__main__":
+    to_markdown()

--- a/examples/example_to_md.py
+++ b/examples/example_to_md.py
@@ -32,7 +32,7 @@ def _terminal_buffer_to_str(buffer: List[str]) -> str:
     return "\n".join(reversed(result))
 
 
-def emit_command_output(chars, screen_width=110, screen_height=120):
+def emit_command_output(chars, screen_width=120, screen_height=120):
     screen = pyte.Screen(columns=screen_width, lines=screen_height)
     stream = pyte.Stream(screen)
     stream.feed(chars)
@@ -59,12 +59,14 @@ def emit_screen(screen: Dict[str, Any], output_markdown_language="shell-session"
                 # Hack since prisma shell-session / bash breaks on backslashes
                 # (I tried escaping them and it breaks on 2, 4 and 8 backslashes).
                 output_markdown_language = "python"
+                actual_output = actual_output.replace("\\", "\\\\")
             code_block += actual_output + "\n"
 
         if output:
             actual_output = emit_command_output(output).strip()
             if "\\" in actual_output:
                 output_markdown_language = "python"
+                actual_output = actual_output.replace("\\", "\\\\")
             code_block += actual_output + "\n"
         code_block += "\n\n"
 

--- a/examples/import-from-csv/example.yaml
+++ b/examples/import-from-csv/example.yaml
@@ -5,8 +5,7 @@
   - docker-compose --project-name splitgraph_example up -d
   record: False
 - commands:
-  - "# Initialize the engine (wait for the container to start up)"
-  - sleep 5
+  - "# Initialize the engine"
   - sgr init
   record: False
 - commands:

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,5 +1,5 @@
 [mypy]
-python_version = 3.6
+python_version = 3.8
 warn_return_any = True
 warn_unused_configs = True
 
@@ -10,4 +10,6 @@ ignore_missing_imports = True
 allow_redefinition = True
 
 strict_optional = True
-
+warn_redundant_casts = True
+warn_unreachable = True
+warn_unused_ignores = True

--- a/splitgraph/commandline/cloud.py
+++ b/splitgraph/commandline/cloud.py
@@ -327,7 +327,7 @@ def description_c(remote, repository, description):
 @click.command("metadata")
 @click.option("--remote", default="data.splitgraph.com", help="Name of the remote registry to use.")
 @click.argument("repository", type=RepositoryType(exists=False))
-@click.argument("metadata_file", type=click.File("r"))
+@click.argument("metadata_file", type=click.File("r"), default="splitgraph.yml")
 @click.pass_context
 def metadata_c(ctx, remote, repository, metadata_file):
     """Upload a metadata file to a Splitgraph repository.

--- a/splitgraph/commandline/image_info.py
+++ b/splitgraph/commandline/image_info.py
@@ -175,7 +175,7 @@ def _get_actual_hashes(
         # One parameter: diff from that and its parent.
         image_2 = image_1_obj.parent_id
         if image_2 is None:
-            click.echo("%s has no parent to compare to!" % image_1)
+            raise ValueError("%s has no parent to compare to!" % image_1)
         image_1, image_2 = image_2, image_1  # snap_1 has to come first
     else:
         assert image_1 is not None

--- a/splitgraph/config/export.py
+++ b/splitgraph/config/export.py
@@ -62,14 +62,10 @@ def serialize_config(
     for remote, remote_config in get_all_in_section(config, "remotes").items():
         assert isinstance(remote_config, dict)
         if config_format:
-            result += (
-                "\n"
-                + serialize_engine_config(remote, cast(Dict[str, str], remote_config), no_shielding)
-                + "\n"
-            )
+            result += "\n" + serialize_engine_config(remote, remote_config, no_shielding) + "\n"
         else:
             result += "\n%s:\n" % remote
-            for key, value in cast(Dict[str, str], remote_config).items():
+            for key, value in remote_config.items():
                 result += _kv_to_str(key, value, no_shielding) + "\n"
 
     # Print Splitfile commands

--- a/splitgraph/core/image.py
+++ b/splitgraph/core/image.py
@@ -47,7 +47,7 @@ class Image(NamedTuple):
     """
 
     image_hash: str
-    parent_id: str
+    parent_id: Optional[str]
     created: datetime
     comment: str
     provenance_data: List[ProvenanceLine]
@@ -66,7 +66,7 @@ class Image(NamedTuple):
             return NotImplemented
         return self.image_hash == other.image_hash and self.repository == other.repository
 
-    def get_parent_children(self) -> Tuple[str, List[Any]]:
+    def get_parent_children(self) -> Tuple[Optional[str], List[str]]:
         """Gets the parent and a list of children of a given image."""
         parent = self.parent_id
 

--- a/splitgraph/core/image_manager.py
+++ b/splitgraph/core/image_manager.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import Any, List, Optional, Set, TYPE_CHECKING, Sequence
+from typing import Any, List, Optional, Set, TYPE_CHECKING, Sequence, cast
 
 from psycopg2.extras import Json
 from psycopg2.sql import SQL, Identifier
@@ -152,7 +152,9 @@ class ImageManager:
         result_size = len(result)
         while True:
             # Keep expanding the set of parents until it stops growing
-            result.update({parent[image] for image in result if parent[image] is not None})
+            result.update(
+                {cast(str, parent[image]) for image in result if parent[image] is not None}
+            )
             if len(result) == result_size:
                 return result
             result_size = len(result)

--- a/splitgraph/core/indexing/bloom.py
+++ b/splitgraph/core/indexing/bloom.py
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
     from splitgraph.engine.postgres.engine import PsycopgEngine
 
 
-def _hash_value(value: Union[datetime, int, str]) -> Tuple[bytes, bytes]:
+def _hash_value(value: Union[datetime, int, str, None]) -> Tuple[bytes, bytes]:
     if value is None:
         # See explanation in generate_bloom_index for why this isn't
         # a completely terrible idea.

--- a/splitgraph/core/object_manager.py
+++ b/splitgraph/core/object_manager.py
@@ -489,7 +489,7 @@ class ObjectManager(FragmentManager):
             ).format(Identifier(SPLITGRAPH_META_SCHEMA))
             + SQL(",".join(itertools.repeat("%s", len(objects))))
             + SQL(") RETURNING object_id"),
-            cast(List[Any], [now]) + objects,
+            [now] + objects,  # type: ignore
             return_shape=ResultShape.MANY_ONE,
         )
         claimed = claimed or []
@@ -521,7 +521,7 @@ class ObjectManager(FragmentManager):
                     + ",".join(itertools.repeat("%s", len(objects)))
                     + ")"
                 ).format(Identifier(SPLITGRAPH_META_SCHEMA)),
-                cast(List[Any], [is_ready]) + list(objects),
+                [is_ready] + list(objects),  # type: ignore
             )
 
     def _release_objects(self, objects: List[str]) -> None:

--- a/splitgraph/core/repository.py
+++ b/splitgraph/core/repository.py
@@ -102,7 +102,7 @@ class Repository:
         cls,
         template: "Repository",
         namespace: Optional[str] = None,
-        repository: None = None,
+        repository: Optional[str] = None,
         engine: Optional[PostgresEngine] = None,
         object_engine: Optional[PostgresEngine] = None,
     ) -> "Repository":

--- a/splitgraph/hooks/mount_handlers.py
+++ b/splitgraph/hooks/mount_handlers.py
@@ -278,9 +278,8 @@ def mount(
 
 def _register_default_handlers() -> None:
     # Register the mount handlers from the config.
-    for handler_name, handler_func_name_unk in get_all_in_section(CONFIG, "mount_handlers").items():
-        assert isinstance(handler_func_name_unk, str)
-        handler_func_name: str = cast(str, handler_func_name_unk)
+    for handler_name, handler_func_name in get_all_in_section(CONFIG, "mount_handlers").items():
+        assert isinstance(handler_func_name, str)
 
         ix = handler_func_name.rindex(".")
         try:

--- a/test/splitgraph/commandline/test_init.py
+++ b/test/splitgraph/commandline/test_init.py
@@ -38,7 +38,7 @@ def test_init_skip_object_handling_version_():
     schema_version, date_installed = get_installed_version(engine, SPLITGRAPH_META_SCHEMA)
 
     try:
-        engine.run_sql("DROP SCHEMA IF EXISTS audit CASCADE")
+        engine.run_sql("DROP SCHEMA IF EXISTS splitgraph_audit CASCADE")
         engine.run_sql("DROP FUNCTION IF EXISTS splitgraph_api.upload_object")
         assert not engine.schema_exists("audit")
         result = runner.invoke(init_c, ["--skip-object-handling"])

--- a/test/splitgraph/commandline/test_init.py
+++ b/test/splitgraph/commandline/test_init.py
@@ -63,7 +63,7 @@ def test_init_skip_object_handling_version_():
         assert schema_version == schema_version_new
         assert date_installed == date_installed_new
 
-        assert engine.schema_exists("audit")
+        assert engine.schema_exists("splitgraph_audit")
         assert (
             engine.run_sql(
                 "SELECT COUNT(*) FROM information_schema.routines "

--- a/test/splitgraph/test_engine.py
+++ b/test/splitgraph/test_engine.py
@@ -140,7 +140,7 @@ def test_uninitialized_engine_error(local_engine_empty):
         local_engine_empty.initialize()
         local_engine_empty.commit()
 
-        local_engine_empty.run_sql("DROP SCHEMA audit CASCADE")
+        local_engine_empty.run_sql("DROP SCHEMA splitgraph_audit CASCADE")
         with pytest.raises(EngineInitializationError) as e:
             local_engine_empty.discard_pending_changes("some/repo")
         assert "Audit triggers" in str(e.value)


### PR DESCRIPTION
* Add ability to record commands and output stream separately to `run_example.py` (pass --dump-screens) and use the dump to create a Markdown file with an "unfolded" cast (`example_to_md.py`)
* Stricter mypy checks
* rename `audit` to `splitgraph_audit`
* downgrade python in-engine to 3.7