### PR TITLE
FDW fixes and additions

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "engine/src/cstore_fdw"]
 	path = engine/src/cstore_fdw
 	url = https://github.com/splitgraph/cstore_fdw.git
+[submodule "engine/src/postgres-elasticsearch-fdw"]
+	path = engine/src/postgres-elasticsearch-fdw
+	url = https://github.com/splitgraph/postgres-elasticsearch-fdw.git

--- a/engine/Dockerfile
+++ b/engine/Dockerfile
@@ -183,8 +183,8 @@ COPY ./bin /splitgraph/bin
 # "Install" elasticsearch_fdw
 RUN --mount=type=cache,id=pip-cache,target=/root/.cache/pip \
     mkdir /pg_es_fdw && \
-    pip install elasticsearch>=7.7.0
-COPY ./engine/src/postgres-elasticsearch-fdw/pg_es_fdw /pg_es_fdw/
+    pip install "elasticsearch>=7.7.0"
+COPY ./engine/src/postgres-elasticsearch-fdw/pg_es_fdw /pg_es_fdw/pg_es_fdw
 
 ENV PATH "${PATH}:/splitgraph/bin"
 ENV PYTHONPATH "${PYTHONPATH}:/splitgraph:/pg_es_fdw"

--- a/engine/Dockerfile
+++ b/engine/Dockerfile
@@ -175,12 +175,19 @@ ENV POSTGRES_USER sgr
 COPY ./engine/etc /etc/
 COPY ./engine/init_scripts /docker-entrypoint-initdb.d/
 
-ENV PYTHONPATH "${PYTHONPATH}:/splitgraph"
 
 # Copy the actual Splitgraph code over at this point.
 COPY ./splitgraph /splitgraph/splitgraph
 COPY ./bin /splitgraph/bin
+
+# "Install" elasticsearch_fdw
+RUN --mount=type=cache,id=pip-cache,target=/root/.cache/pip \
+    mkdir /pg_es_fdw && \
+    pip install elasticsearch>=7.7.0
+COPY ./engine/src/postgres-elasticsearch-fdw/pg_es_fdw /pg_es_fdw/
+
 ENV PATH "${PATH}:/splitgraph/bin"
+ENV PYTHONPATH "${PYTHONPATH}:/splitgraph:/pg_es_fdw"
 
 # https://github.com/postgis/docker-postgis/blob/master/12-3.0/Dockerfile
 ARG with_postgis

--- a/examples/postgis/vote_map.ipynb
+++ b/examples/postgis/vote_map.ipynb
@@ -19,7 +19,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -31,7 +31,7 @@
     "\n",
     "from splitgraph.ingestion.pandas import sql_to_df\n",
     "from splitgraph.core.repository import Repository, clone\n",
-    "from splitgraph.core.common import pretty_size\n",
+    "from splitgraph.core.output import pretty_size\n",
     "from splitgraph.engine import ResultShape\n",
     "from splitgraph.splitfile import execute_commands\n",
     "\n",
@@ -56,15 +56,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2020-05-18 11:26:44,142 Gathering remote metadata...\n",
-      "2020-05-18 11:26:44,285 No image/object metadata to pull.\n"
+      "2020-08-27 22:42:19,491 Gathering remote metadata...\n",
+      "2020-08-27 22:42:22,991 Fetched metadata for 1 image, 1 table, 192 objects and 0 tags.\n"
      ]
     },
     {
@@ -73,7 +73,7 @@
      "text": [
       "Image(image_hash='79724cbf5dcd2b260ac0d60e58135123d527ff4d2e1dc709f6da47fa8f4ee71f', parent_id=None, created=datetime.datetime(2019, 10, 11, 15, 4, 47, 225093), comment=None, provenance_data=None, repository=Repository splitgraph/election-geodata on LOCAL)\n",
       "\n",
-      "943.28 MiB\n"
+      "942.95 MiB\n"
      ]
     }
    ],
@@ -87,7 +87,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
@@ -97,7 +97,7 @@
       "Foreign Scan on nation  (cost=20.00..400000.00 rows=8000 width=50)\n",
       "  Filter: (((state)::text = '36'::text) AND ((county)::text = '061'::text) AND st_isvalid(geom))\n",
       "  Multicorn: Objects removed by filter: 184\n",
-      "  Multicorn: Scan through 8 object(s) (19.33 MiB)\n",
+      "  Multicorn: Scan through 8 object(s) (19.25 MiB)\n",
       "JIT:\n",
       "  Functions: 2\n",
       "  Options: Inlining false, Optimization false, Expressions true, Deforming true\n"
@@ -122,7 +122,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
@@ -240,7 +240,7 @@
        "[5387 rows x 3 columns]"
       ]
      },
-     "execution_count": 4,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -260,7 +260,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
@@ -297,7 +297,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
@@ -372,7 +372,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
@@ -387,7 +387,9 @@
       "Resolving repository splitgraph/2016_election\n",
       "Gathering remote metadata...\n",
       "No image/object metadata to pull.\n",
-      " ---> Using cache\n",
+      "Executing SQL...\n",
+      "Committing vote_map...\n",
+      "Processing table vote_fraction_geo\n",
       " ---> 23ce8f4810c5\n",
       "Successfully built vote_map:23ce8f4810c5.\n"
      ]
@@ -407,7 +409,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
@@ -586,7 +588,7 @@
        "[5175 rows x 7 columns]"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }

--- a/splitgraph/config/keys.py
+++ b/splitgraph/config/keys.py
@@ -61,6 +61,7 @@ DEFAULTS: ConfigDict = {
         "mongo_fdw": "splitgraph.hooks.mount_handlers.mount_mongo",
         "mysql_fdw": "splitgraph.hooks.mount_handlers.mount_mysql",
         "socrata": "splitgraph.ingestion.socrata.mount.mount_socrata",
+        "elasticsearch": "splitgraph.hooks.mount_handlers.mount_elasticsearch",
     },
 }
 

--- a/splitgraph/core/indexing/range.py
+++ b/splitgraph/core/indexing/range.py
@@ -217,7 +217,7 @@ def generate_range_index(
     :param columns: Columns to run the index on (default all)
     :return: Dictionary of {column: [min, max]}
     """
-    columns = columns or [c.name for c in table_schema]
+    columns = columns if columns is not None else [c.name for c in table_schema]
 
     object_pk = [c.name for c in table_schema if c.is_pk]
     if not object_pk:

--- a/splitgraph/core/output.py
+++ b/splitgraph/core/output.py
@@ -66,17 +66,17 @@ def parse_repo_tag_or_hash(value, default="latest"):
 
 def conn_string_to_dict(connection: Optional[str]) -> Dict[str, Any]:
     if connection:
-        match = re.match(r"(\S+):(\S+)@(.+):(\d+)", connection)
+        match = re.match(r"((\S+):(\S+)@)?(.+):(\d+)", connection)
         if not match:
             raise ValueError("Invalid connection string!")
         # In the future, we could turn all of these options into actual Click options,
         # but then we'd also have to parse the docstring deeper to find out the types the function
         # requires, how to serialize them etc etc. Idea for a click-contrib addon perhaps?
         return dict(
-            server=match.group(3),
-            port=int(match.group(4)),
-            username=match.group(1),
-            password=match.group(2),
+            server=match.group(4),
+            port=int(match.group(5)),
+            username=match.group(2),
+            password=match.group(3),
         )
     else:
         return dict(server=None, port=None, username=None, password=None)

--- a/splitgraph/core/server.py
+++ b/splitgraph/core/server.py
@@ -76,6 +76,16 @@ def delete_object_files(object_id: str):
     _remove(object_path + ".schema")
 
 
+def rename_object_file(old_object_id: str, new_object_id: str):
+    import shutil
+
+    for suffix in ("", ".footer", ".schema"):
+        shutil.move(
+            os.path.join(SG_ENGINE_OBJECT_PATH, old_object_id + suffix),
+            os.path.join(SG_ENGINE_OBJECT_PATH, new_object_id + suffix),
+        )
+
+
 def get_object_size(object_id: str) -> int:
     object_path = os.path.join(SG_ENGINE_OBJECT_PATH, object_id)
     return (

--- a/splitgraph/core/server.py
+++ b/splitgraph/core/server.py
@@ -76,7 +76,7 @@ def delete_object_files(object_id: str):
     _remove(object_path + ".schema")
 
 
-def rename_object_file(old_object_id: str, new_object_id: str):
+def rename_object_files(old_object_id: str, new_object_id: str):
     import shutil
 
     for suffix in ("", ".footer", ".schema"):

--- a/splitgraph/engine/postgres/engine.py
+++ b/splitgraph/engine/postgres/engine.py
@@ -979,6 +979,16 @@ class PostgresEngine(AuditTriggerChangeEngine, ObjectEngine):
         self.unmount_objects(object_ids)
         self.run_api_call_batch("delete_object_files", [(o,) for o in object_ids])
 
+    def rename_object(self, old_object_id: str, new_object_id: str):
+        self.run_sql(
+            SQL("ALTER TABLE {}}.{} RENAME TO {}").format(
+                Identifier(SPLITGRAPH_META_SCHEMA),
+                Identifier(old_object_id),
+                Identifier(new_object_id),
+            )
+        )
+        self.run_api_call("rename_object", old_object_id, new_object_id)
+
     def unmount_objects(self, object_ids: List[str]) -> None:
         """Unmount objects from splitgraph_meta (this doesn't delete the physical files."""
         unmount_query = SQL(";").join(

--- a/splitgraph/engine/postgres/engine.py
+++ b/splitgraph/engine/postgres/engine.py
@@ -980,14 +980,9 @@ class PostgresEngine(AuditTriggerChangeEngine, ObjectEngine):
         self.run_api_call_batch("delete_object_files", [(o,) for o in object_ids])
 
     def rename_object(self, old_object_id: str, new_object_id: str):
-        self.run_sql(
-            SQL("ALTER TABLE {}}.{} RENAME TO {}").format(
-                Identifier(SPLITGRAPH_META_SCHEMA),
-                Identifier(old_object_id),
-                Identifier(new_object_id),
-            )
-        )
-        self.run_api_call("rename_object", old_object_id, new_object_id)
+        self.unmount_objects([old_object_id])
+        self.run_api_call("rename_object_files", old_object_id, new_object_id)
+        self.mount_object(new_object_id)
 
     def unmount_objects(self, object_ids: List[str]) -> None:
         """Unmount objects from splitgraph_meta (this doesn't delete the physical files."""

--- a/splitgraph/hooks/mount_handlers.py
+++ b/splitgraph/hooks/mount_handlers.py
@@ -324,13 +324,14 @@ def mount_elasticsearch(
                 "query": "text",
                 "col_1": "text",
                 "col_2": "boolean",
-              }
+              },
               "index": "index-pattern*",
               "rowid_column": "id",
               "query_column": "query",
             }
           }
         }
+    EOF
     ```
     \b
 

--- a/splitgraph/hooks/mount_handlers.py
+++ b/splitgraph/hooks/mount_handlers.py
@@ -41,7 +41,7 @@ def init_fdw(
     engine: "PostgresEngine",
     server_id: str,
     wrapper: str,
-    server_options: Optional[Dict[str, Union[str, int, None]]] = None,
+    server_options: Optional[Dict[str, Union[str, None]]] = None,
     user_options: Optional[Dict[str, str]] = None,
     overwrite: bool = True,
 ) -> None:
@@ -366,7 +366,7 @@ def mount_elasticsearch(
         {
             "wrapper": "pg_es_fdw.ElasticsearchFDW",
             "host": server,
-            "port": port,
+            "port": str(port),
             "username": username,
             "password": password,
         },

--- a/splitgraph/hooks/mount_handlers.py
+++ b/splitgraph/hooks/mount_handlers.py
@@ -268,7 +268,7 @@ def mount_mysql(
     :param password: Password for the read-only user.
     :param remote_schema: Remote schema name.
     :param tables: Tables to mount (default all). If a list, then will use IMPORT FOREIGN SCHEMA.
-    If a dictionary, must have the format {"table_name": {"col_1": "type_1", ...}}.
+    If a dictionary, must have the format `{"table_name": {"col_1": "type_1", ...}}`.
     """
     from splitgraph.engine import get_engine
     from psycopg2.sql import Identifier, SQL
@@ -340,8 +340,7 @@ def mount_elasticsearch(
     :param username: A read-only user that the database will be accessed as.
     :param password: Password for the read-only user.
     :param table_spec: A dictionary of form
-        ```
-        {"table_name":
+        `{"table_name":
             {"schema": {"col1": "type1"...},
              "index": <es index>,
              "type": <es doc_type, optional in ES7 and later>,
@@ -349,8 +348,7 @@ def mount_elasticsearch(
              "score_column": <column to return document score>,
              "scroll_size": <fetch size, default 1000>,
              "scroll_duration": <how long to hold the scroll context open for, default 10m>},
-             ...}
-        ```
+             ...}`
     """
     from splitgraph.engine import get_engine
     from psycopg2.sql import Identifier, SQL

--- a/splitgraph/hooks/mount_handlers.py
+++ b/splitgraph/hooks/mount_handlers.py
@@ -5,7 +5,7 @@ in the command line tool (via `sgr mount`) and in the Splitfile interpreter (via
 
 import logging
 from importlib import import_module
-from typing import Callable, Dict, List, Optional, Union, TYPE_CHECKING, cast
+from typing import Callable, Dict, List, Optional, Union, TYPE_CHECKING
 
 from splitgraph.config import PG_USER, CONFIG
 from splitgraph.config.config import get_all_in_section
@@ -96,6 +96,7 @@ def mount_postgres(
     password: str,
     dbname: str,
     remote_schema: str,
+    extra_server_args: Optional[Dict] = None,
     tables: Optional[List[str]] = None,
 ) -> None:
     """
@@ -111,6 +112,7 @@ def mount_postgres(
     :param password: Password for the read-only user.
     :param dbname: Remote database name.
     :param remote_schema: Remote schema name.
+    :param extra_server_args: Dictionary of extra arguments to pass to the foreign server
     :param tables: Tables to mount (default all).
     """
     from splitgraph.engine import get_engine
@@ -121,13 +123,15 @@ def mount_postgres(
     engine = get_engine()
     logging.info("Importing foreign Postgres schema...")
 
+    extra_server_args = extra_server_args or {}
+
     # Name foreign servers based on their targets so that we can reuse them.
     server_id = "%s_%s_%s_server" % (server, str(port), dbname)
     init_fdw(
         engine,
         server_id,
         "postgres_fdw",
-        {"host": server, "port": str(port), "dbname": dbname},
+        {"host": server, "port": str(port), "dbname": dbname, **extra_server_args},
         {"user": username, "password": password},
         overwrite=False,
     )

--- a/splitgraph/hooks/mount_handlers.py
+++ b/splitgraph/hooks/mount_handlers.py
@@ -5,9 +5,9 @@ in the command line tool (via `sgr mount`) and in the Splitfile interpreter (via
 
 import logging
 from importlib import import_module
-from typing import Callable, Dict, List, Optional, Union, TYPE_CHECKING, cast, Tuple
+from typing import Callable, Dict, List, Optional, Union, TYPE_CHECKING
 
-from splitgraph.config import PG_USER, CONFIG
+from splitgraph.config import CONFIG
 from splitgraph.config.config import get_all_in_section
 from splitgraph.exceptions import MountHandlerError
 
@@ -76,8 +76,8 @@ def init_fdw(
         engine.run_sql(create_server)
 
     if user_options:
-        create_mapping = SQL("CREATE USER MAPPING IF NOT EXISTS FOR {} SERVER {}").format(
-            Identifier(PG_USER), Identifier(server_id)
+        create_mapping = SQL("CREATE USER MAPPING IF NOT EXISTS FOR PUBLIC SERVER {}").format(
+            Identifier(server_id)
         )
         user_keys, user_vals = zip(*user_options.items())
         create_mapping += (

--- a/splitgraph/ingestion/socrata/querying.py
+++ b/splitgraph/ingestion/socrata/querying.py
@@ -170,16 +170,16 @@ def _qual_to_socrata(qual, column_map=None):
         if qual.list_any_or_all == ANY:
             # Convert col op ANY([a,b,c]) into (cop op a) OR (col op b)...
             return " OR ".join(
-                f"({_base_qual_to_socrata(qual.field_name, qual.operator[0], v, column_map)})"
+                f"({_base_qual_to_socrata(qual.field_name, qual.operator, v, column_map)})"
                 for v in qual.value
             )
         # Convert col op ALL(ARRAY[a,b,c...]) into (cop op a) AND (col op b)...
         return " AND ".join(
-            f"({_base_qual_to_socrata(qual.field_name, qual.operator[0], v, column_map)})"
+            f"({_base_qual_to_socrata(qual.field_name, qual.operator, v, column_map)})"
             for v in qual.value
         )
     else:
-        return f"{_base_qual_to_socrata(qual.field_name, qual.operator[0], qual.value, column_map)}"
+        return f"{_base_qual_to_socrata(qual.field_name, qual.operator, qual.value, column_map)}"
 
 
 def quals_to_socrata(quals, column_map: Optional[Dict[str, str]] = None):

--- a/splitgraph/resources/static/cstore.sql
+++ b/splitgraph/resources/static/cstore.sql
@@ -74,6 +74,18 @@ $BODY$
 LANGUAGE plpython3u
 VOLATILE;
 
+CREATE OR REPLACE FUNCTION splitgraph_api.rename_object_files (
+    old_object_id varchar,
+    new_object_id varchar
+)
+    RETURNS void
+    AS $BODY$
+    from splitgraph.core.server import rename_object_files
+    rename_object_files(old_object_id, new_object_id)
+$BODY$
+LANGUAGE plpython3u
+VOLATILE;
+
 CREATE OR REPLACE FUNCTION splitgraph_api.get_object_size (
     object_id varchar
 )

--- a/test/splitgraph/commandline/test_engine.py
+++ b/test/splitgraph/commandline/test_engine.py
@@ -211,6 +211,7 @@ postgres_fdw=splitgraph.hooks.mount_handlers.mount_postgres
 mongo_fdw=splitgraph.hooks.mount_handlers.mount_mongo
 mysql_fdw=splitgraph.hooks.mount_handlers.mount_mysql
 socrata=splitgraph.ingestion.socrata.mount.mount_socrata
+elasticsearch=splitgraph.hooks.mount_handlers.mount_elasticsearch
 [external_handlers]
 S3=splitgraph.hooks.s3.S3ExternalObjectHandler
 """

--- a/test/splitgraph/commands/test_mounting.py
+++ b/test/splitgraph/commands/test_mounting.py
@@ -4,6 +4,7 @@ import pytest
 from test.splitgraph.conftest import _mount_postgres, _mount_mysql, _mount_mongo
 
 from splitgraph.core.repository import Repository
+from splitgraph.core.types import TableColumn
 from splitgraph.engine import get_engine
 
 PG_MNT = Repository.from_schema("test/pg_mount")
@@ -24,6 +25,15 @@ def test_mount_partial(local_engine_empty):
     _mount_postgres(PG_MNT, tables=["fruits"])
     assert get_engine().table_exists(PG_MNT.to_schema(), "fruits")
     assert not get_engine().table_exists(PG_MNT.to_schema(), "vegetables")
+
+
+@pytest.mark.mounting
+def test_mount_force_schema(local_engine_empty):
+    _mount_postgres(PG_MNT, tables={"fruits": {"fruit_id": "character varying"}})
+    assert get_engine().table_exists(PG_MNT.to_schema(), "fruits")
+    assert get_engine().get_full_table_schema(PG_MNT.to_schema(), "fruits") == [
+        TableColumn(1, "fruit_id", "character varying", False, None)
+    ]
 
 
 @pytest.mark.mounting

--- a/test/splitgraph/commands/test_mounting.py
+++ b/test/splitgraph/commands/test_mounting.py
@@ -6,6 +6,7 @@ from test.splitgraph.conftest import _mount_postgres, _mount_mysql, _mount_mongo
 from splitgraph.core.repository import Repository
 from splitgraph.core.types import TableColumn
 from splitgraph.engine import get_engine
+from splitgraph.hooks.mount_handlers import mount
 
 PG_MNT = Repository.from_schema("test/pg_mount")
 MG_MNT = Repository.from_schema("test_mg_mount")
@@ -65,3 +66,51 @@ def test_cross_joins(local_engine_empty):
         )
         == [(2, "James", "orange")]
     )
+
+
+@pytest.mark.mounting
+def test_mount_elasticsearch(local_engine_empty):
+    # No ES running in this stack: this is just a test that we can instantiate the FDW.
+    repo = Repository("test", "es_mount")
+    try:
+        mount(
+            repo.to_schema(),
+            "elasticsearch",
+            dict(
+                username=None,
+                password=None,
+                server="elasticsearch",
+                port=9200,
+                table_spec={
+                    "table_1": {
+                        "schema": {
+                            "id": "text",
+                            "@timestamp": "timestamp",
+                            "query": "text",
+                            "col_1": "text",
+                            "col_2": "boolean",
+                        },
+                        "index": "index-pattern*",
+                        "rowid_column": "id",
+                        "query_column": "query",
+                    }
+                },
+            ),
+        )
+
+        assert get_engine().get_full_table_schema(repo.to_schema(), "table_1") == [
+            TableColumn(ordinal=1, name="id", pg_type="text", is_pk=False, comment=None),
+            TableColumn(
+                ordinal=2,
+                name="@timestamp",
+                pg_type="timestamp without time zone",
+                is_pk=False,
+                comment=None,
+            ),
+            TableColumn(ordinal=3, name="query", pg_type="text", is_pk=False, comment=None),
+            TableColumn(ordinal=4, name="col_1", pg_type="text", is_pk=False, comment=None),
+            TableColumn(ordinal=5, name="col_2", pg_type="boolean", is_pk=False, comment=None),
+        ]
+
+    finally:
+        repo.delete()

--- a/test/splitgraph/ingestion/test_socrata.py
+++ b/test/splitgraph/ingestion/test_socrata.py
@@ -25,7 +25,7 @@ from splitgraph.ingestion.socrata.querying import (
 class Q:
     def __init__(self, col, op, val, is_list=False, is_list_any=True):
         self.field_name = col
-        self.operator = (op,)
+        self.operator = op
         self.value = val
 
         self.is_list_operator = is_list


### PR DESCRIPTION
Add ability to pass extra server args to postgres_fdw:

```
sgr mount postgres_fdw schema -c [connstr] -o@- <<EOF
{
  "extra_server_args": {
    "use_remote_estimate": "true",
	"extensions": "postgis",
	"fetch_size": "10000"
  }
}
EOF
```

Add ability to rename object files in-engine (utility function for some ingestion).

Allow disabling `IMPORT FOREIGN SCHEMA` and passing a table schema in Postgres/MySQL FDWs. For example:

```
sgr mount mysql_fdw schema -c [connstr] -o@- <<EOF
{
  "remote_schema": "mysql_schema",
  "tables": {
    "table_1": {
      "t1_col_1": "integer",
      "t1_col_2": "text"
    },
    "table_2": {
      "t2_col_1": "bigint",
      "t2_col_2": "integer"
    }
  }
}
EOF
```

Add a fork (https://github.com/splitgraph/postgres-elasticsearch-fdw) of https://github.com/matthewfranglen/postgres-elasticsearch-fdw to `sgr mount`, letting others mount ES indexes:

```
sgr mount elasticsearch -c elasticsearch:9200 -o@- <<EOF
{
  "table_spec": {
    "table_1": {
      "schema": {
        "id": "text",
        "@timestamp": "timestamp",
        "query": "text",
        "col_1": "text",
        "col_2": "boolean",
      }
      "index": "index-pattern*",
      "rowid_column": "id",
      "query_column": "query",
    }
  }
}
EOF
```

Differences:

  * Pass qualifiers as ElasticSearch queries using the query DSL (was using the `query=...` qual as a Lucene query string, which is useless in JOINs. Now we combine both the query implied from the quals and the Lucene query string, if passed)
  * Close the search context on `end_scan` (otherwise many ES queries to the FDW in a 10 minute span would cause it to error with a "too many scroll contexts" exception)
  * Add EXPLAIN support (outputs the used ES query)