### PR TITLE
Fix NULL/array handling in Socrata and Elasticsearch

### DIFF
--- a/splitgraph/core/fdw_checkout.py
+++ b/splitgraph/core/fdw_checkout.py
@@ -83,6 +83,8 @@ class QueryingForeignDataWrapper(ForeignDataWrapper):
         )
 
         return [
+            "Original Multicorn quals: %r" % quals,
+            "CNF quals: %r" % cnf_quals,
             "Objects removed by filter: %d" % (len(all_objects) - len(filtered_objects)),
             "Scan through %d object(s) (%s)" % (len(filtered_objects), pretty_size(total_size)),
         ]
@@ -107,8 +109,6 @@ class QueryingForeignDataWrapper(ForeignDataWrapper):
         if self.end_scan_callback:
             self.end_scan_callback(from_fdw=True)
             self.end_scan_callback = None
-
-        log_to_postgres("CNF quals: %r" % (cnf_quals,), _PG_LOGLEVEL)
 
         queries, self.end_scan_callback, self.plan = self.table.query_indirect(columns, cnf_quals)
         yield from queries

--- a/splitgraph/ingestion/socrata/fdw.py
+++ b/splitgraph/ingestion/socrata/fdw.py
@@ -69,7 +69,17 @@ class SocrataForeignDataWrapper(ForeignDataWrapper):
             return 1000000, len(columns) * 10
 
     def explain(self, quals, columns, sortkeys=None, verbose=False):
-        return ["Socrata query to %s" % self.domain, "Socrata dataset ID: %s" % self.table]
+        query = quals_to_socrata(quals, self.column_map)
+        select = cols_to_socrata(columns, self.column_map)
+        order = sortkeys_to_socrata(sortkeys, self.column_map)
+
+        return [
+            "Socrata query to %s" % self.domain,
+            "Socrata dataset ID: %s" % self.table,
+            "Query: %s" % query,
+            "Columns: %s" % select,
+            "Order: %s" % order,
+        ]
 
     def execute(self, quals, columns, sortkeys=None):
         """Main Multicorn entry point."""

--- a/splitgraph/ingestion/socrata/querying.py
+++ b/splitgraph/ingestion/socrata/querying.py
@@ -170,12 +170,12 @@ def _qual_to_socrata(qual, column_map=None):
         if qual.list_any_or_all == ANY:
             # Convert col op ANY([a,b,c]) into (cop op a) OR (col op b)...
             return " OR ".join(
-                f"({_base_qual_to_socrata(qual.field_name, qual.operator, v, column_map)})"
+                f"({_base_qual_to_socrata(qual.field_name, qual.operator[0], v, column_map)})"
                 for v in qual.value
             )
         # Convert col op ALL(ARRAY[a,b,c...]) into (cop op a) AND (col op b)...
         return " AND ".join(
-            f"({_base_qual_to_socrata(qual.field_name, qual.operator, v, column_map)})"
+            f"({_base_qual_to_socrata(qual.field_name, qual.operator[0], v, column_map)})"
             for v in qual.value
         )
     else:

--- a/splitgraph/ingestion/socrata/querying.py
+++ b/splitgraph/ingestion/socrata/querying.py
@@ -161,8 +161,15 @@ def _base_qual_to_socrata(col, op, value, column_map=None):
     soql_op = _convert_op(op)
     if not soql_op:
         return "TRUE"
-    else:
-        return f"{_emit_col(col, column_map)} {soql_op} {_emit_val(value)}"
+    if value is None:
+        if soql_op == "=":
+            soql_op = "IS"
+        elif soql_op in ("<>", "!="):
+            soql_op = "IS NOT"
+        else:
+            return "TRUE"
+
+    return f"{_emit_col(col, column_map)} {soql_op} {_emit_val(value)}"
 
 
 def _qual_to_socrata(qual, column_map=None):

--- a/test/splitgraph/ingestion/test_socrata.py
+++ b/test/splitgraph/ingestion/test_socrata.py
@@ -67,7 +67,7 @@ _col_map = {_long_name_col_sg: _long_name_col}
             "((`some_col` = 1) OR (`some_col` = 2)) "
             "AND ((`some_other_col` <> 1) AND (`some_other_col` <> 2))",
         ),
-        ([Q("some_col", "=", None)], "(`some_col` = NULL)"),
+        ([Q("some_col", "=", None)], "(`some_col` IS NULL)"),
     ],
 )
 def test_socrata_quals(quals, expected):

--- a/test/splitgraph/ingestion/test_socrata.py
+++ b/test/splitgraph/ingestion/test_socrata.py
@@ -268,6 +268,9 @@ def test_socrata_fdw():
         assert fdw.explain([], []) == [
             "Socrata query to data.cityofchicago.gov",
             "Socrata dataset ID: xzkq-xp2w",
+            "Query: ",
+            "Columns: ",
+            "Order: :id",
         ]
 
         assert list(

--- a/test/splitgraph/ingestion/test_socrata.py
+++ b/test/splitgraph/ingestion/test_socrata.py
@@ -25,7 +25,10 @@ from splitgraph.ingestion.socrata.querying import (
 class Q:
     def __init__(self, col, op, val, is_list=False, is_list_any=True):
         self.field_name = col
-        self.operator = op
+        if is_list:
+            self.operator = (op, is_list_any)
+        else:
+            self.operator = op
         self.value = val
 
         self.is_list_operator = is_list


### PR DESCRIPTION
  * Socrata now correctly emits IS NULL / IS NOT NULL, same with ES (using ES query syntax). 
  * Fix array handling (`a IN (1,2,3)` queries get rewritten and pushed down correctly).
  * Output more query information in EXPLAIN for Socrata/LQ.