### PR TITLE
Support for Socrata mounts

### DIFF
--- a/.github/workflows/build_and_test_and_release.yml
+++ b/.github/workflows/build_and_test_and_release.yml
@@ -37,7 +37,10 @@ jobs:
       - name: "Save Docker cache"
         run: |
           mkdir -p ~/docker_images
+          docker images
           docker save -o ~/docker_images/engine.tar $DOCKER_REPO/$DOCKER_ENGINE_IMAGE:$DOCKER_TAG
+          echo "Saved engine $DOCKER_REPO/$DOCKER_ENGINE_IMAGE:$DOCKER_TAG to cache"
+          ls -lah ~/docker_images
       - name: "Start the test Compose stack"
         if: "!contains(github.event.head_commit.message, '[skip test]')"
         run: ./.ci/up_architecture.sh

--- a/docs/generate_reference.py
+++ b/docs/generate_reference.py
@@ -164,7 +164,7 @@ def _emit_command(command_name):
 
 
 def _slug_section(section):
-    return section.lower().replace(" ", "_").replace("/", "_")
+    return section.lower().replace(" ", "-").replace("/", "-")
 
 
 @click.command(name="sgr")

--- a/poetry.lock
+++ b/poetry.lock
@@ -111,6 +111,14 @@ version = "1.0.0"
 
 [[package]]
 category = "main"
+description = "A decorator for caching properties in classes."
+name = "cached-property"
+optional = false
+python-versions = "*"
+version = "1.5.1"
+
+[[package]]
+category = "main"
 description = "Python package for providing Mozilla's CA Bundle."
 name = "certifi"
 optional = false
@@ -275,7 +283,7 @@ description = "File identification library for Python"
 name = "identify"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,>=2.7"
-version = "1.4.15"
+version = "1.4.17"
 
 [package.extras]
 license = ["editdistance"]
@@ -439,7 +447,7 @@ description = "More routines for operating on iterables, beyond itertools"
 name = "more-itertools"
 optional = false
 python-versions = ">=3.5"
-version = "8.2.0"
+version = "8.3.0"
 
 [[package]]
 category = "dev"
@@ -487,7 +495,7 @@ description = "Core utilities for Python packages"
 name = "packaging"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "20.3"
+version = "20.4"
 
 [package.dependencies]
 pyparsing = ">=2.0.2"
@@ -705,15 +713,15 @@ category = "dev"
 description = "Pytest plugin for measuring coverage."
 name = "pytest-cov"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "2.8.1"
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+version = "2.9.0"
 
 [package.dependencies]
 coverage = ">=4.4"
 pytest = ">=3.6"
 
 [package.extras]
-testing = ["fields", "hunter", "process-tests (2.0.2)", "six", "virtualenv"]
+testing = ["fields", "hunter", "process-tests (2.0.2)", "six", "pytest-xdist", "virtualenv"]
 
 [[package]]
 category = "dev"
@@ -805,7 +813,7 @@ description = "Python 2 and 3 compatibility utilities"
 name = "six"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
-version = "1.14.0"
+version = "1.15.0"
 
 [[package]]
 category = "dev"
@@ -816,12 +824,23 @@ python-versions = "*"
 version = "2.0.0"
 
 [[package]]
+category = "main"
+description = "Python library for the Socrata Open Data API"
+name = "sodapy"
+optional = false
+python-versions = "*"
+version = "2.1.0"
+
+[package.dependencies]
+requests = ">=2.20.0"
+
+[[package]]
 category = "dev"
 description = "Python documentation generator"
 name = "sphinx"
 optional = false
 python-versions = ">=3.5"
-version = "3.0.3"
+version = "3.0.4"
 
 [package.dependencies]
 Jinja2 = ">=2.3"
@@ -955,9 +974,10 @@ description = "A utility library for working with Table Schema in Python"
 name = "tableschema"
 optional = false
 python-versions = "*"
-version = "1.17.0"
+version = "1.18.0"
 
 [package.dependencies]
+cached-property = ">=1.5"
 click = ">=3.3"
 isodate = ">=0.5.4"
 jsonschema = ">=2.5"
@@ -1071,7 +1091,7 @@ description = "Virtual Python Environment builder"
 name = "virtualenv"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,>=2.7"
-version = "20.0.20"
+version = "20.0.21"
 
 [package.dependencies]
 appdirs = ">=1.4.3,<2"
@@ -1135,7 +1155,7 @@ testing = ["jaraco.itertools", "func-timeout"]
 pandas = ["pandas", "sqlalchemy"]
 
 [metadata]
-content-hash = "8b28c1ae2157093511a81f96155cde78326eb6719f12f7514a3a14c720096c0a"
+content-hash = "77873dc70168cd00cb7bf802915a5fb5be68ee0b91c8e3263140fecac0e5c3f5"
 python-versions = "~=3.6"
 
 [metadata.files]
@@ -1177,6 +1197,10 @@ black = [
 bump2version = [
     {file = "bump2version-1.0.0-py2.py3-none-any.whl", hash = "sha256:477f0e18a0d58e50bb3dbc9af7fcda464fd0ebfc7a6151d8888602d7153171a0"},
     {file = "bump2version-1.0.0.tar.gz", hash = "sha256:cd4f3a231305e405ed8944d8ff35bd742d9bc740ad62f483bd0ca21ce7131984"},
+]
+cached-property = [
+    {file = "cached-property-1.5.1.tar.gz", hash = "sha256:9217a59f14a5682da7c4b8829deadbfc194ac22e9908ccf7c8820234e80a1504"},
+    {file = "cached_property-1.5.1-py2.py3-none-any.whl", hash = "sha256:3a026f1a54135677e7da5ce819b0c690f156f37976f3e30c5430740725203d7f"},
 ]
 certifi = [
     {file = "certifi-2020.4.5.1-py2.py3-none-any.whl", hash = "sha256:1d987a998c75633c40847cc966fcf5904906c920a7f17ef374f5aa4282abd304"},
@@ -1270,8 +1294,8 @@ httpretty = [
     {file = "httpretty-1.0.2.tar.gz", hash = "sha256:24a6fd2fe1c76e94801b74db8f52c0fb42718dc4a199a861b305b1a492b9d868"},
 ]
 identify = [
-    {file = "identify-1.4.15-py2.py3-none-any.whl", hash = "sha256:88ed90632023e52a6495749c6732e61e08ec9f4f04e95484a5c37b9caf40283c"},
-    {file = "identify-1.4.15.tar.gz", hash = "sha256:23c18d97bb50e05be1a54917ee45cc61d57cb96aedc06aabb2b02331edf0dbf0"},
+    {file = "identify-1.4.17-py2.py3-none-any.whl", hash = "sha256:ef6fa3d125c27516f8d1aaa2038c3263d741e8723825eb38350cdc0288ab35eb"},
+    {file = "identify-1.4.17.tar.gz", hash = "sha256:be66b9673d59336acd18a3a0e0c10d35b8a780309561edf16c46b6b74b83f6af"},
 ]
 idna = [
     {file = "idna-2.9-py2.py3-none-any.whl", hash = "sha256:a068a21ceac8a4d63dbfd964670474107f541babbd2250d61922f029858365fa"},
@@ -1373,8 +1397,8 @@ minio = [
     {file = "minio-5.0.10.tar.gz", hash = "sha256:6ecb7637a35f806733e9d112eacfa599a58d7c3d4698fda2b5c86fff5d34b417"},
 ]
 more-itertools = [
-    {file = "more-itertools-8.2.0.tar.gz", hash = "sha256:b1ddb932186d8a6ac451e1d95844b382f55e12686d51ca0c68b6f61f2ab7a507"},
-    {file = "more_itertools-8.2.0-py3-none-any.whl", hash = "sha256:5dd8bcf33e5f9513ffa06d5ad33d78f31e1931ac9a18f33d37e77a180d393a7c"},
+    {file = "more-itertools-8.3.0.tar.gz", hash = "sha256:558bb897a2232f5e4f8e2399089e35aecb746e1f9191b6584a151647e89267be"},
+    {file = "more_itertools-8.3.0-py3-none-any.whl", hash = "sha256:7818f596b1e87be009031c7653d01acc46ed422e6656b394b0f765ce66ed4982"},
 ]
 mypy = [
     {file = "mypy-0.770-cp35-cp35m-macosx_10_6_x86_64.whl", hash = "sha256:a34b577cdf6313bf24755f7a0e3f3c326d5c1f4fe7422d1d06498eb25ad0c600"},
@@ -1423,8 +1447,8 @@ numpy = [
     {file = "numpy-1.18.4.zip", hash = "sha256:bbcc85aaf4cd84ba057decaead058f43191cc0e30d6bc5d44fe336dc3d3f4509"},
 ]
 packaging = [
-    {file = "packaging-20.3-py2.py3-none-any.whl", hash = "sha256:82f77b9bee21c1bafbf35a84905d604d5d1223801d639cf3ed140bd651c08752"},
-    {file = "packaging-20.3.tar.gz", hash = "sha256:3c292b474fda1671ec57d46d739d072bfd495a4f51ad01a055121d81e952b7a3"},
+    {file = "packaging-20.4-py2.py3-none-any.whl", hash = "sha256:998416ba6962ae7fbd6596850b80e17859a5753ba17c32284f67bfff33784181"},
+    {file = "packaging-20.4.tar.gz", hash = "sha256:4357f74f47b9c12db93624a82154e9b120fa8293699949152b22065d556079f8"},
 ]
 pandas = [
     {file = "pandas-0.25.3-cp35-cp35m-macosx_10_6_intel.whl", hash = "sha256:df8864824b1fe488cf778c3650ee59c3a0d8f42e53707de167ba6b4f7d35f133"},
@@ -1548,8 +1572,8 @@ pytest = [
     {file = "pytest-5.4.2.tar.gz", hash = "sha256:eb2b5e935f6a019317e455b6da83dd8650ac9ffd2ee73a7b657a30873d67a698"},
 ]
 pytest-cov = [
-    {file = "pytest-cov-2.8.1.tar.gz", hash = "sha256:cc6742d8bac45070217169f5f72ceee1e0e55b0221f54bcf24845972d3a47f2b"},
-    {file = "pytest_cov-2.8.1-py2.py3-none-any.whl", hash = "sha256:cdbdef4f870408ebdbfeb44e63e07eb18bb4619fae852f6e760645fa36172626"},
+    {file = "pytest-cov-2.9.0.tar.gz", hash = "sha256:b6a814b8ed6247bd81ff47f038511b57fe1ce7f4cc25b9106f1a4b106f1d9322"},
+    {file = "pytest_cov-2.9.0-py2.py3-none-any.whl", hash = "sha256:c87dfd8465d865655a8213859f1b4749b43448b5fae465cb981e16d52a811424"},
 ]
 pytest-env = [
     {file = "pytest-env-0.6.2.tar.gz", hash = "sha256:7e94956aef7f2764f3c147d216ce066bf6c42948bb9e293169b1b1c880a580c2"},
@@ -1621,16 +1645,20 @@ rfc3986 = [
     {file = "rfc3986-1.4.0.tar.gz", hash = "sha256:112398da31a3344dc25dbf477d8df6cb34f9278a94fee2625d89e4514be8bb9d"},
 ]
 six = [
-    {file = "six-1.14.0-py2.py3-none-any.whl", hash = "sha256:8f3cd2e254d8f793e7f3d6d9df77b92252b52637291d0f0da013c76ea2724b6c"},
-    {file = "six-1.14.0.tar.gz", hash = "sha256:236bdbdce46e6e6a3d61a337c0f8b763ca1e8717c03b369e87a7ec7ce1319c0a"},
+    {file = "six-1.15.0-py2.py3-none-any.whl", hash = "sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced"},
+    {file = "six-1.15.0.tar.gz", hash = "sha256:30639c035cdb23534cd4aa2dd52c3bf48f06e5f4a941509c8bafd8ce11080259"},
 ]
 snowballstemmer = [
     {file = "snowballstemmer-2.0.0-py2.py3-none-any.whl", hash = "sha256:209f257d7533fdb3cb73bdbd24f436239ca3b2fa67d56f6ff88e86be08cc5ef0"},
     {file = "snowballstemmer-2.0.0.tar.gz", hash = "sha256:df3bac3df4c2c01363f3dd2cfa78cce2840a79b9f1c2d2de9ce8d31683992f52"},
 ]
+sodapy = [
+    {file = "sodapy-2.1.0-py2.py3-none-any.whl", hash = "sha256:c1d30f01eab50014c356b4e315368a3beb914b2c4fb78af48edc5721866a7f26"},
+    {file = "sodapy-2.1.0.tar.gz", hash = "sha256:44e701efc16600d2b3b24b56b6e1d3a0e55567909b9ac84af8f9d1eb4870dc0f"},
+]
 sphinx = [
-    {file = "Sphinx-3.0.3-py3-none-any.whl", hash = "sha256:f5505d74cf9592f3b997380f9bdb2d2d0320ed74dd69691e3ee0644b956b8d83"},
-    {file = "Sphinx-3.0.3.tar.gz", hash = "sha256:62edfd92d955b868d6c124c0942eba966d54b5f3dcb4ded39e65f74abac3f572"},
+    {file = "Sphinx-3.0.4-py3-none-any.whl", hash = "sha256:779a519adbd3a70fc7c468af08c5e74829868b0a5b34587b33340e010291856c"},
+    {file = "Sphinx-3.0.4.tar.gz", hash = "sha256:ea64df287958ee5aac46be7ac2b7277305b0381d213728c3a49d8bb9b8415807"},
 ]
 sphinx-rtd-theme = [
     {file = "sphinx_rtd_theme-0.4.3-py2.py3-none-any.whl", hash = "sha256:00cf895504a7895ee433807c62094cf1e95f065843bf3acd17037c3e9a2becd4"},
@@ -1691,8 +1719,8 @@ sqlalchemy = [
     {file = "SQLAlchemy-1.3.17.tar.gz", hash = "sha256:156a27548ba4e1fed944ff9fcdc150633e61d350d673ae7baaf6c25c04ac1f71"},
 ]
 tableschema = [
-    {file = "tableschema-1.17.0-py2.py3-none-any.whl", hash = "sha256:55ace13cb8a93640c5e65d627cd092bc56b66b8accb97f8ae1ccb5602de51929"},
-    {file = "tableschema-1.17.0.tar.gz", hash = "sha256:d162fcad8682cf79dc8a7bc47378df9b8d5228486242c33c8fd03d3a5c711a69"},
+    {file = "tableschema-1.18.0-py2.py3-none-any.whl", hash = "sha256:81da12169e2a342d30a58b59a003195a8859dd720f882221f3d1b0895083c87e"},
+    {file = "tableschema-1.18.0.tar.gz", hash = "sha256:cdbb7dddec4ee39ad46fbaa3117ec2e75374b2b8c154c99d37e7d6f533669045"},
 ]
 tabulate = [
     {file = "tabulate-0.8.7-py3-none-any.whl", hash = "sha256:ac64cb76d53b1231d364babcd72abbb16855adac7de6665122f97b593f1eb2ba"},
@@ -1743,8 +1771,8 @@ urllib3 = [
     {file = "urllib3-1.25.9.tar.gz", hash = "sha256:3018294ebefce6572a474f0604c2021e33b3fd8006ecd11d62107a5d2a963527"},
 ]
 virtualenv = [
-    {file = "virtualenv-20.0.20-py2.py3-none-any.whl", hash = "sha256:b4c14d4d73a0c23db267095383c4276ef60e161f94fde0427f2f21a0132dde74"},
-    {file = "virtualenv-20.0.20.tar.gz", hash = "sha256:fd0e54dec8ac96c1c7c87daba85f0a59a7c37fe38748e154306ca21c73244637"},
+    {file = "virtualenv-20.0.21-py2.py3-none-any.whl", hash = "sha256:a730548b27366c5e6cbdf6f97406d861cccece2e22275e8e1a757aeff5e00c70"},
+    {file = "virtualenv-20.0.21.tar.gz", hash = "sha256:a116629d4e7f4d03433b8afa27f43deba09d48bc48f5ecefa4f015a178efb6cf"},
 ]
 wcwidth = [
     {file = "wcwidth-0.1.9-py2.py3-none-any.whl", hash = "sha256:cafe2186b3c009a04067022ce1dcd79cb38d8d65ee4f4791b8888d6599d1bbe1"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,15 +20,19 @@ docker = ">=4.0"
 click_log = "^0.3.2"
 tqdm = "^4.46.0"
 packaging = "^20.1"
+tabulate = "^0.8.7"
+asciitree = "^0.3.3"
+
+# Socrata dataset mounting.
+# This could be optional but it's very lightweight (only requires requests).
+sodapy = ">=2.1"
+
 # Required for CSV ingestion and type inference
 tableschema = "^1.15.0"
 # Pin tabulator (depended on by tableschema) to our fork that doesn't
 # include S3/SQLAlchemy deps (we only use schema inference for CSVs and
 # these libraries add ~40MB to the total install size).
 tabulator = { git = "https://github.com/splitgraph/tabulator-py.git" }
-
-tabulate = "^0.8.7"
-asciitree = "^0.3.3"
 
 # Extra requirements for Pandas ingestion
 pandas = {version = ">=0.24", extras = ["ingestion"], optional = true }

--- a/splitgraph.spec
+++ b/splitgraph.spec
@@ -8,7 +8,8 @@ block_cipher = None
 
 a = Analysis(['bin/sgr'],
              pathex=['.'],
-             hiddenimports=["splitgraph.hooks.s3", "splitgraph.hooks.splitfile_commands"],
+             hiddenimports=["splitgraph.hooks.s3", "splitgraph.hooks.splitfile_commands",
+             "splitgraph.ingestion.socrata.mount", "splitgraph.ingestion.socrata.querying"],
              hookspath=[],
              # Linux build on Travis pulls in numpy for no obvious reason
              excludes=['numpy'],

--- a/splitgraph/commandline/image_creation.py
+++ b/splitgraph/commandline/image_creation.py
@@ -8,6 +8,7 @@ from collections import defaultdict
 import click
 
 from splitgraph.commandline.common import ImageType, RepositoryType, JsonType, remote_switch_option
+from splitgraph.config import get_singleton, CONFIG
 from splitgraph.exceptions import TableNotFoundError
 
 
@@ -72,9 +73,10 @@ def checkout_c(image_spec, force, uncheckout, layered):
 @click.option(
     "-c",
     "--chunk-size",
-    default=10000,
+    default=int(get_singleton(CONFIG, "SG_COMMIT_CHUNK_SIZE")),
     type=int,
-    help="Split new tables into chunks of this many rows (by primary key).",
+    help="Split new tables into chunks of this many rows (by primary key). The default "
+    "value is governed by the SG_COMMIT_CHUNK_SIZE configuration parameter.",
 )
 @click.option(
     "-k",

--- a/splitgraph/commandline/mount.py
+++ b/splitgraph/commandline/mount.py
@@ -90,19 +90,22 @@ def _make_mount_handler_command(handler_name: str) -> Command:
     ]
 
     def _callback(schema, connection, handler_options):
-        match = re.match(r"(\S+):(\S+)@(.+):(\d+)", connection)
-        # In the future, we could turn all of these options into actual Click options,
-        # but then we'd also have to parse the docstring deeper to find out the types the function
-        # requires, how to serialize them etc etc. Idea for a click-contrib addon perhaps?
         handler_options = json.loads(handler_options)
-        handler_options.update(
-            dict(
-                server=match.group(3),
-                port=int(match.group(4)),
-                username=match.group(1),
-                password=match.group(2),
+        if connection:
+            match = re.match(r"(\S+):(\S+)@(.+):(\d+)", connection)
+            # In the future, we could turn all of these options into actual Click options,
+            # but then we'd also have to parse the docstring deeper to find out the types the function
+            # requires, how to serialize them etc etc. Idea for a click-contrib addon perhaps?
+            handler_options.update(
+                dict(
+                    server=match.group(3),
+                    port=int(match.group(4)),
+                    username=match.group(1),
+                    password=match.group(2),
+                )
             )
-        )
+        else:
+            handler_options.update(dict(server=None, port=None, username=None, password=None,))
         mount(schema, mount_handler=handler_name, handler_kwargs=handler_options)
 
     cmd = click.Command(handler_name, params=params, callback=_callback, help=help_text)

--- a/splitgraph/commandline/mount.py
+++ b/splitgraph/commandline/mount.py
@@ -88,24 +88,11 @@ def _make_mount_handler_command(handler_name: str) -> Command:
         ),
         click.Option(["--handler-options", "-o"], help=handler_options_help, default="{}"),
     ]
+    from splitgraph.core.common import conn_string_to_dict
 
     def _callback(schema, connection, handler_options):
         handler_options = json.loads(handler_options)
-        if connection:
-            match = re.match(r"(\S+):(\S+)@(.+):(\d+)", connection)
-            # In the future, we could turn all of these options into actual Click options,
-            # but then we'd also have to parse the docstring deeper to find out the types the function
-            # requires, how to serialize them etc etc. Idea for a click-contrib addon perhaps?
-            handler_options.update(
-                dict(
-                    server=match.group(3),
-                    port=int(match.group(4)),
-                    username=match.group(1),
-                    password=match.group(2),
-                )
-            )
-        else:
-            handler_options.update(dict(server=None, port=None, username=None, password=None,))
+        handler_options.update(conn_string_to_dict(connection))
         mount(schema, mount_handler=handler_name, handler_kwargs=handler_options)
 
     cmd = click.Command(handler_name, params=params, callback=_callback, help=help_text)

--- a/splitgraph/config/config.py
+++ b/splitgraph/config/config.py
@@ -110,9 +110,11 @@ def create_config_dict() -> ConfigDict:
 
     # Fix certain sections to have lower case by convention
     if "mount_handlers" in config_dict:
-        config_dict["mount_handlers"] = {
-            k.lower(): v for k, v in config_dict["mount_handlers"].items()
-        }
+        handlers = config_dict["mount_handlers"]
+        assert isinstance(handlers, dict)
+        config_dict["mount_handlers"] = cast(
+            Dict[str, str], {k.lower(): v for k, v in handlers.items()}
+        )
 
     return config_dict
 

--- a/splitgraph/config/config.py
+++ b/splitgraph/config/config.py
@@ -142,9 +142,7 @@ def patch_config(config: ConfigDict, patch: ConfigDict) -> ConfigDict:
 
 def get_singleton(config: ConfigDict, item: str) -> str:
     """Return a singleton (not a section) variable from the config."""
-    result = config[item]
-    assert isinstance(result, str)
-    return result
+    return str(config[item])
 
 
 def get_all_in_section(config: ConfigDict, section: str) -> Dict[str, Union[str, Dict[str, str]]]:

--- a/splitgraph/config/config.py
+++ b/splitgraph/config/config.py
@@ -108,6 +108,12 @@ def create_config_dict() -> ConfigDict:
     config_dict = update_config_dict_from_env_vars(config_dict)
     config_dict = update_config_dict_from_arguments(config_dict)
 
+    # Fix certain sections to have lower case by convention
+    if "mount_handlers" in config_dict:
+        config_dict["mount_handlers"] = {
+            k.lower(): v for k, v in config_dict["mount_handlers"].items()
+        }
+
     return config_dict
 
 

--- a/splitgraph/config/export.py
+++ b/splitgraph/config/export.py
@@ -101,9 +101,8 @@ def overwrite_config(
     :param include_defaults: Whether to include values that are the same
         as their defaults.
     """
+    new_config_data = serialize_config(
+        new_config, config_format=True, no_shielding=True, include_defaults=include_defaults
+    )
     with open(config_path, "w") as f:
-        f.write(
-            serialize_config(
-                new_config, config_format=True, no_shielding=True, include_defaults=include_defaults
-            )
-        )
+        f.write(new_config_data)

--- a/splitgraph/config/export.py
+++ b/splitgraph/config/export.py
@@ -78,7 +78,7 @@ def serialize_config(
     if "mount_handlers" in config:
         result += "\nFDW Mount handlers:\n" if not config_format else "[mount_handlers]\n"
         for handler_name, handler_func in get_all_in_section(config, "mount_handlers").items():
-            result += _kv_to_str(handler_name, cast(str, handler_func).lower(), no_shielding) + "\n"
+            result += _kv_to_str(handler_name, cast(str, handler_func), no_shielding) + "\n"
 
     # Print external object handlers
     if "external_handlers" in config:

--- a/splitgraph/config/keys.py
+++ b/splitgraph/config/keys.py
@@ -59,7 +59,7 @@ DEFAULTS: ConfigDict = {
 }
 
 ALL_KEYS = list(DEFAULTS.keys())
-KEYS = [k for k in ALL_KEYS if k not in ["remotes", "external_handlers"]]
+KEYS = [k for k in ALL_KEYS if k not in ["remotes", "external_handlers", "mount_handlers"]]
 # Keys whose contents we don't print fully
 SENSITIVE_KEY_SUFFIXES = ["_PWD", "_TOKEN"]
 

--- a/splitgraph/config/keys.py
+++ b/splitgraph/config/keys.py
@@ -50,6 +50,12 @@ DEFAULTS: ConfigDict = {
     "SG_CMD_ASCII": "false",
     # Some default sections: these can't be overridden via envvars.
     "external_handlers": {"S3": "splitgraph.hooks.s3.S3ExternalObjectHandler"},
+    "mount_handlers": {
+        "postgres_fdw": "splitgraph.hooks.mount_handlers.mount_postgres",
+        "mongo_fdw": "splitgraph.hooks.mount_handlers.mount_mongo",
+        "mysql_fdw": "splitgraph.hooks.mount_handlers.mount_mysql",
+        "socrata": "splitgraph.ingestion.socrata.mount.mount_socrata",
+    },
 }
 
 ALL_KEYS = list(DEFAULTS.keys())

--- a/splitgraph/config/keys.py
+++ b/splitgraph/config/keys.py
@@ -29,6 +29,7 @@ DEFAULTS: ConfigDict = {
     # US election dataset build by about 30% (82s -> 56s) for the version that uses FROM IMPORT and
     # by about 50% (101s -> 53s) for the version that runs a single big join against multiple images.
     "SG_LQ_TUNING": "SET enable_sort=off; SET enable_hashagg=on;",
+    "SG_COMMIT_CHUNK_SIZE": "10000",
     "SG_ENGINE_POOL": "16",
     "SG_CONFIG_FILE": "",
     "SG_META_SCHEMA": "splitgraph_meta",
@@ -133,6 +134,7 @@ This can also be changed by passing `--verbosity` to `sgr`, e.g. `sgr --verbosit
     "SG_ENGINE_POSTGRES_DB_NAME": "Name of the default database that the superuser connects to to initialize Splitgraph.",
     "SG_ENGINE_OBJECT_PATH": "Path on the engine's filesystem where Splitgraph physical object files are stored.",
     "SG_LQ_TUNING": "Postgres query planner configuration for Splitfile execution and table imports. This is run before a layered query is executed and allows to tune query planning in case of LQ performance issues. For possible values, see the [PostgreSQL documentation](https://www.postgresql.org/docs/12/runtime-config-query.html).",
+    "SG_COMMIT_CHUNK_SIZE": "Default chunk size when `sgr commit` is run. Can be overriden in the command line client by passing `--chunk-size`",
     "SG_ENGINE_POOL": "Size of the connection pool used to download/upload objects. Note that in the case of layered querying with joins on multiple tables, each table will use this many parallel threads to download objects, which can overwhelm the engine. Decrease this value in that case.",
     "SG_CONFIG_FILE": "Location of the Splitgraph configuration file. By default, Splitgraph looks for the configuration in `~/.splitgraph/.sgconfig` and then the current directory.",
     "SG_META_SCHEMA": "Name of the metadata schema. Note that whilst this can be changed, it hasn't been tested and won't be taken into account by engines connecting to this one.",

--- a/splitgraph/core/common.py
+++ b/splitgraph/core/common.py
@@ -502,6 +502,8 @@ def parse_repo_tag_or_hash(value, default="latest"):
 def conn_string_to_dict(connection: Optional[str]) -> Dict[str, Any]:
     if connection:
         match = re.match(r"(\S+):(\S+)@(.+):(\d+)", connection)
+        if not match:
+            raise ValueError("Invalid connection string!")
         # In the future, we could turn all of these options into actual Click options,
         # but then we'd also have to parse the docstring deeper to find out the types the function
         # requires, how to serialize them etc etc. Idea for a click-contrib addon perhaps?

--- a/splitgraph/core/common.py
+++ b/splitgraph/core/common.py
@@ -497,3 +497,19 @@ def parse_repo_tag_or_hash(value, default="latest"):
 
     repo = Repository.from_schema(repo_image[0])
     return repo, tag_or_hash
+
+
+def conn_string_to_dict(connection: Optional[str]) -> Dict[str, Any]:
+    if connection:
+        match = re.match(r"(\S+):(\S+)@(.+):(\d+)", connection)
+        # In the future, we could turn all of these options into actual Click options,
+        # but then we'd also have to parse the docstring deeper to find out the types the function
+        # requires, how to serialize them etc etc. Idea for a click-contrib addon perhaps?
+        return dict(
+            server=match.group(3),
+            port=int(match.group(4)),
+            username=match.group(1),
+            password=match.group(2),
+        )
+    else:
+        return dict(server=None, port=None, username=None, password=None)

--- a/splitgraph/core/common.py
+++ b/splitgraph/core/common.py
@@ -3,6 +3,7 @@ Common internal functions used by Splitgraph commands.
 """
 import logging
 import os
+import re
 import sys
 from datetime import date, datetime, time
 from decimal import Decimal
@@ -468,6 +469,21 @@ def truncate_list(items: List[Any], max_entries: int = 10) -> str:
     return ",".join(str(i) for i in items[:max_entries]) + (
         ", ..." if len(items) > max_entries else ""
     )
+
+
+_slugify = re.compile(r"[^\sa-zA-Z0-9]")
+
+
+def slugify(text: str, max_length: int = 50) -> str:
+    text = _slugify.sub("", text.lower()).strip()
+    parts = re.split(r"\s+", text)
+    result = parts[0]
+    for p in parts[1:]:
+        new = result + "_" + p
+        if len(new) > max_length:
+            break
+        result = new
+    return result[:max_length]
 
 
 def parse_repo_tag_or_hash(value, default="latest"):

--- a/splitgraph/core/indexing/range.py
+++ b/splitgraph/core/indexing/range.py
@@ -9,36 +9,10 @@ from splitgraph.core.common import adapt, coerce_val_to_json
 from splitgraph.core.sql import select
 from splitgraph.core.types import Quals, Changeset, TableSchema
 from splitgraph.engine import ResultShape
+from splitgraph.engine.postgres.engine import PG_INDEXABLE_TYPES
 
 if TYPE_CHECKING:
     from splitgraph.engine.postgres.engine import PsycopgEngine
-
-# PG types we can run max/min on
-_PG_INDEXABLE_TYPES = [
-    "bigint",
-    "bigserial",
-    "bit",
-    "character",
-    "character varying",
-    "cidr",
-    "date",
-    "double precision",
-    "inet",
-    "integer",
-    "money",
-    "numeric",
-    "real",
-    "smallint",
-    "smallserial",
-    "serial",
-    "text",
-    "time",
-    "time without time zone",
-    "time with time zone",
-    "timestamp",
-    "timestamp without time zone",
-    "timestamp with time zone",
-]
 
 T = TypeVar("T")
 
@@ -247,12 +221,12 @@ def generate_range_index(
 
     object_pk = [c.name for c in table_schema if c.is_pk]
     if not object_pk:
-        object_pk = [c.name for c in table_schema]
+        object_pk = [c.name for c in table_schema if c.pg_type in PG_INDEXABLE_TYPES]
     column_types = {c.name: _strip_type_mod(c.pg_type) for c in table_schema}
     columns_to_index = [
         c.name
         for c in table_schema
-        if _strip_type_mod(c.pg_type) in _PG_INDEXABLE_TYPES and (c.is_pk or c.name in columns)
+        if _strip_type_mod(c.pg_type) in PG_INDEXABLE_TYPES and (c.is_pk or c.name in columns)
     ]
 
     logging.debug("Running range index on columns %s", columns_to_index)

--- a/splitgraph/core/repository.py
+++ b/splitgraph/core/repository.py
@@ -396,7 +396,7 @@ class Repository:
         image_hash: Optional[str] = None,
         comment: Optional[str] = None,
         snap_only: bool = False,
-        chunk_size: Optional[int] = 10000,
+        chunk_size: Optional[int] = None,
         split_changeset: bool = False,
         extra_indexes: Optional[Dict[str, ExtraIndexInfo]] = None,
         in_fragment_order: Optional[Dict[str, List[str]]] = None,
@@ -436,6 +436,8 @@ class Repository:
         if image_hash is None:
             # Generate a random hexadecimal hash for new images
             image_hash = "{:064x}".format(getrandbits(256))
+
+        chunk_size = chunk_size or int(get_singleton(CONFIG, "SG_COMMIT_CHUNK_SIZE"))
 
         self.images.add(head.image_hash if head else None, image_hash, comment=comment)
         self._commit(

--- a/splitgraph/core/sql/_blacklist.py
+++ b/splitgraph/core/sql/_blacklist.py
@@ -27,6 +27,7 @@ IMPORT_SQL_PERMITTED_NODES = [
     "CaseExpr",
     "CaseWhen",
     "Alias",
+    "SQLValueFunction",
 ]
 SPLITFILE_SQL_PERMITTED_NODES = IMPORT_SQL_PERMITTED_NODES + [
     "RangeVar",

--- a/splitgraph/engine/__init__.py
+++ b/splitgraph/engine/__init__.py
@@ -386,18 +386,6 @@ class SQLEngine(ABC):
         """
         raise NotImplementedError()
 
-    def get_column_names_types(self, schema: str, table_name: str) -> List[Tuple[str, str]]:
-        """Returns a list of (column, type) in a given table."""
-        return cast(
-            List[Tuple[str, str]],
-            self.run_sql(
-                """SELECT column_name, data_type FROM information_schema.columns
-                           WHERE table_schema = %s
-                           AND table_name = %s""",
-                (schema, table_name),
-            ),
-        )
-
     def get_full_table_schema(self, schema: str, table_name: str) -> "TableSchema":
         """
         Generates a list of (column ordinal, name, data type, is_pk, column comment),
@@ -504,7 +492,7 @@ class ChangeEngine(SQLEngine, ABC):
         Returns the key used to identify a row in a change (list of column name, column type).
         If the tracked table has a PK, we use that; if it doesn't, the whole row is used.
         """
-        return self.get_primary_keys(schema, table) or self.get_column_names_types(schema, table)
+        raise NotImplementedError()
 
 
 class ObjectEngine:

--- a/splitgraph/hooks/mount_handlers.py
+++ b/splitgraph/hooks/mount_handlers.py
@@ -34,8 +34,6 @@ def get_mount_handlers() -> List[str]:
 def register_mount_handler(name: str, mount_function: Callable) -> None:
     """Returns a mount function under a given name. See `get_mount_handler` for the mount handler spec."""
     global _MOUNT_HANDLERS
-    if name in _MOUNT_HANDLERS:
-        raise MountHandlerError("Cannot register a mount handler %s as it already exists!" % name)
     _MOUNT_HANDLERS[name] = mount_function
 
 

--- a/splitgraph/ingestion/socrata/fdw.py
+++ b/splitgraph/ingestion/socrata/fdw.py
@@ -13,10 +13,10 @@ from splitgraph.ingestion.socrata.querying import (
 
 try:
     from multicorn import ForeignDataWrapper, ANY
-    from multicorn.utils import log_to_postgres
 except ImportError:
-    # Multicorn not installed (OK if we're not on the engine machine).
-    pass
+    # Multicorn not installed (OK if we're not on the engine -- tests).
+    ForeignDataWrapper = object
+    ANY = object()
 
 _PG_LOGLEVEL = logging.INFO
 

--- a/splitgraph/ingestion/socrata/fdw.py
+++ b/splitgraph/ingestion/socrata/fdw.py
@@ -1,0 +1,99 @@
+"""Module imported by Multicorn on the Splitgraph engine server: a foreign data wrapper
+that communicates to Socrata datasets using sodapy."""
+import json
+import logging
+
+import splitgraph.config
+from splitgraph.ingestion.socrata.querying import (
+    estimate_socrata_rows_width,
+    quals_to_socrata,
+    cols_to_socrata,
+)
+
+try:
+    from multicorn import ForeignDataWrapper, ANY
+    from multicorn.utils import log_to_postgres
+except ImportError:
+    # Multicorn not installed (OK if we're not on the engine machine).
+    pass
+
+_PG_LOGLEVEL = logging.INFO
+
+
+def to_json(row):
+    return {k: json.dumps(v) if isinstance(v, (dict, list)) else v for k, v in row.items()}
+
+
+class SocrataForeignDataWrapper(ForeignDataWrapper):
+    def get_rel_size(self, quals, columns):
+        """
+        Method called from the planner to estimate the resulting relation
+        size for a scan.
+        It will help the planner in deciding between different types of plans,
+        according to their costs.
+        Args:
+            quals (list): A list of Qual instances describing the filters
+                applied to this scan.
+            columns (list): The list of columns that must be returned.
+        Returns:
+            A tuple of the form (expected_number_of_rows, avg_row_width (in bytes))
+        """
+        try:
+            return estimate_socrata_rows_width(columns, self.table_meta)
+        except Exception:
+            return 1000000, len(columns) * 10
+
+    def explain(self, quals, columns, sortkeys=None, verbose=False):
+        return ["Socrata query to %s" % self.endpoint, "Socrata dataset ID: %s" % self.table]
+
+    def execute(self, quals, columns, sortkeys=None):
+        """Main Multicorn entry point."""
+        query = quals_to_socrata(quals)
+        select = cols_to_socrata(columns)
+
+        result = self.client.get(dataset_identifier=self.table, where=query, select=select)
+
+        for r in result:
+            r = to_json(r)
+            logging.info("returning %s", r)
+            yield r
+
+        # yield from result
+
+    @property
+    def table_meta(self):
+        if not self._metadata:
+            self._metadata = self.client.get_metadata(dataset_identifier=self.table)
+        return self._metadata
+
+    def __init__(self, fdw_options, fdw_columns):
+        """The foreign data wrapper is initialized on the first query.
+        Args:
+            fdw_options (dict): The foreign data wrapper options. It is a dictionary
+                mapping keys from the sql "CREATE FOREIGN TABLE"
+                statement options. It is left to the implementor
+                to decide what should be put in those options, and what
+                to do with them.
+
+        """
+        # Initialize the logger that will log to the engine's stderr: log timestamp and PID.
+        from sodapy import Socrata
+
+        logging.basicConfig(
+            format="%(asctime)s [%(process)d] %(levelname)s %(message)s",
+            level=splitgraph.config.CONFIG["SG_LOGLEVEL"],
+        )
+
+        # Dict of connection parameters as well as the table, repository and image hash to query.
+        self.fdw_options = fdw_options
+
+        # The foreign datawrapper columns (name -> ColumnDefinition).
+        self.fdw_columns = fdw_columns
+
+        self.table = self.fdw_options["table"]
+        self.app_token = self.fdw_options.get("app_token")
+        self.endpoint = self.fdw_options["endpoint"]
+        self.client = Socrata(domain=self.endpoint, app_token=self.app_token)
+
+        # Cached table metadata
+        self._metadata = None

--- a/splitgraph/ingestion/socrata/fdw.py
+++ b/splitgraph/ingestion/socrata/fdw.py
@@ -44,7 +44,7 @@ class SocrataForeignDataWrapper(ForeignDataWrapper):
             return 1000000, len(columns) * 10
 
     def explain(self, quals, columns, sortkeys=None, verbose=False):
-        return ["Socrata query to %s" % self.endpoint, "Socrata dataset ID: %s" % self.table]
+        return ["Socrata query to %s" % self.domain, "Socrata dataset ID: %s" % self.table]
 
     def execute(self, quals, columns, sortkeys=None):
         """Main Multicorn entry point."""
@@ -92,8 +92,8 @@ class SocrataForeignDataWrapper(ForeignDataWrapper):
 
         self.table = self.fdw_options["table"]
         self.app_token = self.fdw_options.get("app_token")
-        self.endpoint = self.fdw_options["endpoint"]
-        self.client = Socrata(domain=self.endpoint, app_token=self.app_token)
+        self.domain = self.fdw_options["domain"]
+        self.client = Socrata(domain=self.domain, app_token=self.app_token)
 
         # Cached table metadata
         self._metadata = None

--- a/splitgraph/ingestion/socrata/mount.py
+++ b/splitgraph/ingestion/socrata/mount.py
@@ -11,7 +11,7 @@ def mount_socrata(
     port,
     username,
     password,
-    endpoint,
+    domain: str,
     tables: Optional[Dict[str, Any]] = None,
     app_token: Optional[str] = None,
 ) -> None:
@@ -21,7 +21,7 @@ def mount_socrata(
     Mounts a remote Socrata dataset and forwards queries to it
     \b
 
-    :param endpoint: Socrata endpoint, for example, https://data.albanyny.gov. Required.
+    :param domain: Socrata domain, for example, data.albanyny.gov. Required.
     :param tables: A dictionary mapping PostgreSQL table names to Socrata table IDs. For example,
         {"salaries": "xzkq-xp2w"}. If skipped, ALL tables in the Socrata endpoint will be mounted.
     :param app_token: Socrata app token. Optional.
@@ -31,15 +31,15 @@ def mount_socrata(
     from psycopg2.sql import Identifier, SQL
 
     engine = get_engine()
-    logging.info("Mounting Socrata endpoint...")
+    logging.info("Mounting Socrata domain...")
     server_id = mountpoint + "_server"
 
     options = {
         "wrapper": "splitgraph.ingestion.socrata.fdw.SocrataForeignDataWrapper",
     }
 
-    if endpoint:
-        options["endpoint"] = endpoint
+    if domain:
+        options["domain"] = domain
     if app_token:
         options["app_token"] = app_token
 
@@ -50,7 +50,7 @@ def mount_socrata(
     engine.run_sql(SQL("CREATE SCHEMA IF NOT EXISTS {}").format(Identifier(mountpoint)))
 
     logging.info("Getting Socrata metadata")
-    client = Socrata(domain=endpoint, app_token=app_token)
+    client = Socrata(domain=domain, app_token=app_token)
     sought_ids = tables.values() if tables else []
     datasets = client.datasets(ids=sought_ids, only=["dataset"])
 

--- a/splitgraph/ingestion/socrata/mount.py
+++ b/splitgraph/ingestion/socrata/mount.py
@@ -1,0 +1,104 @@
+"""Splitgraph mount handler for Socrata datasets"""
+import logging
+from typing import Optional, Dict, Any
+
+from splitgraph.hooks.mount_handlers import init_fdw
+
+
+def mount_socrata(
+    mountpoint: str,
+    server,
+    port,
+    username,
+    password,
+    endpoint,
+    tables: Optional[Dict[str, Any]] = None,
+    app_token: Optional[str] = None,
+) -> None:
+    """
+    Mount a Socrata dataset.
+
+    Mounts a remote Socrata dataset and forwards queries to it
+    \b
+
+    :param endpoint: Socrata endpoint, for example, https://data.albanyny.gov. Required.
+    :param tables: A dictionary mapping PostgreSQL table names to Socrata table IDs. For example,
+        {"salaries": "xzkq-xp2w"}. If skipped, ALL tables in the Socrata endpoint will be mounted.
+    :param app_token: Socrata app token. Optional.
+    """
+    from splitgraph.engine import get_engine
+    from sodapy import Socrata
+    from psycopg2.sql import Identifier, SQL
+
+    engine = get_engine()
+    logging.info("Mounting Socrata endpoint...")
+    server_id = mountpoint + "_server"
+
+    options = {
+        "wrapper": "splitgraph.ingestion.socrata.fdw.SocrataForeignDataWrapper",
+    }
+
+    if endpoint:
+        options["endpoint"] = endpoint
+    if app_token:
+        options["app_token"] = app_token
+
+    init_fdw(
+        engine, server_id=server_id, wrapper="multicorn", server_options=options,
+    )
+
+    engine.run_sql(SQL("CREATE SCHEMA IF NOT EXISTS {}").format(Identifier(mountpoint)))
+
+    logging.info("Getting Socrata metadata")
+    client = Socrata(domain=endpoint, app_token=app_token)
+    sought_ids = tables.values() if tables else []
+    datasets = client.datasets(ids=sought_ids, only=["dataset"])
+
+    mount_statements, mount_args = generate_socrata_mount_queries(
+        sought_ids, datasets, mountpoint, server_id, tables
+    )
+
+    engine.run_sql(SQL(";").join(mount_statements), mount_args)
+
+
+def generate_socrata_mount_queries(sought_ids, datasets, mountpoint, server_id, tables):
+    # Local imports since this module gets run from commandline entrypoint on startup.
+
+    from splitgraph.core.common import pluralise, truncate_list, slugify
+    from splitgraph.core.table import create_foreign_table
+    from splitgraph.ingestion.socrata.querying import socrata_to_sg_schema
+
+    found_ids = set(d["resource"]["id"] for d in datasets)
+    logging.info("Loaded metadata for %s", pluralise("Socrata table", len(found_ids)))
+
+    if tables:
+        missing_ids = [d for d in found_ids if d not in sought_ids]
+        if missing_ids:
+            raise ValueError(
+                "Some Socrata tables couldn't be found! Missing tables: %s"
+                % truncate_list(missing_ids)
+            )
+
+        tables_inv = {s: p for p, s in tables.items()}
+    else:
+        tables_inv = {}
+
+    mount_statements = []
+    mount_args = []
+    for dataset in datasets:
+        socrata_id = dataset["resource"]["id"]
+        table_name = tables_inv.get(socrata_id) or slugify(
+            dataset["resource"]["name"]
+        ) + "_" + socrata_id.replace("-", "_")
+        schema_spec = socrata_to_sg_schema(dataset)
+        sql, args = create_foreign_table(
+            schema=mountpoint,
+            server=server_id,
+            table_name=table_name,
+            schema_spec=schema_spec,
+            internal_table_name=socrata_id,
+        )
+        mount_statements.append(sql)
+        mount_args.extend(args)
+
+    return mount_statements, mount_args

--- a/splitgraph/ingestion/socrata/querying.py
+++ b/splitgraph/ingestion/socrata/querying.py
@@ -82,8 +82,8 @@ def _emit_col(col):
 def _emit_val(val):
     if val is None:
         return "NULL"
-    if isinstance(val, str):
-        val = val.replace("'", "''")
+    if not isinstance(val, (int, float)):
+        val = str(val).replace("'", "''")
         return f"'{val}'"
     return str(val)
 
@@ -140,7 +140,7 @@ def sortkeys_to_socrata(sortkeys):
 
     clauses = []
     for key in sortkeys:
-        if not key.nulls_first:
+        if key.nulls_first != key.is_reversed:
             raise ValueError("Unsupported SortKey %s" % str(key))
         order = "DESC" if key.is_reversed else "ASC"
         clauses.append(f"{_emit_col(key.attname)} {order}")

--- a/splitgraph/ingestion/socrata/querying.py
+++ b/splitgraph/ingestion/socrata/querying.py
@@ -1,0 +1,128 @@
+from typing import Dict, Any
+
+from splitgraph.core.types import TableSchema, TableColumn
+
+try:
+    from multicorn import ANY
+except ImportError:
+    # Don't fail the import if we're running this directly.
+    ANY = object()
+
+
+_socrata_types = {
+    "checkbox": "boolean",
+    "double": "double",
+    "floating timestamp": "timestamp without time zone",
+    "calendar date": "date",
+    "money": "money",
+    "number": "numeric",
+    "text": "text",
+    "url": "text",
+}
+
+
+def _socrata_to_pg_type(socrata_type):
+    socrata_type = socrata_type.lower()
+    if socrata_type in [
+        "line",
+        "location",
+        "multiline",
+        "multipoint",
+        "multipolygon",
+        "point",
+    ]:
+        return "json"
+    if socrata_type in _socrata_types:
+        return _socrata_types[socrata_type]
+    else:
+        return "text"
+
+
+def socrata_to_sg_schema(metadata: Dict[str, Any]) -> TableSchema:
+    try:
+        col_names = metadata["resource"]["columns_field_name"]
+        col_types = metadata["resource"]["columns_datatype"]
+    except KeyError:
+        raise ValueError("Invalid Socrata metadata!")
+
+    col_desc = metadata["resource"].get("columns_description") or [None] * len(col_names)
+
+    return [
+        TableColumn(i, n, _socrata_to_pg_type(t), False, d)
+        for i, (n, t, d) in enumerate(zip(col_names, col_types, col_desc))
+    ]
+
+
+def estimate_socrata_rows_width(columns, metadata):
+    """Estimate number of rows required for a query and each row's width
+    from the table metadata."""
+
+    # We currently don't use qualifiers for this, they get passed to Socrata
+    # directly. Socrata's metadata does contain some statistics for each column
+    # (min, max, sum, most popular values etc) that can be used to help the planner though.
+
+    contents = metadata["columns"][0]["cachedContents"]
+    cardinality = int(contents["non_null"]) + int(contents["null"])
+    column_widths = {c["fieldName"]: c["width"] for c in metadata["columns"]}
+
+    row_width = sum(column_widths[c] for c in columns)
+
+    return cardinality, row_width
+
+
+def _emit_col(col):
+    return col
+
+
+def _emit_val(val):
+    if val is None:
+        return "NULL"
+    if isinstance(val, str):
+        val = val.replace("'", "''")
+        return f"'{val}'"
+    return str(val)
+
+
+def _convert_op(op):
+    if op in ["=", ">", ">=", "<", "<=", "<>", "!="]:
+        return op
+    if op == "~~":
+        return "LIKE"
+    return None
+
+
+def _base_qual_to_socrata(col, op, value):
+    soql_op = _convert_op(op)
+    if not soql_op:
+        return "TRUE"
+    else:
+        return f"{_emit_col(col)} {soql_op} {_emit_val(value)}"
+
+
+def _qual_to_socrata(qual):
+    if qual.is_list_operator:
+        if qual.list_any_or_all == ANY:
+            # Convert col op ANY([a,b,c])
+            if qual.operator[0] == "=":
+                return f"{_emit_col(qual.field_name)} IN (" + ",".join(
+                    f"{_emit_val(v)}" for v in qual.value
+                )
+            else:
+                return "TRUE"
+        else:
+            # Convert col op ALL(ARRAY[a,b,c...]) into (cop op a) AND (col op b)...
+            return " AND ".join(
+                f"({_base_qual_to_socrata(qual.field_name, qual.operator[0], v)})"
+                for v in qual.value
+            )
+    else:
+        return f"{_base_qual_to_socrata(qual.field_name, qual.operator[0], qual.value)}"
+
+
+def quals_to_socrata(quals):
+    """Convert a list of Multicorn quals to a SoQL query"""
+    return " AND ".join(f"({_qual_to_socrata(q)})" for q in quals)
+
+
+def cols_to_socrata(cols):
+    return ",".join(f"{_emit_col(c)}" for c in cols)

--- a/splitgraph/ingestion/socrata/querying.py
+++ b/splitgraph/ingestion/socrata/querying.py
@@ -107,19 +107,15 @@ def _base_qual_to_socrata(col, op, value):
 def _qual_to_socrata(qual):
     if qual.is_list_operator:
         if qual.list_any_or_all == ANY:
-            # Convert col op ANY([a,b,c])
-            if qual.operator[0] == "=":
-                return f"{_emit_col(qual.field_name)} IN (" + ",".join(
-                    f"{_emit_val(v)}" for v in qual.value
-                )
-            else:
-                return "TRUE"
-        else:
-            # Convert col op ALL(ARRAY[a,b,c...]) into (cop op a) AND (col op b)...
-            return " AND ".join(
+            # Convert col op ANY([a,b,c]) into (cop op a) OR (col op b)...
+            return " OR ".join(
                 f"({_base_qual_to_socrata(qual.field_name, qual.operator[0], v)})"
                 for v in qual.value
             )
+        # Convert col op ALL(ARRAY[a,b,c...]) into (cop op a) AND (col op b)...
+        return " AND ".join(
+            f"({_base_qual_to_socrata(qual.field_name, qual.operator[0], v)})" for v in qual.value
+        )
     else:
         return f"{_base_qual_to_socrata(qual.field_name, qual.operator[0], qual.value)}"
 

--- a/splitgraph/ingestion/socrata/querying.py
+++ b/splitgraph/ingestion/socrata/querying.py
@@ -68,7 +68,7 @@ def estimate_socrata_rows_width(columns, metadata):
 
     contents = metadata["columns"][0]["cachedContents"]
     cardinality = int(contents["non_null"]) + int(contents["null"])
-    column_widths = {c["fieldName"]: c["width"] for c in metadata["columns"]}
+    column_widths = {c["fieldName"]: c.get("width", 100) for c in metadata["columns"]}
 
     row_width = sum(column_widths[c] for c in columns)
 

--- a/splitgraph/splitfile/_parsing.py
+++ b/splitgraph/splitfile/_parsing.py
@@ -56,7 +56,7 @@ SPLITFILE_GRAMMAR = Grammar(
     # Yeah, six slashes should be about enough to capture \'
     non_single_quote = ~"(\\\\\\'|[^'])*"
 
-    no_db_conn_string = ~"(\S+):(\S+)@(.+):(\d+)"
+    no_db_conn_string = ~"((\S+):(\S+)@(.+):(\d+))?"
     identifier = ~"[_a-zA-Z0-9-]+"
     space = ~"\s*"
     space_nn = ~"[ \t]*"

--- a/splitgraph/splitfile/execution.py
+++ b/splitgraph/splitfile/execution.py
@@ -30,7 +30,7 @@ from ._parsing import (
     extract_all_table_aliases,
     parse_custom_command,
 )
-from ..core.common import pluralise, truncate_line
+from ..core.common import pluralise, truncate_line, conn_string_to_dict
 from ..core.types import ProvenanceLine
 
 
@@ -359,14 +359,7 @@ def _execute_db_import(
     tmp_mountpoint.delete()
     try:
         handler_kwargs = json.loads(fdw_params)
-        handler_kwargs.update(
-            dict(
-                server=conn_string.group(3),
-                port=int(conn_string.group(4)),
-                username=conn_string.group(1),
-                password=conn_string.group(2),
-            )
-        )
+        handler_kwargs.update(conn_string_to_dict(conn_string.group() if conn_string else None))
         mount_handler(tmp_mountpoint.to_schema(), **handler_kwargs)
         # The foreign database is a moving target, so the new image hash is random.
         # Maybe in the future, when the object hash is a function of its contents, we can be smarter here...

--- a/test/resources/.sgconfig
+++ b/test/resources/.sgconfig
@@ -69,10 +69,5 @@ BOBBYTABLES=test.splitgraph.splitfile.test_custom_commands.CalcHashTestCommand
 BROKEN1=some.module.that.definitely.doesnt.Exist
 BROKEN2=test.splitgraph.splitfile.test_custom_commands.NonexistentCommand
 
-[mount_handlers]
-postgres_fdw=splitgraph.hooks.mount_handlers.mount_postgres
-mongo_fdw=splitgraph.hooks.mount_handlers.mount_mongo
-mysql_fdw=splitgraph.hooks.mount_handlers.mount_mysql
-
 [external_handlers]
 S3=splitgraph.hooks.s3.S3ExternalObjectHandler

--- a/test/resources/ingestion/socrata/dataset_metadata.json
+++ b/test/resources/ingestion/socrata/dataset_metadata.json
@@ -1,0 +1,807 @@
+{
+  "id": "xzkq-xp2w",
+  "name": "Current Employee Names, Salaries, and Position Titles",
+  "attribution": "City of Chicago",
+  "attributionLink": "http://www.chicago.gov",
+  "averageRating": 0,
+  "category": "Administration & Finance",
+  "createdAt": 1317154735,
+  "description": "This dataset is a listing of all current City of Chicago employees, complete with full names, departments, positions, employment status (part-time or full-time), frequency of hourly employee \u2013where applicable\u2014and annual salaries or hourly rate. For hourly employees, the City is providing the hourly rate and frequency of hourly employees (40, 35, 20 and 10) to allow dataset users to estimate annual wages for hourly employees. Please note that annual wages will vary by employee, depending on number of hours worked and seasonal status. For information on the positions and related salaries detailed in the annual budgets, see https://www.cityofchicago.org/city/en/depts/obm.html",
+  "displayType": "table",
+  "downloadCount": 14062287,
+  "hideFromCatalog": false,
+  "hideFromDataJson": false,
+  "indexUpdatedAt": 1517348530,
+  "licenseId": "SEE_TERMS_OF_USE",
+  "newBackend": true,
+  "numberOfComments": 0,
+  "oid": 27885816,
+  "provenance": "official",
+  "publicationAppendEnabled": false,
+  "publicationDate": 1517334321,
+  "publicationGroup": 241512,
+  "publicationStage": "published",
+  "rowsUpdatedAt": 1580512908,
+  "rowsUpdatedBy": "vewm-vupz",
+  "tableId": 14844751,
+  "totalTimesRated": 0,
+  "viewCount": 1549397,
+  "viewLastModified": 1580512895,
+  "viewType": "tabular",
+  "approvals": [
+    {
+      "reviewedAt": 1517334321,
+      "reviewedAutomatically": true,
+      "state": "approved",
+      "submissionId": 949531,
+      "submissionObject": "public_audience_request",
+      "submissionOutcome": "change_audience",
+      "submittedAt": 1517334321,
+      "workflowId": 2226,
+      "submissionDetails": {
+        "permissionType": "READ"
+      },
+      "submissionOutcomeApplication": {
+        "failureCount": 0,
+        "status": "success"
+      },
+      "submitter": {
+        "id": "vi9p-p863",
+        "displayName": "Eric Phillips"
+      }
+    }
+  ],
+  "columns": [
+    {
+      "id": 343058131,
+      "name": "Name",
+      "dataTypeName": "text",
+      "description": "Name of employee",
+      "fieldName": "name",
+      "position": 1,
+      "rdfProperties": "http://xmlns.com/foaf/0.1/name",
+      "renderTypeName": "text",
+      "tableColumnId": 1532233,
+      "width": 218,
+      "cachedContents": {
+        "largest": "ZYSKOWSKI,  DARIUSZ",
+        "non_null": "33702",
+        "null": "0",
+        "top": [
+          {
+            "item": "HERNANDEZ,  JUAN C",
+            "count": "5"
+          },
+          {
+            "item": "PEREZ,  JOSE A",
+            "count": "4"
+          },
+          {
+            "item": "DELGADO,  JUAN",
+            "count": "4"
+          },
+          {
+            "item": "LOPEZ,  ROBERT",
+            "count": "4"
+          },
+          {
+            "item": "ROMERO,  MIGUEL A",
+            "count": "4"
+          },
+          {
+            "item": "RIVERA,  RICARDO",
+            "count": "4"
+          },
+          {
+            "item": "GARCIA,  LUIS A",
+            "count": "3"
+          },
+          {
+            "item": "HERNANDEZ,  RUBEN",
+            "count": "3"
+          },
+          {
+            "item": "GARCIA,  GABRIEL",
+            "count": "3"
+          },
+          {
+            "item": "RIOS,  ALFREDO",
+            "count": "3"
+          },
+          {
+            "item": "WALSH,  MICHAEL J",
+            "count": "3"
+          },
+          {
+            "item": "RODRIGUEZ,  JOSE L",
+            "count": "3"
+          },
+          {
+            "item": "MARTINEZ,  JOSE A",
+            "count": "3"
+          },
+          {
+            "item": "HERNANDEZ,  DANIEL",
+            "count": "3"
+          },
+          {
+            "item": "VEGA,  GERARDO",
+            "count": "3"
+          },
+          {
+            "item": "TORRES,  JACQUELINE",
+            "count": "3"
+          },
+          {
+            "item": "FLORES,  MICHAEL A",
+            "count": "3"
+          },
+          {
+            "item": "JOHNSON,  NICHOLAS",
+            "count": "3"
+          },
+          {
+            "item": "GARCIA,  JULIO",
+            "count": "3"
+          },
+          {
+            "item": "RODRIGUEZ,  JOSE",
+            "count": "3"
+          }
+        ],
+        "smallest": "AARON,  JEFFERY M",
+        "not_null": "33586",
+        "cardinality": "33380"
+      },
+      "format": {
+        "displayStyle": "plain",
+        "rdf": "http://xmlns.com/foaf/0.1/name",
+        "align": "left",
+        "aggregate": "count"
+      }
+    },
+    {
+      "id": 343058132,
+      "name": "Job Titles",
+      "dataTypeName": "text",
+      "description": "Title of employee at the time when the data was updated.",
+      "fieldName": "job_titles",
+      "position": 2,
+      "rdfProperties": "http://xmlns.com/foaf/0.1/title",
+      "renderTypeName": "text",
+      "tableColumnId": 1532235,
+      "width": 220,
+      "cachedContents": {
+        "largest": "ZONING PLAN EXAMINER",
+        "non_null": "33702",
+        "null": "0",
+        "top": [
+          {
+            "item": "POLICE OFFICER",
+            "count": "9761"
+          },
+          {
+            "item": "FIREFIGHTER-EMT",
+            "count": "1381"
+          },
+          {
+            "item": "SERGEANT",
+            "count": "1315"
+          },
+          {
+            "item": "POLICE OFFICER (ASSIGNED AS DETECTIVE)",
+            "count": "1115"
+          },
+          {
+            "item": "MOTOR TRUCK DRIVER",
+            "count": "1046"
+          },
+          {
+            "item": "POOL MOTOR TRUCK DRIVER",
+            "count": "811"
+          },
+          {
+            "item": "SANITATION LABORER",
+            "count": "545"
+          },
+          {
+            "item": "FIREFIGHTER-EMT (RECRUIT)",
+            "count": "504"
+          },
+          {
+            "item": "CONSTRUCTION LABORER",
+            "count": "461"
+          },
+          {
+            "item": "CROSSING GUARD",
+            "count": "396"
+          },
+          {
+            "item": "PARAMEDIC",
+            "count": "379"
+          },
+          {
+            "item": "LIEUTENANT-EMT",
+            "count": "355"
+          },
+          {
+            "item": "LIEUTENANT",
+            "count": "354"
+          },
+          {
+            "item": "TRAFFIC CONTROL AIDE-HOURLY",
+            "count": "345"
+          },
+          {
+            "item": "FIRE ENGINEER-EMT",
+            "count": "344"
+          },
+          {
+            "item": "CROSSING GUARD - PER CBA",
+            "count": "335"
+          },
+          {
+            "item": "FIREFIGHTER",
+            "count": "300"
+          },
+          {
+            "item": "POLICE OFFICER / FLD TRNG OFFICER",
+            "count": "280"
+          },
+          {
+            "item": "GENERAL LABORER - DSS",
+            "count": "257"
+          },
+          {
+            "item": "PARAMEDIC I/C",
+            "count": "246"
+          }
+        ],
+        "smallest": "1ST DEPUTY INSPECTOR GENERAL",
+        "not_null": "33586",
+        "cardinality": "1119"
+      },
+      "format": {
+        "displayStyle": "plain",
+        "rdf": "http://xmlns.com/foaf/0.1/title",
+        "align": "left"
+      }
+    },
+    {
+      "id": 343058133,
+      "name": "Department",
+      "dataTypeName": "text",
+      "description": "Department where employee worked.",
+      "fieldName": "department",
+      "position": 3,
+      "rdfProperties": "http://xmlns.com/foaf/0.1/workplaceHomepage",
+      "renderTypeName": "text",
+      "tableColumnId": 1532236,
+      "width": 183,
+      "cachedContents": {
+        "largest": "WATER MGMNT",
+        "non_null": "33702",
+        "null": "0",
+        "top": [
+          {
+            "item": "POLICE",
+            "count": "13848"
+          },
+          {
+            "item": "FIRE",
+            "count": "4627"
+          },
+          {
+            "item": "STREETS & SAN",
+            "count": "2175"
+          },
+          {
+            "item": "WATER MGMNT",
+            "count": "1914"
+          },
+          {
+            "item": "AVIATION",
+            "count": "1856"
+          },
+          {
+            "item": "OEMC",
+            "count": "1737"
+          },
+          {
+            "item": "TRANSPORTN",
+            "count": "1113"
+          },
+          {
+            "item": "PUBLIC LIBRARY",
+            "count": "1088"
+          },
+          {
+            "item": "DAIS",
+            "count": "1033"
+          },
+          {
+            "item": "FAMILY & SUPPORT",
+            "count": "656"
+          },
+          {
+            "item": "FINANCE",
+            "count": "544"
+          },
+          {
+            "item": "HEALTH",
+            "count": "467"
+          },
+          {
+            "item": "LAW",
+            "count": "398"
+          },
+          {
+            "item": "CITY COUNCIL",
+            "count": "362"
+          },
+          {
+            "item": "BUILDINGS",
+            "count": "258"
+          },
+          {
+            "item": "PUBLIC SAFETY ADMIN",
+            "count": "244"
+          },
+          {
+            "item": "BUSINESS AFFAIRS",
+            "count": "167"
+          },
+          {
+            "item": "HOUSING & ECON DEV",
+            "count": "154"
+          },
+          {
+            "item": "COPA",
+            "count": "123"
+          },
+          {
+            "item": "BOARD OF ELECTION",
+            "count": "111"
+          }
+        ],
+        "smallest": "ADMIN HEARNG",
+        "not_null": "33586",
+        "cardinality": "36"
+      },
+      "format": {
+        "displayStyle": "plain",
+        "rdf": "http://xmlns.com/foaf/0.1/workplaceHomepage",
+        "align": "left"
+      }
+    },
+    {
+      "id": 343058134,
+      "name": "Full or Part-Time",
+      "dataTypeName": "text",
+      "description": "Whether the employee was employed full- (F) or part-time (P).",
+      "fieldName": "full_or_part_time",
+      "position": 4,
+      "renderTypeName": "text",
+      "tableColumnId": 46949521,
+      "width": 170,
+      "cachedContents": {
+        "largest": "P",
+        "non_null": "33702",
+        "null": "0",
+        "top": [
+          {
+            "item": "F",
+            "count": "31534"
+          },
+          {
+            "item": "P",
+            "count": "2168"
+          }
+        ],
+        "smallest": "F",
+        "not_null": "33586",
+        "cardinality": "2"
+      },
+      "format": {
+        "displayStyle": "plain",
+        "align": "left"
+      }
+    },
+    {
+      "id": 343058135,
+      "name": "Salary or Hourly",
+      "dataTypeName": "text",
+      "description": "Defines whether an employee is paid on an hourly basis or salary basis. Hourly employees are further defined by the number of hours they work in a week. See the \"Frequency Description\" column.",
+      "fieldName": "salary_or_hourly",
+      "position": 5,
+      "renderTypeName": "text",
+      "tableColumnId": 46949646,
+      "width": 143,
+      "cachedContents": {
+        "largest": "Salary",
+        "non_null": "33702",
+        "null": "0",
+        "top": [
+          {
+            "item": "Salary",
+            "count": "25528"
+          },
+          {
+            "item": "Hourly",
+            "count": "8174"
+          }
+        ],
+        "smallest": "Hourly",
+        "not_null": "33586",
+        "cardinality": "2"
+      },
+      "format": {
+        "displayStyle": "plain",
+        "align": "left"
+      }
+    },
+    {
+      "id": 343058136,
+      "name": "Typical Hours",
+      "dataTypeName": "number",
+      "description": "Describes the typical amount of work for hourly employees. This data does not apply to salary employees.\n\n40 - Employee paid on an hourly basis; works an 8 hour day; can be either full-time permanent (FT/P) or full-time temporary (FT-T) which is a seasonal employee; 35 - Employee paid on an hourly basis; works a 7 hour day; can be either full-time permanent (FT/P) or full-time temporary (FT-T) which is a seasonal employee; 20 - Employee paid on a part-time, hourly basis; typically works a 4 hour day, 5 days a week; 10 - Employee paid on a part-time, hourly basis; works 10 hours or less in a week.",
+      "fieldName": "typical_hours",
+      "position": 6,
+      "renderTypeName": "number",
+      "tableColumnId": 46949794,
+      "width": 150,
+      "cachedContents": {
+        "largest": "40",
+        "non_null": "8174",
+        "average": "34.50760408875592",
+        "null": "25528",
+        "top": [
+          {
+            "item": "40",
+            "count": "5920"
+          },
+          {
+            "item": "20",
+            "count": "1928"
+          },
+          {
+            "item": "10",
+            "count": "235"
+          },
+          {
+            "item": "35",
+            "count": "91"
+          }
+        ],
+        "smallest": "10",
+        "not_null": "7948",
+        "sum": "276820",
+        "cardinality": "4"
+      },
+      "format": {
+        "precisionStyle": "standard",
+        "noCommas": "true",
+        "align": "left"
+      }
+    },
+    {
+      "id": 343058137,
+      "name": "Annual Salary",
+      "dataTypeName": "number",
+      "description": "Annual salary rates. Only applies for employees whose pay frequency is \"Salary\". Hourly employees rates are only shown in \"Hourly Rates\" column.",
+      "fieldName": "annual_salary",
+      "position": 7,
+      "renderTypeName": "number",
+      "tableColumnId": 46949824,
+      "width": 162,
+      "cachedContents": {
+        "largest": "275004",
+        "non_null": "25528",
+        "average": "86786.99979015142",
+        "null": "8174",
+        "top": [
+          {
+            "item": "90024",
+            "count": "1743"
+          },
+          {
+            "item": "84054",
+            "count": "1500"
+          },
+          {
+            "item": "93354",
+            "count": "1469"
+          },
+          {
+            "item": "72510",
+            "count": "1307"
+          },
+          {
+            "item": "87006",
+            "count": "1143"
+          },
+          {
+            "item": "76266",
+            "count": "860"
+          },
+          {
+            "item": "96060",
+            "count": "786"
+          },
+          {
+            "item": "68616",
+            "count": "663"
+          },
+          {
+            "item": "92274",
+            "count": "566"
+          },
+          {
+            "item": "80016",
+            "count": "457"
+          },
+          {
+            "item": "100980",
+            "count": "453"
+          },
+          {
+            "item": "48078",
+            "count": "449"
+          },
+          {
+            "item": "118644",
+            "count": "445"
+          },
+          {
+            "item": "56304",
+            "count": "381"
+          },
+          {
+            "item": "114948",
+            "count": "379"
+          },
+          {
+            "item": "103932",
+            "count": "328"
+          },
+          {
+            "item": "122472",
+            "count": "298"
+          },
+          {
+            "item": "97440",
+            "count": "283"
+          },
+          {
+            "item": "89148",
+            "count": "281"
+          },
+          {
+            "item": "74568",
+            "count": "254"
+          }
+        ],
+        "smallest": "14160",
+        "not_null": "25638",
+        "sum": "2183647701.72",
+        "cardinality": "924"
+      },
+      "format": {
+        "precisionStyle": "currency",
+        "humane": "false",
+        "currencyStyle": "USD",
+        "precision": "2",
+        "align": "right",
+        "aggregate": "sum"
+      }
+    },
+    {
+      "id": 343058138,
+      "name": "Hourly Rate",
+      "dataTypeName": "number",
+      "description": "The hourly salary rates for individuals whose pay frequency is \"hourly\". Hourly employees have varying hours worked throughout the week, which is described in the \"Frequency Description\" column.",
+      "fieldName": "hourly_rate",
+      "position": 8,
+      "renderTypeName": "number",
+      "tableColumnId": 46949904,
+      "width": 150,
+      "cachedContents": {
+        "largest": "128",
+        "non_null": "8174",
+        "average": "32.78855771628023",
+        "null": "25528",
+        "top": [
+          {
+            "item": "37.45",
+            "count": "1495"
+          },
+          {
+            "item": "43.72",
+            "count": "779"
+          },
+          {
+            "item": "38.52",
+            "count": "528"
+          },
+          {
+            "item": "19.86",
+            "count": "345"
+          },
+          {
+            "item": "49.35",
+            "count": "298"
+          },
+          {
+            "item": "2.65",
+            "count": "260"
+          },
+          {
+            "item": "51.1",
+            "count": "213"
+          },
+          {
+            "item": "48.93",
+            "count": "195"
+          },
+          {
+            "item": "51.85",
+            "count": "194"
+          },
+          {
+            "item": "29.96",
+            "count": "193"
+          },
+          {
+            "item": "49.26",
+            "count": "166"
+          },
+          {
+            "item": "51",
+            "count": "117"
+          },
+          {
+            "item": "22.36",
+            "count": "108"
+          },
+          {
+            "item": "13.4",
+            "count": "107"
+          },
+          {
+            "item": "33.71",
+            "count": "106"
+          },
+          {
+            "item": "15.94",
+            "count": "96"
+          },
+          {
+            "item": "25.47",
+            "count": "93"
+          },
+          {
+            "item": "18.52",
+            "count": "88"
+          },
+          {
+            "item": "14.1",
+            "count": "87"
+          },
+          {
+            "item": "20.31",
+            "count": "83"
+          }
+        ],
+        "smallest": "2.65",
+        "not_null": "7948",
+        "sum": "263029.81",
+        "cardinality": "178"
+      },
+      "format": {
+        "precisionStyle": "currency",
+        "humane": "false",
+        "currencyStyle": "USD",
+        "precision": "2",
+        "align": "right"
+      }
+    }
+  ],
+  "grants": [
+    {
+      "inherited": false,
+      "type": "viewer",
+      "flags": [
+        "public"
+      ]
+    }
+  ],
+  "license": {
+    "name": "See Terms of Use"
+  },
+  "metadata": {
+    "rdfSubject": "0",
+    "jsonQuery": {
+      "order": [
+        {
+          "columnFieldName": "name",
+          "ascending": true
+        }
+      ]
+    },
+    "custom_fields": {
+      "Metadata": {
+        "Time Period": "Last Updated January 2020",
+        "Frequency": "Data are updated semi-annually",
+        "Data Owner": "Human Resources"
+      }
+    },
+    "filterCondition": {
+      "metadata": {
+        "advanced": true,
+        "unifiedVersion": 2
+      },
+      "children": [
+        {
+          "metadata": {
+            "tableColumnId": {
+              "241512": 1532236
+            },
+            "includeAuto": 15,
+            "operator": "EQUALS"
+          },
+          "type": "operator",
+          "value": "OR"
+        }
+      ],
+      "type": "operator",
+      "value": "AND"
+    },
+    "rowLabel": "Employee",
+    "availableDisplayTypes": [
+      "table",
+      "fatrow",
+      "page"
+    ],
+    "renderTypeConfig": {
+      "visible": {
+        "table": true
+      }
+    }
+  },
+  "owner": {
+    "id": "vi9p-p863",
+    "displayName": "Eric Phillips",
+    "screenName": "Eric Phillips",
+    "type": "interactive",
+    "userSegment": "community_user"
+  },
+  "query": {
+    "orderBys": [
+      {
+        "ascending": true,
+        "expression": {
+          "columnId": 343058131,
+          "type": "column"
+        }
+      }
+    ]
+  },
+  "rights": [
+    "read"
+  ],
+  "tableAuthor": {
+    "id": "vi9p-p863",
+    "displayName": "Eric Phillips",
+    "screenName": "Eric Phillips",
+    "type": "interactive",
+    "userSegment": "community_user"
+  },
+  "tags": [
+    "personnel"
+  ],
+  "flags": [
+    "default",
+    "restorable",
+    "restorePossibleForType"
+  ]
+}

--- a/test/resources/ingestion/socrata/find_datasets.json
+++ b/test/resources/ingestion/socrata/find_datasets.json
@@ -1,0 +1,154 @@
+[
+  {
+    "resource": {
+      "name": "Current Employee Names, Salaries, and Position Titles",
+      "id": "xzkq-xp2w",
+      "parent_fxf": [],
+      "description": "This dataset is a listing of all current City of Chicago employees, complete with full names, departments, positions, employment status (part-time or full-time), frequency of hourly employee \u2013where applicable\u2014and annual salaries or hourly rate. For hourly employees, the City is providing the hourly rate and frequency of hourly employees (40, 35, 20 and 10) to allow dataset users to estimate annual wages for hourly employees. Please note that annual wages will vary by employee, depending on number of hours worked and seasonal status. For information on the positions and related salaries detailed in the annual budgets, see https://www.cityofchicago.org/city/en/depts/obm.html",
+      "attribution": "City of Chicago",
+      "attribution_link": "http://www.chicago.gov",
+      "contact_email": "dataportal@cityofchicago.org",
+      "type": "dataset",
+      "updatedAt": "2020-01-31T23:21:48.000Z",
+      "createdAt": "2011-09-27T20:18:55.000Z",
+      "metadata_updated_at": "2020-01-31T23:21:35.000Z",
+      "data_updated_at": "2020-01-31T23:21:48.000Z",
+      "page_views": {
+        "page_views_last_week": 3530,
+        "page_views_last_month": 15427,
+        "page_views_total": 1549238,
+        "page_views_last_week_log": 11.7858611057596,
+        "page_views_last_month_log": 13.913263430628763,
+        "page_views_total_log": 20.563128294159895
+      },
+      "columns_name": [
+        "Full or Part-Time",
+        "Hourly Rate",
+        "Salary or Hourly",
+        "Job Titles",
+        "Typical Hours",
+        "Annual Salary",
+        "Name",
+        "Department"
+      ],
+      "columns_field_name": [
+        "full_or_part_time",
+        "hourly_rate",
+        "salary_or_hourly",
+        "job_titles",
+        "typical_hours",
+        "annual_salary",
+        "name",
+        "department"
+      ],
+      "columns_datatype": [
+        "Text",
+        "Number",
+        "Text",
+        "Text",
+        "Number",
+        "Number",
+        "Text",
+        "Text"
+      ],
+      "columns_description": [
+        "Whether the employee was employed full- (F) or part-time (P).",
+        "The hourly salary rates for individuals whose pay frequency is \"hourly\". Hourly employees have varying hours worked throughout the week, which is described in the \"Frequency Description\" column.",
+        "Defines whether an employee is paid on an hourly basis or salary basis. Hourly employees are further defined by the number of hours they work in a week. See the \"Frequency Description\" column.",
+        "Title of employee at the time when the data was updated.",
+        "Describes the typical amount of work for hourly employees. This data does not apply to salary employees.\n\n40 - Employee paid on an hourly basis; works an 8 hour day; can be either full-time permanent (FT/P) or full-time temporary (FT-T) which is a seasonal employee; 35 - Employee paid on an hourly basis; works a 7 hour day; can be either full-time permanent (FT/P) or full-time temporary (FT-T) which is a seasonal employee; 20 - Employee paid on a part-time, hourly basis; typically works a 4 hour day, 5 days a week; 10 - Employee paid on a part-time, hourly basis; works 10 hours or less in a week.",
+        "Annual salary rates. Only applies for employees whose pay frequency is \"Salary\". Hourly employees rates are only shown in \"Hourly Rates\" column.",
+        "Name of employee",
+        "Department where employee worked."
+      ],
+      "columns_format": [
+        {
+          "displayStyle": "plain",
+          "align": "left"
+        },
+        {
+          "precision": "2",
+          "align": "right",
+          "currencyStyle": "USD",
+          "humane": "false",
+          "precisionStyle": "currency"
+        },
+        {
+          "displayStyle": "plain",
+          "align": "left"
+        },
+        {
+          "displayStyle": "plain",
+          "rdf": "http://xmlns.com/foaf/0.1/title",
+          "align": "left"
+        },
+        {
+          "precisionStyle": "standard",
+          "noCommas": "true",
+          "align": "left"
+        },
+        {
+          "precision": "2",
+          "align": "right",
+          "aggregate": "sum",
+          "currencyStyle": "USD",
+          "humane": "false",
+          "precisionStyle": "currency"
+        },
+        {
+          "displayStyle": "plain",
+          "rdf": "http://xmlns.com/foaf/0.1/name",
+          "align": "left",
+          "aggregate": "count"
+        },
+        {
+          "displayStyle": "plain",
+          "rdf": "http://xmlns.com/foaf/0.1/workplaceHomepage",
+          "align": "left"
+        }
+      ],
+      "download_count": 14062267,
+      "provenance": "official",
+      "lens_view_type": "tabular",
+      "blob_mime_type": null,
+      "hide_from_data_json": false,
+      "publication_date": "2018-01-30T17:45:21.000Z"
+    },
+    "classification": {
+      "categories": [
+        "finance",
+        "demographics",
+        "economy"
+      ],
+      "tags": [],
+      "domain_category": "Administration & Finance",
+      "domain_tags": [
+        "personnel"
+      ],
+      "domain_metadata": [
+        {
+          "key": "Metadata_Time-Period",
+          "value": "Last Updated January 2020"
+        },
+        {
+          "key": "Metadata_Frequency",
+          "value": "Data are updated semi-annually"
+        },
+        {
+          "key": "Metadata_Data-Owner",
+          "value": "Human Resources"
+        }
+      ]
+    },
+    "metadata": {
+      "domain": "data.cityofchicago.org",
+      "license": "See Terms of Use"
+    },
+    "permalink": "https://data.cityofchicago.org/d/xzkq-xp2w",
+    "link": "https://data.cityofchicago.org/Administration-Finance/Current-Employee-Names-Salaries-and-Position-Title/xzkq-xp2w",
+    "owner": {
+      "id": "vi9p-p863",
+      "display_name": "Eric Phillips"
+    }
+  }
+]

--- a/test/splitgraph/commandline/test_engine.py
+++ b/test/splitgraph/commandline/test_engine.py
@@ -206,6 +206,16 @@ _PULL_PROGRESS = [
 ]
 
 
+_HANDLER_CONFIG = """[mount_handlers]
+postgres_fdw=splitgraph.hooks.mount_handlers.mount_postgres
+mongo_fdw=splitgraph.hooks.mount_handlers.mount_mongo
+mysql_fdw=splitgraph.hooks.mount_handlers.mount_mysql
+socrata=splitgraph.ingestion.socrata.mount.mount_socrata
+[external_handlers]
+S3=splitgraph.hooks.s3.S3ExternalObjectHandler
+"""
+
+
 @pytest.mark.parametrize(
     "test_case",
     [
@@ -219,8 +229,7 @@ _PULL_PROGRESS = [
             "/home/user/.splitgraph/.sgconfig",
             "[defaults]\nSG_ENGINE_USER=not_sgr\n"
             "SG_ENGINE_PWD=pwd\nSG_ENGINE_ADMIN_USER=not_sgr\n"
-            "SG_ENGINE_ADMIN_PWD=pwd\n"
-            + "[external_handlers]\nS3=splitgraph.hooks.s3.S3ExternalObjectHandler\n",
+            "SG_ENGINE_ADMIN_PWD=pwd\n" + _HANDLER_CONFIG,
         ),
         # Case 2: no source config, a different engine: gets inserted as a new remote
         (
@@ -234,8 +243,7 @@ _PULL_PROGRESS = [
             "SG_ENGINE_DB_NAME=splitgraph\n"
             "SG_ENGINE_POSTGRES_DB_NAME=postgres\n"
             "SG_ENGINE_ADMIN_USER=not_sgr\n"
-            "SG_ENGINE_ADMIN_PWD=pwd\n"
-            "[external_handlers]\nS3=splitgraph.hooks.s3.S3ExternalObjectHandler\n",
+            "SG_ENGINE_ADMIN_PWD=pwd\n" + _HANDLER_CONFIG,
         ),
         # Case 3: have source config, default engine gets overwritten
         (
@@ -243,8 +251,7 @@ _PULL_PROGRESS = [
             "default",
             "/home/user/.sgconfig",
             "[defaults]\nSG_ENGINE_USER=not_sgr\nSG_ENGINE_PWD=pwd\n"
-            "SG_ENGINE_ADMIN_USER=not_sgr\nSG_ENGINE_ADMIN_PWD=pwd\n"
-            + "[external_handlers]\nS3=splitgraph.hooks.s3.S3ExternalObjectHandler\n",
+            "SG_ENGINE_ADMIN_USER=not_sgr\nSG_ENGINE_ADMIN_PWD=pwd\n" + _HANDLER_CONFIG,
         ),
         # Case 4: have source config, non-default engine gets overwritten
         (
@@ -267,8 +274,7 @@ _PULL_PROGRESS = [
             "SG_ENGINE_USER=not_sgr\nSG_ENGINE_PWD=pwd\n"
             "SG_ENGINE_FDW_HOST=localhost\nSG_ENGINE_FDW_PORT=5432\n"
             "SG_ENGINE_DB_NAME=splitgraph\nSG_ENGINE_POSTGRES_DB_NAME=postgres\n"
-            "SG_ENGINE_ADMIN_USER=not_sgr\nSG_ENGINE_ADMIN_PWD=pwd\n"
-            "[external_handlers]\nS3=splitgraph.hooks.s3.S3ExternalObjectHandler\n",
+            "SG_ENGINE_ADMIN_USER=not_sgr\nSG_ENGINE_ADMIN_PWD=pwd\n" + _HANDLER_CONFIG,
         ),
     ],
 )
@@ -356,7 +362,7 @@ def test_commandline_engine_creation_config_patching_integration(teardown_test_e
 
     # Do some spot checks to make sure we didn't overwrite anything.
     assert "SG_S3_HOST=//objectstorage" in config
-    assert "POSTGRES_FDW=splitgraph.hooks.mount_handlers.mount_postgres" in config
+    assert "postgres_fdw=splitgraph.hooks.mount_handlers.mount_postgres" in config
     assert "[remote: %s]" % TEST_ENGINE_NAME in config
     assert "[remote: remote_engine]" in config
 

--- a/test/splitgraph/ingestion/test_socrata.py
+++ b/test/splitgraph/ingestion/test_socrata.py
@@ -86,34 +86,37 @@ def test_socrata_mounting(local_engine_empty):
 
     assert local_engine_empty.get_full_table_schema("test/pg_mount", "some_table") == [
         TableColumn(
-            ordinal=1,
+            ordinal=1, name=":id", pg_type="text", is_pk=False, comment="Socrata column ID"
+        ),
+        TableColumn(
+            ordinal=2,
             name="full_or_part_time",
             pg_type="text",
             is_pk=False,
             comment="Whether the employee was employed full- (F) or part-time (P).",
         ),
         TableColumn(
-            ordinal=2, name="hourly_rate", pg_type="numeric", is_pk=False, comment=mock.ANY
+            ordinal=3, name="hourly_rate", pg_type="numeric", is_pk=False, comment=mock.ANY
         ),
         TableColumn(
-            ordinal=3, name="salary_or_hourly", pg_type="text", is_pk=False, comment=mock.ANY
+            ordinal=4, name="salary_or_hourly", pg_type="text", is_pk=False, comment=mock.ANY
         ),
         TableColumn(
-            ordinal=4,
+            ordinal=5,
             name="job_titles",
             pg_type="text",
             is_pk=False,
             comment="Title of employee at the time when the data was updated.",
         ),
         TableColumn(
-            ordinal=5, name="typical_hours", pg_type="numeric", is_pk=False, comment=mock.ANY
+            ordinal=6, name="typical_hours", pg_type="numeric", is_pk=False, comment=mock.ANY
         ),
         TableColumn(
-            ordinal=6, name="annual_salary", pg_type="numeric", is_pk=False, comment=mock.ANY
+            ordinal=7, name="annual_salary", pg_type="numeric", is_pk=False, comment=mock.ANY
         ),
-        TableColumn(ordinal=7, name="name", pg_type="text", is_pk=False, comment=mock.ANY),
+        TableColumn(ordinal=8, name="name", pg_type="text", is_pk=False, comment=mock.ANY),
         TableColumn(
-            ordinal=8,
+            ordinal=9,
             name="department",
             pg_type="text",
             is_pk=False,

--- a/test/splitgraph/ingestion/test_socrata.py
+++ b/test/splitgraph/ingestion/test_socrata.py
@@ -1,0 +1,161 @@
+import json
+import os
+from unittest import mock
+from unittest.mock import MagicMock
+
+import pytest
+from sodapy import Socrata
+from test.splitgraph.conftest import INGESTION_RESOURCES
+
+from splitgraph.core.types import TableColumn
+from splitgraph.ingestion.socrata.mount import mount_socrata
+from splitgraph.ingestion.socrata.querying import estimate_socrata_rows_width, quals_to_socrata, ANY
+
+
+class Q:
+    def __init__(self, col, op, val, is_list=False, is_list_any=True):
+        self.field_name = col
+        self.operator = (op,)
+        self.value = val
+
+        self.is_list_operator = is_list
+        # Code doesn't check for the actual "ALL" value so we can put whatever here
+        self.list_any_or_all = ANY if is_list_any else "ALL"
+
+
+@pytest.mark.parametrize(
+    "quals,expected",
+    [
+        ([Q("some_col", ">", 42)], "(some_col > 42)"),
+        (
+            [
+                Q("some_col", ">", 42),
+                Q("some_other_col", "~~", "%te'st%"),
+                Q("some_other_col", "^", 1.23),
+            ],
+            "(some_col > 42) AND (some_other_col LIKE '%te''st%') AND (TRUE)",
+        ),
+        (
+            [
+                Q("some_col", "=", [1, 2, 3, 4, 5], is_list=True),
+                Q("some_other_col", "<>", [1, 2, 3, 4, 5], is_list=True, is_list_any=False),
+            ],
+            "(some_col IN (1,2,3,4,5) AND ((some_other_col <> 1) AND (some_other_col <> 2) "
+            "AND (some_other_col <> 3) AND (some_other_col <> 4) AND (some_other_col <> 5))",
+        ),
+    ],
+)
+def test_socrata_quals(quals, expected):
+    assert quals_to_socrata(quals) == expected
+
+
+def test_socrata_get_rel_size():
+    with open(os.path.join(INGESTION_RESOURCES, "socrata/dataset_metadata.json"), "r") as f:
+        socrata_meta = json.load(f)
+
+    assert estimate_socrata_rows_width(columns=["annual_salary"], metadata=socrata_meta) == (
+        33702,
+        162,
+    )
+    assert estimate_socrata_rows_width(
+        columns=["annual_salary", "name"], metadata=socrata_meta
+    ) == (33702, 380)
+    assert estimate_socrata_rows_width(
+        columns=["name", "annual_salary"], metadata=socrata_meta
+    ) == (33702, 380)
+
+
+def test_socrata_mounting(local_engine_empty):
+    with open(os.path.join(INGESTION_RESOURCES, "socrata/find_datasets.json"), "r") as f:
+        socrata_meta = json.load(f)
+
+    socrata = MagicMock(spec=Socrata)
+    socrata.datasets.return_value = socrata_meta
+    with mock.patch("sodapy.Socrata", return_value=socrata):
+
+        mount_socrata(
+            "test/pg_mount",
+            None,
+            None,
+            None,
+            None,
+            "example.com",
+            {"some_table": "xzkq-xp2w"},
+            "some_token",
+        )
+
+    assert local_engine_empty.get_full_table_schema("test/pg_mount", "some_table") == [
+        TableColumn(
+            ordinal=1,
+            name="full_or_part_time",
+            pg_type="text",
+            is_pk=False,
+            comment="Whether the employee was employed full- (F) or part-time (P).",
+        ),
+        TableColumn(
+            ordinal=2, name="hourly_rate", pg_type="numeric", is_pk=False, comment=mock.ANY
+        ),
+        TableColumn(
+            ordinal=3, name="salary_or_hourly", pg_type="text", is_pk=False, comment=mock.ANY
+        ),
+        TableColumn(
+            ordinal=4,
+            name="job_titles",
+            pg_type="text",
+            is_pk=False,
+            comment="Title of employee at the time when the data was updated.",
+        ),
+        TableColumn(
+            ordinal=5, name="typical_hours", pg_type="numeric", is_pk=False, comment=mock.ANY
+        ),
+        TableColumn(
+            ordinal=6, name="annual_salary", pg_type="numeric", is_pk=False, comment=mock.ANY
+        ),
+        TableColumn(ordinal=7, name="name", pg_type="text", is_pk=False, comment=mock.ANY),
+        TableColumn(
+            ordinal=8,
+            name="department",
+            pg_type="text",
+            is_pk=False,
+            comment="Department where employee worked.",
+        ),
+    ]
+
+
+def test_socrata_mounting_slug(local_engine_empty):
+    with open(os.path.join(INGESTION_RESOURCES, "socrata/find_datasets.json"), "r") as f:
+        socrata_meta = json.load(f)
+
+    socrata = MagicMock(spec=Socrata)
+    socrata.datasets.return_value = socrata_meta
+    with mock.patch("sodapy.Socrata", return_value=socrata):
+
+        mount_socrata(
+            "test/pg_mount", None, None, None, None, "example.com", None, "some_token",
+        )
+
+    assert local_engine_empty.get_all_tables("test/pg_mount") == [
+        "current_employee_names_salaries_and_position_xzkq_xp2w"
+    ]
+
+
+def test_socrata_mounting_missing_tables():
+    with open(os.path.join(INGESTION_RESOURCES, "socrata/find_datasets.json"), "r") as f:
+        socrata_meta = json.load(f)
+
+    socrata = MagicMock(spec=Socrata)
+    socrata.datasets.return_value = socrata_meta
+    with mock.patch("sodapy.Socrata", return_value=socrata):
+        with pytest.raises(ValueError) as e:
+            mount_socrata(
+                "test/pg_mount",
+                None,
+                None,
+                None,
+                None,
+                "example.com",
+                {"some_table": "wrong_id"},
+                "some_token",
+            )
+
+    assert "Some Socrata tables couldn't be found! Missing tables: xzkq-xp2w" in str(e.value)


### PR DESCRIPTION
Add support for querying any Socrata dataset through an FDW \+ mounting a whole Socrata endpoint and autodiscovering table names, types and column comments:

Full docs in .com.

```
 `sgr mount socrata chicago -o '{"domain": "data.cityofchicago.org"}'
```

```
sgr mount socrata chicago_data
    --handler-options '{"domain": "data.cityofchicago.org", \\
                        "tables": {"fire_stations": "28km-gtjn"}, \\
                        "app_token": "YOUR_APP_TOKEN"}'
```

LIMIT/OFFSET/ORDER/WHERE are pushed down to Socrata and rewritten in SoQL (https://dev.socrata.com/docs/queries/) so other clients can easily page through tables and filter through them without having to download the dataset.

Support for Splitfiles also available:

```
FROM MOUNT socrata
  '{"domain": "data.cityofchicago.org",
    "tables": {"business_licenses": "r5kz-chrr",
               "business_owners": "ezma-pppn"}}'
IMPORT {
    SELECT bo.owner_first_name, bo.owner_last_name, bl.legal_name, bl.address, bl.city, bl.license_id, bl.expiration_date
    FROM business_licenses bl
    JOIN business_owners bo
    ON bl.account_number = bo.account_number
    WHERE bl.license_description = 'Tavern'
    AND bl.expiration_date > '2020-05-01'
} AS chicago_bars
```


Couple of WIPs / outstanding issues:

  * multicorn doesn't support OR (clauses with OR are dropped and whole table is loaded (?))
  * issues with comparing date columns with `now()` in multicorn
  * `X in ('val1', 'val2', 'val3')`... type queries that DBeaver sends for filtering on multiple values seem to not be translated correctly to SoQL.