### PR TITLE
Code for managed Singer ingestion and state storage

### DIFF
--- a/.ci/install.sh
+++ b/.ci/install.sh
@@ -8,7 +8,16 @@ pip install --no-deps -r /tmp/requirements.txt
 poetry install -E pandas
 
 # Needed to test the dbt example, not required by core sg
+python -m venv "$DBT_VENV"
+. "$DBT_VENV"/bin/activate
 pip install dbt
+
+# Singer tap integration test
+python -m venv "$TAP_MYSQL_VENV"
+. "$TAP_MYSQL_VENV"/bin/activate
+pip install tap-mysql
+
+# No deactivate here -- Poetry will use a separate venv for Splitgraph.
 
 # sudo cat /etc/docker/daemon.json
 

--- a/.ci/install.sh
+++ b/.ci/install.sh
@@ -3,7 +3,7 @@
 source "$HOME"/.poetry/env
 
 poetry export --dev -f requirements.txt --without-hashes -o /tmp/requirements.txt -E pandas
-sed -i "/^-e/d" /tmp/requirements.txt
+sed -i "/^-e \.\./d" /tmp/requirements.txt
 pip install --no-deps -r /tmp/requirements.txt
 poetry install -E pandas
 

--- a/.github/workflows/build_and_test_and_release.yml
+++ b/.github/workflows/build_and_test_and_release.yml
@@ -62,7 +62,7 @@ jobs:
         if: "!startsWith(github.ref, 'refs/tags/') && !contains(github.event.head_commit.message, '[skip test]')"
         run: |
           source "$HOME"/.poetry/env
-          export PATH=$PATH:$DBT_VENV/bin
+          export PATH=$PATH:$(readlink -f $DBT_VENV/bin)
           poetry run pytest examples/ -sv -m "example" --cov-append
       - name: "Submit coverage to Coveralls"
         if: "!contains(github.event.head_commit.message, '[skip test]')"
@@ -82,6 +82,7 @@ jobs:
         # We could split this out into a separate stage but it would mean installing Poetry, Compose and this package all over again.
         run: |
           echo "Building Asciicast/doc bundle"
+          export PATH=$PATH:$(readlink -f $DBT_VENV/bin)
           ./.ci/build_artifacts.sh
           echo "Uploading engine image to Docker Hub"
           ./.ci/push_engine.sh

--- a/.github/workflows/build_and_test_and_release.yml
+++ b/.github/workflows/build_and_test_and_release.yml
@@ -13,6 +13,8 @@ jobs:
       DOCKER_REPO: splitgraph
       DOCKER_ENGINE_IMAGE: engine
       DOCKER_TAG: development
+      DBT_VENV: dbt_venv
+      TAP_MYSQL_VENV: tap_mysql_venv
 
     steps:
       - uses: actions/checkout@v2
@@ -49,9 +51,10 @@ jobs:
         run: |
           source "$HOME"/.poetry/env
           poetry run mypy splitgraph
-          poetry run pytest -v -m "not mounting and not example"
+          poetry run pytest test/ -v -m "not mounting and not example"
           ./wait-for-test-architecture.sh --mounting
-          poetry run pytest -v -m "mounting and not example" --cov-append
+          export PATH=$PATH:$TAP_MYSQL_VENV/bin
+          poetry run pytest test/ -v -m "mounting and not example" --cov-append
           ./.ci/down_architecture.sh
       - name: "Run example tests"
         # Don't run example tests if we're doing a release -- we'll be
@@ -59,7 +62,8 @@ jobs:
         if: "!startsWith(github.ref, 'refs/tags/') && !contains(github.event.head_commit.message, '[skip test]')"
         run: |
           source "$HOME"/.poetry/env
-          poetry run pytest -sv -m "example" --cov-append
+          export PATH=$PATH:$DBT_VENV/bin
+          poetry run pytest test/ -sv -m "example" --cov-append
       - name: "Submit coverage to Coveralls"
         if: "!contains(github.event.head_commit.message, '[skip test]')"
         env:

--- a/.github/workflows/build_and_test_and_release.yml
+++ b/.github/workflows/build_and_test_and_release.yml
@@ -63,7 +63,7 @@ jobs:
         run: |
           source "$HOME"/.poetry/env
           export PATH=$PATH:$DBT_VENV/bin
-          poetry run pytest test/ -sv -m "example" --cov-append
+          poetry run pytest examples/ -sv -m "example" --cov-append
       - name: "Submit coverage to Coveralls"
         if: "!contains(github.event.head_commit.message, '[skip test]')"
         env:

--- a/engine/Dockerfile
+++ b/engine/Dockerfile
@@ -110,6 +110,7 @@ RUN apt-get update -qq && \
         python3.7 \
         python3-setuptools \
         postgresql-plpython3-12 \
+        git \
         wget && \
 
         curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && \

--- a/engine/build_scripts/build_splitgraph.sh
+++ b/engine/build_scripts/build_splitgraph.sh
@@ -14,7 +14,7 @@ source "$HOME"/.poetry/env
 poetry config virtualenvs.create false
 
 # Export the requirements into pip and install them separately (faster than Poetry)
-poetry export -f requirements.txt --without-hashes -o requirements.txt && sed -i "/^-e/d" requirements.txt
+poetry export -f requirements.txt --without-hashes -o requirements.txt && sed -i "/^-e \.\./d" requirements.txt
 pip install --no-deps -r requirements.txt
 
 # We don't use pip/poetry here to install the package in "editable" mode as we

--- a/examples/custom_fdw/src/.sgconfig
+++ b/examples/custom_fdw/src/.sgconfig
@@ -5,6 +5,6 @@ SG_ENGINE_PORT=5432
 SG_ENGINE_USER=sgr
 SG_ENGINE_PWD=supersecure
 
-[mount_handlers]
+[data_sources]
 ; Register the "HackerNewsDataSource" function as the hackernews mount handler
 hackernews=hn_fdw.mount.HackerNewsDataSource

--- a/examples/import-from-mongo/.sgconfig
+++ b/examples/import-from-mongo/.sgconfig
@@ -5,5 +5,5 @@ SG_ENGINE_PORT=5432
 SG_ENGINE_USER=sgr
 SG_ENGINE_PWD=supersecure
 
-[mount_handlers]
+[data_sources]
 mongo_fdw=splitgraph.hooks.mount_handlers.mount_mongo

--- a/examples/import-from-mongo/.sgconfig
+++ b/examples/import-from-mongo/.sgconfig
@@ -6,4 +6,4 @@ SG_ENGINE_USER=sgr
 SG_ENGINE_PWD=supersecure
 
 [data_sources]
-mongo_fdw=splitgraph.hooks.mount_handlers.mount_mongo
+mongo_fdw=splitgraph.hooks.data_source.MongoDataSource

--- a/examples/template/.sgconfig
+++ b/examples/template/.sgconfig
@@ -5,7 +5,7 @@ SG_ENGINE_PORT=5432
 SG_ENGINE_USER=sgr
 SG_ENGINE_PWD=supersecure
 
-[mount_handlers]
+[data_sources]
 mongo_fdw=splitgraph.hooks.mount_handlers.mount_mongo
 
 ; Add needed configuration here

--- a/examples/template/.sgconfig
+++ b/examples/template/.sgconfig
@@ -6,6 +6,6 @@ SG_ENGINE_USER=sgr
 SG_ENGINE_PWD=supersecure
 
 [data_sources]
-mongo_fdw=splitgraph.hooks.mount_handlers.mount_mongo
+mongo_fdw=splitgraph.hooks.data_source.MongoDataSource
 
 ; Add needed configuration here

--- a/poetry.lock
+++ b/poetry.lock
@@ -62,11 +62,11 @@ description = "Classes Without Boilerplate"
 name = "attrs"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "20.2.0"
+version = "20.3.0"
 
 [package.extras]
-dev = ["coverage (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "zope.interface", "sphinx", "sphinx-rtd-theme", "pre-commit"]
-docs = ["sphinx", "sphinx-rtd-theme", "zope.interface"]
+dev = ["coverage (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "zope.interface", "furo", "sphinx", "pre-commit"]
+docs = ["furo", "sphinx", "zope.interface"]
 tests = ["coverage (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "zope.interface"]
 tests_no_zope = ["coverage (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six"]
 
@@ -121,7 +121,7 @@ description = "Python package for providing Mozilla's CA Bundle."
 name = "certifi"
 optional = false
 python-versions = "*"
-version = "2020.6.20"
+version = "2020.11.8"
 
 [[package]]
 category = "dev"
@@ -288,7 +288,7 @@ description = "File identification library for Python"
 name = "identify"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,>=2.7"
-version = "1.5.6"
+version = "1.5.9"
 
 [package.extras]
 license = ["editdistance"]
@@ -504,7 +504,7 @@ description = "NumPy is the fundamental package for array computing with Python.
 name = "numpy"
 optional = true
 python-versions = ">=3.6"
-version = "1.19.3"
+version = "1.19.4"
 
 [[package]]
 category = "main"
@@ -551,7 +551,7 @@ description = "Utility library for gitignore style pattern matching of file path
 name = "pathspec"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
-version = "0.8.0"
+version = "0.8.1"
 
 [[package]]
 category = "dev"
@@ -662,7 +662,7 @@ description = "pyfakefs implements a fake file system that mocks the Python file
 name = "pyfakefs"
 optional = false
 python-versions = ">=3.5"
-version = "4.1.0"
+version = "4.2.1"
 
 [[package]]
 category = "dev"
@@ -800,7 +800,7 @@ description = "World timezone definitions, modern and historical"
 name = "pytz"
 optional = false
 python-versions = "*"
-version = "2020.1"
+version = "2020.4"
 
 [[package]]
 category = "main"
@@ -887,7 +887,7 @@ description = "Python documentation generator"
 name = "sphinx"
 optional = false
 python-versions = ">=3.5"
-version = "3.2.1"
+version = "3.3.0"
 
 [package.dependencies]
 Jinja2 = ">=2.3"
@@ -910,7 +910,7 @@ sphinxcontrib-serializinghtml = "*"
 
 [package.extras]
 docs = ["sphinxcontrib-websupport"]
-lint = ["flake8 (>=3.5.0)", "flake8-import-order", "mypy (>=0.780)", "docutils-stubs"]
+lint = ["flake8 (>=3.5.0)", "flake8-import-order", "mypy (>=0.790)", "docutils-stubs"]
 test = ["pytest", "pytest-cov", "html5lib", "typed-ast", "cython"]
 
 [[package]]
@@ -1034,8 +1034,8 @@ category = "dev"
 description = "Python Library for Tom's Obvious, Minimal Language"
 name = "toml"
 optional = false
-python-versions = "*"
-version = "0.10.1"
+python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
+version = "0.10.2"
 
 [[package]]
 category = "main"
@@ -1167,8 +1167,8 @@ atomicwrites = [
     {file = "atomicwrites-1.4.0.tar.gz", hash = "sha256:ae70396ad1a434f9c7046fd2dd196fc04b12f9e91ffb859164193be8b6168a7a"},
 ]
 attrs = [
-    {file = "attrs-20.2.0-py2.py3-none-any.whl", hash = "sha256:fce7fc47dfc976152e82d53ff92fa0407700c21acd20886a13777a0d20e655dc"},
-    {file = "attrs-20.2.0.tar.gz", hash = "sha256:26b54ddbbb9ee1d34d5d3668dd37d6cf74990ab23c828c2888dccdceee395594"},
+    {file = "attrs-20.3.0-py2.py3-none-any.whl", hash = "sha256:31b2eced602aa8423c2aea9c76a724617ed67cf9513173fd3a4f03e3a929c7e6"},
+    {file = "attrs-20.3.0.tar.gz", hash = "sha256:832aa3cde19744e49938b91fea06d69ecb9e649c93ba974535d08ad92164f700"},
 ]
 babel = [
     {file = "Babel-2.8.0-py2.py3-none-any.whl", hash = "sha256:d670ea0b10f8b723672d3a6abeb87b565b244da220d76b4dba1b66269ec152d4"},
@@ -1183,8 +1183,8 @@ bump2version = [
     {file = "bump2version-1.0.1.tar.gz", hash = "sha256:762cb2bfad61f4ec8e2bdf452c7c267416f8c70dd9ecb1653fd0bbb01fa936e6"},
 ]
 certifi = [
-    {file = "certifi-2020.6.20-py2.py3-none-any.whl", hash = "sha256:8fc0819f1f30ba15bdb34cceffb9ef04d99f420f68eb75d901e9560b8749fc41"},
-    {file = "certifi-2020.6.20.tar.gz", hash = "sha256:5930595817496dd21bb8dc35dad090f1c2cd0adfaf21204bf6732ca5d8ee34d3"},
+    {file = "certifi-2020.11.8-py2.py3-none-any.whl", hash = "sha256:1f422849db327d534e3d0c5f02a263458c3955ec0aae4ff09b95f195c59f4edd"},
+    {file = "certifi-2020.11.8.tar.gz", hash = "sha256:f05def092c44fbf25834a51509ef6e631dc19765ab8a57b4e7ab85531f0a9cf4"},
 ]
 cfgv = [
     {file = "cfgv-3.0.0-py2.py3-none-any.whl", hash = "sha256:f22b426ed59cd2ab2b54ff96608d846c33dfb8766a67f0b4a6ce130ce244414f"},
@@ -1279,8 +1279,8 @@ httpretty = [
     {file = "httpretty-1.0.2.tar.gz", hash = "sha256:24a6fd2fe1c76e94801b74db8f52c0fb42718dc4a199a861b305b1a492b9d868"},
 ]
 identify = [
-    {file = "identify-1.5.6-py2.py3-none-any.whl", hash = "sha256:3139bf72d81dfd785b0a464e2776bd59bdc725b4cc10e6cf46b56a0db931c82e"},
-    {file = "identify-1.5.6.tar.gz", hash = "sha256:969d844b7a85d32a5f9ac4e163df6e846d73c87c8b75847494ee8f4bd2186421"},
+    {file = "identify-1.5.9-py2.py3-none-any.whl", hash = "sha256:5dd84ac64a9a115b8e0b27d1756b244b882ad264c3c423f42af8235a6e71ca12"},
+    {file = "identify-1.5.9.tar.gz", hash = "sha256:c9504ba6a043ee2db0a9d69e43246bc138034895f6338d5aed1b41e4a73b1513"},
 ]
 idna = [
     {file = "idna-2.10-py2.py3-none-any.whl", hash = "sha256:b97d804b1e9b523befed77c48dacec60e6dcb0b5391d57af6a65a312a90648c0"},
@@ -1418,40 +1418,40 @@ nodeenv = [
     {file = "nodeenv-1.5.0.tar.gz", hash = "sha256:ab45090ae383b716c4ef89e690c41ff8c2b257b85b309f01f3654df3d084bd7c"},
 ]
 numpy = [
-    {file = "numpy-1.19.3-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:942d2cdcb362739908c26ce8dd88db6e139d3fa829dd7452dd9ff02cba6b58b2"},
-    {file = "numpy-1.19.3-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:efd656893171bbf1331beca4ec9f2e74358fc732a2084f664fd149cc4b3441d2"},
-    {file = "numpy-1.19.3-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:1a307bdd3dd444b1d0daa356b5f4c7de2e24d63bdc33ea13ff718b8ec4c6a268"},
-    {file = "numpy-1.19.3-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:9d08d84bb4128abb9fbd9f073e5c69f70e5dab991a9c42e5b4081ea5b01b5db0"},
-    {file = "numpy-1.19.3-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:7197ee0a25629ed782c7bd01871ee40702ffeef35bc48004bc2fdcc71e29ba9d"},
-    {file = "numpy-1.19.3-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:8edc4d687a74d0a5f8b9b26532e860f4f85f56c400b3a98899fc44acb5e27add"},
-    {file = "numpy-1.19.3-cp36-cp36m-win32.whl", hash = "sha256:522053b731e11329dd52d258ddf7de5288cae7418b55e4b7d32f0b7e31787e9d"},
-    {file = "numpy-1.19.3-cp36-cp36m-win_amd64.whl", hash = "sha256:eefc13863bf01583a85e8c1121a901cc7cb8f059b960c4eba30901e2e6aba95f"},
-    {file = "numpy-1.19.3-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:6ff88bcf1872b79002569c63fe26cd2cda614e573c553c4d5b814fb5eb3d2822"},
-    {file = "numpy-1.19.3-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:e080087148fd70469aade2abfeadee194357defd759f9b59b349c6192aba994c"},
-    {file = "numpy-1.19.3-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:50f68ebc439821b826823a8da6caa79cd080dee2a6d5ab9f1163465a060495ed"},
-    {file = "numpy-1.19.3-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:b9074d062d30c2779d8af587924f178a539edde5285d961d2dfbecbac9c4c931"},
-    {file = "numpy-1.19.3-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:463792a249a81b9eb2b63676347f996d3f0082c2666fd0604f4180d2e5445996"},
-    {file = "numpy-1.19.3-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:ea6171d2d8d648dee717457d0f75db49ad8c2f13100680e284d7becf3dc311a6"},
-    {file = "numpy-1.19.3-cp37-cp37m-win32.whl", hash = "sha256:0ee77786eebbfa37f2141fd106b549d37c89207a0d01d8852fde1c82e9bfc0e7"},
-    {file = "numpy-1.19.3-cp37-cp37m-win_amd64.whl", hash = "sha256:271139653e8b7a046d11a78c0d33bafbddd5c443a5b9119618d0652a4eb3a09f"},
-    {file = "numpy-1.19.3-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:e983cbabe10a8989333684c98fdc5dd2f28b236216981e0c26ed359aaa676772"},
-    {file = "numpy-1.19.3-cp38-cp38-manylinux1_i686.whl", hash = "sha256:d78294f1c20f366cde8a75167f822538a7252b6e8b9d6dbfb3bdab34e7c1929e"},
-    {file = "numpy-1.19.3-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:199bebc296bd8a5fc31c16f256ac873dd4d5b4928dfd50e6c4995570fc71a8f3"},
-    {file = "numpy-1.19.3-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:dffed17848e8b968d8d3692604e61881aa6ef1f8074c99e81647ac84f6038535"},
-    {file = "numpy-1.19.3-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:5ea4401ada0d3988c263df85feb33818dc995abc85b8125f6ccb762009e7bc68"},
-    {file = "numpy-1.19.3-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:604d2e5a31482a3ad2c88206efd43d6fcf666ada1f3188fd779b4917e49b7a98"},
-    {file = "numpy-1.19.3-cp38-cp38-win32.whl", hash = "sha256:a2daea1cba83210c620e359de2861316f49cc7aea8e9a6979d6cb2ddab6dda8c"},
-    {file = "numpy-1.19.3-cp38-cp38-win_amd64.whl", hash = "sha256:dfdc8b53aa9838b9d44ed785431ca47aa3efaa51d0d5dd9c412ab5247151a7c4"},
-    {file = "numpy-1.19.3-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:9f7f56b5e85b08774939622b7d45a5d00ff511466522c44fc0756ac7692c00f2"},
-    {file = "numpy-1.19.3-cp39-cp39-manylinux1_i686.whl", hash = "sha256:8802d23e4895e0c65e418abe67cdf518aa5cbb976d97f42fd591f921d6dffad0"},
-    {file = "numpy-1.19.3-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:c4aa79993f5d856765819a3651117520e41ac3f89c3fc1cb6dee11aa562df6da"},
-    {file = "numpy-1.19.3-cp39-cp39-manylinux2010_i686.whl", hash = "sha256:51e8d2ae7c7e985c7bebf218e56f72fa93c900ad0c8a7d9fbbbf362f45710f69"},
-    {file = "numpy-1.19.3-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:50d3513469acf5b2c0406e822d3f314d7ac5788c2b438c24e5dd54d5a81ef522"},
-    {file = "numpy-1.19.3-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:741d95eb2b505bb7a99fbf4be05fa69f466e240c2b4f2d3ddead4f1b5f82a5a5"},
-    {file = "numpy-1.19.3-cp39-cp39-win32.whl", hash = "sha256:1ea7e859f16e72ab81ef20aae69216cfea870676347510da9244805ff9670170"},
-    {file = "numpy-1.19.3-cp39-cp39-win_amd64.whl", hash = "sha256:83af653bb92d1e248ccf5fdb05ccc934c14b936bcfe9b917dc180d3f00250ac6"},
-    {file = "numpy-1.19.3-pp36-pypy36_pp73-manylinux2010_x86_64.whl", hash = "sha256:9a0669787ba8c9d3bb5de5d9429208882fb47764aa79123af25c5edc4f5966b9"},
-    {file = "numpy-1.19.3.zip", hash = "sha256:35bf5316af8dc7c7db1ad45bec603e5fb28671beb98ebd1d65e8059efcfd3b72"},
+    {file = "numpy-1.19.4-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:e9b30d4bd69498fc0c3fe9db5f62fffbb06b8eb9321f92cc970f2969be5e3949"},
+    {file = "numpy-1.19.4-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:fedbd128668ead37f33917820b704784aff695e0019309ad446a6d0b065b57e4"},
+    {file = "numpy-1.19.4-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:8ece138c3a16db8c1ad38f52eb32be6086cc72f403150a79336eb2045723a1ad"},
+    {file = "numpy-1.19.4-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:64324f64f90a9e4ef732be0928be853eee378fd6a01be21a0a8469c4f2682c83"},
+    {file = "numpy-1.19.4-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:ad6f2ff5b1989a4899bf89800a671d71b1612e5ff40866d1f4d8bcf48d4e5764"},
+    {file = "numpy-1.19.4-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:d6c7bb82883680e168b55b49c70af29b84b84abb161cbac2800e8fcb6f2109b6"},
+    {file = "numpy-1.19.4-cp36-cp36m-win32.whl", hash = "sha256:13d166f77d6dc02c0a73c1101dd87fdf01339febec1030bd810dcd53fff3b0f1"},
+    {file = "numpy-1.19.4-cp36-cp36m-win_amd64.whl", hash = "sha256:448ebb1b3bf64c0267d6b09a7cba26b5ae61b6d2dbabff7c91b660c7eccf2bdb"},
+    {file = "numpy-1.19.4-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:27d3f3b9e3406579a8af3a9f262f5339005dd25e0ecf3cf1559ff8a49ed5cbf2"},
+    {file = "numpy-1.19.4-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:16c1b388cc31a9baa06d91a19366fb99ddbe1c7b205293ed072211ee5bac1ed2"},
+    {file = "numpy-1.19.4-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:e5b6ed0f0b42317050c88022349d994fe72bfe35f5908617512cd8c8ef9da2a9"},
+    {file = "numpy-1.19.4-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:18bed2bcb39e3f758296584337966e68d2d5ba6aab7e038688ad53c8f889f757"},
+    {file = "numpy-1.19.4-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:fe45becb4c2f72a0907c1d0246ea6449fe7a9e2293bb0e11c4e9a32bb0930a15"},
+    {file = "numpy-1.19.4-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:6d7593a705d662be5bfe24111af14763016765f43cb6923ed86223f965f52387"},
+    {file = "numpy-1.19.4-cp37-cp37m-win32.whl", hash = "sha256:6ae6c680f3ebf1cf7ad1d7748868b39d9f900836df774c453c11c5440bc15b36"},
+    {file = "numpy-1.19.4-cp37-cp37m-win_amd64.whl", hash = "sha256:9eeb7d1d04b117ac0d38719915ae169aa6b61fca227b0b7d198d43728f0c879c"},
+    {file = "numpy-1.19.4-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:cb1017eec5257e9ac6209ac172058c430e834d5d2bc21961dceeb79d111e5909"},
+    {file = "numpy-1.19.4-cp38-cp38-manylinux1_i686.whl", hash = "sha256:edb01671b3caae1ca00881686003d16c2209e07b7ef8b7639f1867852b948f7c"},
+    {file = "numpy-1.19.4-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:f29454410db6ef8126c83bd3c968d143304633d45dc57b51252afbd79d700893"},
+    {file = "numpy-1.19.4-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:ec149b90019852266fec2341ce1db513b843e496d5a8e8cdb5ced1923a92faab"},
+    {file = "numpy-1.19.4-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:1aeef46a13e51931c0b1cf8ae1168b4a55ecd282e6688fdb0a948cc5a1d5afb9"},
+    {file = "numpy-1.19.4-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:08308c38e44cc926bdfce99498b21eec1f848d24c302519e64203a8da99a97db"},
+    {file = "numpy-1.19.4-cp38-cp38-win32.whl", hash = "sha256:5734bdc0342aba9dfc6f04920988140fb41234db42381cf7ccba64169f9fe7ac"},
+    {file = "numpy-1.19.4-cp38-cp38-win_amd64.whl", hash = "sha256:09c12096d843b90eafd01ea1b3307e78ddd47a55855ad402b157b6c4862197ce"},
+    {file = "numpy-1.19.4-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:e452dc66e08a4ce642a961f134814258a082832c78c90351b75c41ad16f79f63"},
+    {file = "numpy-1.19.4-cp39-cp39-manylinux1_i686.whl", hash = "sha256:a5d897c14513590a85774180be713f692df6fa8ecf6483e561a6d47309566f37"},
+    {file = "numpy-1.19.4-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:a09f98011236a419ee3f49cedc9ef27d7a1651df07810ae430a6b06576e0b414"},
+    {file = "numpy-1.19.4-cp39-cp39-manylinux2010_i686.whl", hash = "sha256:50e86c076611212ca62e5a59f518edafe0c0730f7d9195fec718da1a5c2bb1fc"},
+    {file = "numpy-1.19.4-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:f0d3929fe88ee1c155129ecd82f981b8856c5d97bcb0d5f23e9b4242e79d1de3"},
+    {file = "numpy-1.19.4-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:c42c4b73121caf0ed6cd795512c9c09c52a7287b04d105d112068c1736d7c753"},
+    {file = "numpy-1.19.4-cp39-cp39-win32.whl", hash = "sha256:8cac8790a6b1ddf88640a9267ee67b1aee7a57dfa2d2dd33999d080bc8ee3a0f"},
+    {file = "numpy-1.19.4-cp39-cp39-win_amd64.whl", hash = "sha256:4377e10b874e653fe96985c05feed2225c912e328c8a26541f7fc600fb9c637b"},
+    {file = "numpy-1.19.4-pp36-pypy36_pp73-manylinux2010_x86_64.whl", hash = "sha256:2a2740aa9733d2e5b2dfb33639d98a64c3b0f24765fed86b0fd2aec07f6a0a08"},
+    {file = "numpy-1.19.4.zip", hash = "sha256:141ec3a3300ab89c7f2b0775289954d193cc8edb621ea05f99db9cb181530512"},
 ]
 packaging = [
     {file = "packaging-20.4-py2.py3-none-any.whl", hash = "sha256:998416ba6962ae7fbd6596850b80e17859a5753ba17c32284f67bfff33784181"},
@@ -1482,8 +1482,8 @@ parsimonious = [
     {file = "parsimonious-0.8.1.tar.gz", hash = "sha256:3add338892d580e0cb3b1a39e4a1b427ff9f687858fdd61097053742391a9f6b"},
 ]
 pathspec = [
-    {file = "pathspec-0.8.0-py2.py3-none-any.whl", hash = "sha256:7d91249d21749788d07a2d0f94147accd8f845507400749ea19c1ec9054a12b0"},
-    {file = "pathspec-0.8.0.tar.gz", hash = "sha256:da45173eb3a6f2a5a487efba21f050af2b41948be6ab52b6a1e3ff22bb8b7061"},
+    {file = "pathspec-0.8.1-py2.py3-none-any.whl", hash = "sha256:aa0cb481c4041bf52ffa7b0d8fa6cd3e88a2ca4879c533c9153882ee2556790d"},
+    {file = "pathspec-0.8.1.tar.gz", hash = "sha256:86379d6b86d75816baba717e64b1a3a3469deb93bb76d613c9ce79edc5cb68fd"},
 ]
 pefile = [
     {file = "pefile-2019.4.18.tar.gz", hash = "sha256:a5d6e8305c6b210849b47a6174ddf9c452b2888340b8177874b862ba6c207645"},
@@ -1555,8 +1555,8 @@ py = [
     {file = "py-1.9.0.tar.gz", hash = "sha256:9ca6883ce56b4e8da7e79ac18787889fa5206c79dcc67fb065376cd2fe03f342"},
 ]
 pyfakefs = [
-    {file = "pyfakefs-4.1.0-py3-none-any.whl", hash = "sha256:1eae36f920e54a7f9f50789f21ab77ceb481ef697bec66de6495ecdf5db44f0f"},
-    {file = "pyfakefs-4.1.0.tar.gz", hash = "sha256:bbbaa8b622fa50751a5839350fff3c1f8b1bbd364cd40fd0c7442e18fe5edc8e"},
+    {file = "pyfakefs-4.2.1-py3-none-any.whl", hash = "sha256:2b1bf60ebbbaa3bf8c4c263576ec38e69368bdce4e6d7dbdbe136999f24ece6d"},
+    {file = "pyfakefs-4.2.1.tar.gz", hash = "sha256:0aad5ac8cb671f296a497a83a4672b54ee2fc0acb947a51198ca10a3b656100f"},
 ]
 pygments = [
     {file = "Pygments-2.7.2-py3-none-any.whl", hash = "sha256:88a0bbcd659fcb9573703957c6b9cff9fab7295e6e76db54c9d00ae42df32773"},
@@ -1596,8 +1596,8 @@ python-dateutil = [
     {file = "python_dateutil-2.8.1-py2.py3-none-any.whl", hash = "sha256:75bb3f31ea686f1197762692a9ee6a7550b59fc6ca3a1f4b5d7e32fb98e2da2a"},
 ]
 pytz = [
-    {file = "pytz-2020.1-py2.py3-none-any.whl", hash = "sha256:a494d53b6d39c3c6e44c3bec237336e14305e4f29bbf800b599253057fbb79ed"},
-    {file = "pytz-2020.1.tar.gz", hash = "sha256:c35965d010ce31b23eeb663ed3cc8c906275d6be1a34393a1d73a41febf4a048"},
+    {file = "pytz-2020.4-py2.py3-none-any.whl", hash = "sha256:5c55e189b682d420be27c6995ba6edce0c0a77dd67bfbe2ae6607134d5851ffd"},
+    {file = "pytz-2020.4.tar.gz", hash = "sha256:3e6b7dd2d1e0a59084bcee14a17af60c5c562cdc16d828e8eba2e683d3a7e268"},
 ]
 pywin32 = [
     {file = "pywin32-227-cp27-cp27m-win32.whl", hash = "sha256:371fcc39416d736401f0274dd64c2302728c9e034808e37381b5e1b22be4a6b0"},
@@ -1676,8 +1676,8 @@ sodapy = [
     {file = "sodapy-2.1.0.tar.gz", hash = "sha256:44e701efc16600d2b3b24b56b6e1d3a0e55567909b9ac84af8f9d1eb4870dc0f"},
 ]
 sphinx = [
-    {file = "Sphinx-3.2.1-py3-none-any.whl", hash = "sha256:ce6fd7ff5b215af39e2fcd44d4a321f6694b4530b6f2b2109b64d120773faea0"},
-    {file = "Sphinx-3.2.1.tar.gz", hash = "sha256:321d6d9b16fa381a5306e5a0b76cd48ffbc588e6340059a729c6fdd66087e0e8"},
+    {file = "Sphinx-3.3.0-py3-none-any.whl", hash = "sha256:3abdb2c57a65afaaa4f8573cbabd5465078eb6fd282c1e4f87f006875a7ec0c7"},
+    {file = "Sphinx-3.3.0.tar.gz", hash = "sha256:1c21e7c5481a31b531e6cbf59c3292852ccde175b504b00ce2ff0b8f4adc3649"},
 ]
 sphinx-rtd-theme = [
     {file = "sphinx_rtd_theme-0.5.0-py2.py3-none-any.whl", hash = "sha256:373413d0f82425aaa28fb288009bf0d0964711d347763af2f1b65cafcb028c82"},
@@ -1752,8 +1752,8 @@ tabulate = [
     {file = "tabulate-0.8.7.tar.gz", hash = "sha256:db2723a20d04bcda8522165c73eea7c300eda74e0ce852d9022e0159d7895007"},
 ]
 toml = [
-    {file = "toml-0.10.1-py2.py3-none-any.whl", hash = "sha256:bda89d5935c2eac546d648028b9901107a595863cb36bae0c73ac804a9b4ce88"},
-    {file = "toml-0.10.1.tar.gz", hash = "sha256:926b612be1e5ce0634a2ca03470f95169cf16f939018233a670519cb4ac58b0f"},
+    {file = "toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"},
+    {file = "toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"},
 ]
 tqdm = [
     {file = "tqdm-4.51.0-py2.py3-none-any.whl", hash = "sha256:9ad44aaf0fc3697c06f6e05c7cf025dd66bc7bcb7613c66d85f4464c47ac8fad"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -331,8 +331,8 @@ description = "Read resources from Python packages"
 marker = "python_version < \"3.7\""
 name = "importlib-resources"
 optional = false
-python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
-version = "3.2.0"
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,>=2.7"
+version = "3.3.0"
 
 [package.dependencies]
 [package.dependencies.zipp]
@@ -504,7 +504,7 @@ description = "NumPy is the fundamental package for array computing with Python.
 name = "numpy"
 optional = true
 python-versions = ">=3.6"
-version = "1.19.2"
+version = "1.19.3"
 
 [[package]]
 category = "main"
@@ -698,7 +698,7 @@ description = "Community maintained hooks for PyInstaller"
 name = "pyinstaller-hooks-contrib"
 optional = false
 python-versions = "*"
-version = "2020.9"
+version = "2020.10"
 
 [[package]]
 category = "dev"
@@ -737,7 +737,7 @@ description = "pytest: simple powerful testing with Python"
 name = "pytest"
 optional = false
 python-versions = ">=3.5"
-version = "6.1.1"
+version = "6.1.2"
 
 [package.dependencies]
 atomicwrites = ">=1.0"
@@ -834,7 +834,7 @@ description = "Alternative regular expression module, to replace re."
 name = "regex"
 optional = false
 python-versions = "*"
-version = "2020.10.23"
+version = "2020.10.28"
 
 [[package]]
 category = "main"
@@ -1295,8 +1295,8 @@ importlib-metadata = [
     {file = "importlib_metadata-2.0.0.tar.gz", hash = "sha256:77a540690e24b0305878c37ffd421785a6f7e53c8b5720d211b211de8d0e95da"},
 ]
 importlib-resources = [
-    {file = "importlib_resources-3.2.0-py2.py3-none-any.whl", hash = "sha256:8edc04db69df82b68f6d63925b368ef4d45c3c101e2c3fc418945bab395016ea"},
-    {file = "importlib_resources-3.2.0.tar.gz", hash = "sha256:3a06ef514291bec1cc89c905380b17a59c0381bc536500f322b56404f7a86ef6"},
+    {file = "importlib_resources-3.3.0-py2.py3-none-any.whl", hash = "sha256:a3d34a8464ce1d5d7c92b0ea4e921e696d86f2aa212e684451cb1482c8d84ed5"},
+    {file = "importlib_resources-3.3.0.tar.gz", hash = "sha256:7b51f0106c8ec564b1bef3d9c588bc694ce2b92125bbb6278f4f2f5b54ec3592"},
 ]
 inflection = [
     {file = "inflection-0.5.1-py2.py3-none-any.whl", hash = "sha256:f38b2b640938a4f35ade69ac3d053042959b62a0f1076a5bbaa1b9526605a8a2"},
@@ -1418,32 +1418,40 @@ nodeenv = [
     {file = "nodeenv-1.5.0.tar.gz", hash = "sha256:ab45090ae383b716c4ef89e690c41ff8c2b257b85b309f01f3654df3d084bd7c"},
 ]
 numpy = [
-    {file = "numpy-1.19.2-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:b594f76771bc7fc8a044c5ba303427ee67c17a09b36e1fa32bde82f5c419d17a"},
-    {file = "numpy-1.19.2-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:e6ddbdc5113628f15de7e4911c02aed74a4ccff531842c583e5032f6e5a179bd"},
-    {file = "numpy-1.19.2-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:3733640466733441295b0d6d3dcbf8e1ffa7e897d4d82903169529fd3386919a"},
-    {file = "numpy-1.19.2-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:4339741994c775396e1a274dba3609c69ab0f16056c1077f18979bec2a2c2e6e"},
-    {file = "numpy-1.19.2-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:7c6646314291d8f5ea900a7ea9c4261f834b5b62159ba2abe3836f4fa6705526"},
-    {file = "numpy-1.19.2-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:7118f0a9f2f617f921ec7d278d981244ba83c85eea197be7c5a4f84af80a9c3c"},
-    {file = "numpy-1.19.2-cp36-cp36m-win32.whl", hash = "sha256:9a3001248b9231ed73894c773142658bab914645261275f675d86c290c37f66d"},
-    {file = "numpy-1.19.2-cp36-cp36m-win_amd64.whl", hash = "sha256:967c92435f0b3ba37a4257c48b8715b76741410467e2bdb1097e8391fccfae15"},
-    {file = "numpy-1.19.2-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:d526fa58ae4aead839161535d59ea9565863bb0b0bdb3cc63214613fb16aced4"},
-    {file = "numpy-1.19.2-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:eb25c381d168daf351147713f49c626030dcff7a393d5caa62515d415a6071d8"},
-    {file = "numpy-1.19.2-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:62139af94728d22350a571b7c82795b9d59be77fc162414ada6c8b6a10ef5d02"},
-    {file = "numpy-1.19.2-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:0c66da1d202c52051625e55a249da35b31f65a81cb56e4c69af0dfb8fb0125bf"},
-    {file = "numpy-1.19.2-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:2117536e968abb7357d34d754e3733b0d7113d4c9f1d921f21a3d96dec5ff716"},
-    {file = "numpy-1.19.2-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:54045b198aebf41bf6bf4088012777c1d11703bf74461d70cd350c0af2182e45"},
-    {file = "numpy-1.19.2-cp37-cp37m-win32.whl", hash = "sha256:aba1d5daf1144b956bc87ffb87966791f5e9f3e1f6fab3d7f581db1f5b598f7a"},
-    {file = "numpy-1.19.2-cp37-cp37m-win_amd64.whl", hash = "sha256:addaa551b298052c16885fc70408d3848d4e2e7352de4e7a1e13e691abc734c1"},
-    {file = "numpy-1.19.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:58d66a6b3b55178a1f8a5fe98df26ace76260a70de694d99577ddeab7eaa9a9d"},
-    {file = "numpy-1.19.2-cp38-cp38-manylinux1_i686.whl", hash = "sha256:59f3d687faea7a4f7f93bd9665e5b102f32f3fa28514f15b126f099b7997203d"},
-    {file = "numpy-1.19.2-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:cebd4f4e64cfe87f2039e4725781f6326a61f095bc77b3716502bed812b385a9"},
-    {file = "numpy-1.19.2-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:c35a01777f81e7333bcf276b605f39c872e28295441c265cd0c860f4b40148c1"},
-    {file = "numpy-1.19.2-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:d7ac33585e1f09e7345aa902c281bd777fdb792432d27fca857f39b70e5dd31c"},
-    {file = "numpy-1.19.2-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:04c7d4ebc5ff93d9822075ddb1751ff392a4375e5885299445fcebf877f179d5"},
-    {file = "numpy-1.19.2-cp38-cp38-win32.whl", hash = "sha256:51ee93e1fac3fe08ef54ff1c7f329db64d8a9c5557e6c8e908be9497ac76374b"},
-    {file = "numpy-1.19.2-cp38-cp38-win_amd64.whl", hash = "sha256:1669ec8e42f169ff715a904c9b2105b6640f3f2a4c4c2cb4920ae8b2785dac65"},
-    {file = "numpy-1.19.2-pp36-pypy36_pp73-manylinux2010_x86_64.whl", hash = "sha256:0bfd85053d1e9f60234f28f63d4a5147ada7f432943c113a11afcf3e65d9d4c8"},
-    {file = "numpy-1.19.2.zip", hash = "sha256:0d310730e1e793527065ad7dde736197b705d0e4c9999775f212b03c44a8484c"},
+    {file = "numpy-1.19.3-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:942d2cdcb362739908c26ce8dd88db6e139d3fa829dd7452dd9ff02cba6b58b2"},
+    {file = "numpy-1.19.3-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:efd656893171bbf1331beca4ec9f2e74358fc732a2084f664fd149cc4b3441d2"},
+    {file = "numpy-1.19.3-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:1a307bdd3dd444b1d0daa356b5f4c7de2e24d63bdc33ea13ff718b8ec4c6a268"},
+    {file = "numpy-1.19.3-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:9d08d84bb4128abb9fbd9f073e5c69f70e5dab991a9c42e5b4081ea5b01b5db0"},
+    {file = "numpy-1.19.3-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:7197ee0a25629ed782c7bd01871ee40702ffeef35bc48004bc2fdcc71e29ba9d"},
+    {file = "numpy-1.19.3-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:8edc4d687a74d0a5f8b9b26532e860f4f85f56c400b3a98899fc44acb5e27add"},
+    {file = "numpy-1.19.3-cp36-cp36m-win32.whl", hash = "sha256:522053b731e11329dd52d258ddf7de5288cae7418b55e4b7d32f0b7e31787e9d"},
+    {file = "numpy-1.19.3-cp36-cp36m-win_amd64.whl", hash = "sha256:eefc13863bf01583a85e8c1121a901cc7cb8f059b960c4eba30901e2e6aba95f"},
+    {file = "numpy-1.19.3-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:6ff88bcf1872b79002569c63fe26cd2cda614e573c553c4d5b814fb5eb3d2822"},
+    {file = "numpy-1.19.3-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:e080087148fd70469aade2abfeadee194357defd759f9b59b349c6192aba994c"},
+    {file = "numpy-1.19.3-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:50f68ebc439821b826823a8da6caa79cd080dee2a6d5ab9f1163465a060495ed"},
+    {file = "numpy-1.19.3-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:b9074d062d30c2779d8af587924f178a539edde5285d961d2dfbecbac9c4c931"},
+    {file = "numpy-1.19.3-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:463792a249a81b9eb2b63676347f996d3f0082c2666fd0604f4180d2e5445996"},
+    {file = "numpy-1.19.3-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:ea6171d2d8d648dee717457d0f75db49ad8c2f13100680e284d7becf3dc311a6"},
+    {file = "numpy-1.19.3-cp37-cp37m-win32.whl", hash = "sha256:0ee77786eebbfa37f2141fd106b549d37c89207a0d01d8852fde1c82e9bfc0e7"},
+    {file = "numpy-1.19.3-cp37-cp37m-win_amd64.whl", hash = "sha256:271139653e8b7a046d11a78c0d33bafbddd5c443a5b9119618d0652a4eb3a09f"},
+    {file = "numpy-1.19.3-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:e983cbabe10a8989333684c98fdc5dd2f28b236216981e0c26ed359aaa676772"},
+    {file = "numpy-1.19.3-cp38-cp38-manylinux1_i686.whl", hash = "sha256:d78294f1c20f366cde8a75167f822538a7252b6e8b9d6dbfb3bdab34e7c1929e"},
+    {file = "numpy-1.19.3-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:199bebc296bd8a5fc31c16f256ac873dd4d5b4928dfd50e6c4995570fc71a8f3"},
+    {file = "numpy-1.19.3-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:dffed17848e8b968d8d3692604e61881aa6ef1f8074c99e81647ac84f6038535"},
+    {file = "numpy-1.19.3-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:5ea4401ada0d3988c263df85feb33818dc995abc85b8125f6ccb762009e7bc68"},
+    {file = "numpy-1.19.3-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:604d2e5a31482a3ad2c88206efd43d6fcf666ada1f3188fd779b4917e49b7a98"},
+    {file = "numpy-1.19.3-cp38-cp38-win32.whl", hash = "sha256:a2daea1cba83210c620e359de2861316f49cc7aea8e9a6979d6cb2ddab6dda8c"},
+    {file = "numpy-1.19.3-cp38-cp38-win_amd64.whl", hash = "sha256:dfdc8b53aa9838b9d44ed785431ca47aa3efaa51d0d5dd9c412ab5247151a7c4"},
+    {file = "numpy-1.19.3-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:9f7f56b5e85b08774939622b7d45a5d00ff511466522c44fc0756ac7692c00f2"},
+    {file = "numpy-1.19.3-cp39-cp39-manylinux1_i686.whl", hash = "sha256:8802d23e4895e0c65e418abe67cdf518aa5cbb976d97f42fd591f921d6dffad0"},
+    {file = "numpy-1.19.3-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:c4aa79993f5d856765819a3651117520e41ac3f89c3fc1cb6dee11aa562df6da"},
+    {file = "numpy-1.19.3-cp39-cp39-manylinux2010_i686.whl", hash = "sha256:51e8d2ae7c7e985c7bebf218e56f72fa93c900ad0c8a7d9fbbbf362f45710f69"},
+    {file = "numpy-1.19.3-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:50d3513469acf5b2c0406e822d3f314d7ac5788c2b438c24e5dd54d5a81ef522"},
+    {file = "numpy-1.19.3-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:741d95eb2b505bb7a99fbf4be05fa69f466e240c2b4f2d3ddead4f1b5f82a5a5"},
+    {file = "numpy-1.19.3-cp39-cp39-win32.whl", hash = "sha256:1ea7e859f16e72ab81ef20aae69216cfea870676347510da9244805ff9670170"},
+    {file = "numpy-1.19.3-cp39-cp39-win_amd64.whl", hash = "sha256:83af653bb92d1e248ccf5fdb05ccc934c14b936bcfe9b917dc180d3f00250ac6"},
+    {file = "numpy-1.19.3-pp36-pypy36_pp73-manylinux2010_x86_64.whl", hash = "sha256:9a0669787ba8c9d3bb5de5d9429208882fb47764aa79123af25c5edc4f5966b9"},
+    {file = "numpy-1.19.3.zip", hash = "sha256:35bf5316af8dc7c7db1ad45bec603e5fb28671beb98ebd1d65e8059efcfd3b72"},
 ]
 packaging = [
     {file = "packaging-20.4-py2.py3-none-any.whl", hash = "sha256:998416ba6962ae7fbd6596850b80e17859a5753ba17c32284f67bfff33784181"},
@@ -1558,8 +1566,8 @@ pyinstaller = [
     {file = "pyinstaller-4.0.tar.gz", hash = "sha256:970beb07115761d5e4ec317c1351b712fd90ae7f23994db914c633281f99bab0"},
 ]
 pyinstaller-hooks-contrib = [
-    {file = "pyinstaller-hooks-contrib-2020.9.tar.gz", hash = "sha256:a5fd45a920012802e3f2089e1d3501ef2f49265dfea8fc46c3310f18e3326c91"},
-    {file = "pyinstaller_hooks_contrib-2020.9-py2.py3-none-any.whl", hash = "sha256:c382f3ac1a42b45cfecd581475c36db77da90e479b2f5bcb6d840d21fa545114"},
+    {file = "pyinstaller-hooks-contrib-2020.10.tar.gz", hash = "sha256:bf4543a16c9c6e9dd2d70ea3fee78b81d3357a68f706df471d990213892259d9"},
+    {file = "pyinstaller_hooks_contrib-2020.10-py2.py3-none-any.whl", hash = "sha256:dd752c88c1c7bb6920f7de248c12d4411c0463877e5e64afdc4f7e93dff9fc94"},
 ]
 pylint = [
     {file = "pylint-2.6.0-py3-none-any.whl", hash = "sha256:bfe68f020f8a0fece830a22dd4d5dddb4ecc6137db04face4c3420a46a52239f"},
@@ -1573,8 +1581,8 @@ pyrsistent = [
     {file = "pyrsistent-0.17.3.tar.gz", hash = "sha256:2e636185d9eb976a18a8a8e96efce62f2905fea90041958d8cc2a189756ebf3e"},
 ]
 pytest = [
-    {file = "pytest-6.1.1-py3-none-any.whl", hash = "sha256:7a8190790c17d79a11f847fba0b004ee9a8122582ebff4729a082c109e81a4c9"},
-    {file = "pytest-6.1.1.tar.gz", hash = "sha256:8f593023c1a0f916110285b6efd7f99db07d59546e3d8c36fc60e2ab05d3be92"},
+    {file = "pytest-6.1.2-py3-none-any.whl", hash = "sha256:4288fed0d9153d9646bfcdf0c0428197dba1ecb27a33bb6e031d002fa88653fe"},
+    {file = "pytest-6.1.2.tar.gz", hash = "sha256:c0a7e94a8cdbc5422a51ccdad8e6f1024795939cc89159a0ae7f0b316ad3823e"},
 ]
 pytest-cov = [
     {file = "pytest-cov-2.10.1.tar.gz", hash = "sha256:47bd0ce14056fdd79f93e1713f88fad7bdcc583dcd7783da86ef2f085a0bb88e"},
@@ -1623,33 +1631,33 @@ pyyaml = [
     {file = "PyYAML-5.3.1.tar.gz", hash = "sha256:b8eac752c5e14d3eca0e6dd9199cd627518cb5ec06add0de9d32baeee6fe645d"},
 ]
 regex = [
-    {file = "regex-2020.10.23-cp27-cp27m-win32.whl", hash = "sha256:781906e45ef1d10a0ed9ec8ab83a09b5e0d742de70e627b20d61ccb1b1d3964d"},
-    {file = "regex-2020.10.23-cp27-cp27m-win_amd64.whl", hash = "sha256:8cd0d587aaac74194ad3e68029124c06245acaeddaae14cb45844e5c9bebeea4"},
-    {file = "regex-2020.10.23-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:af360e62a9790e0a96bc9ac845d87bfa0e4ee0ee68547ae8b5a9c1030517dbef"},
-    {file = "regex-2020.10.23-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:4e21340c07090ddc8c16deebfd82eb9c9e1ec5e62f57bb86194a2595fd7b46e0"},
-    {file = "regex-2020.10.23-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:e5f6aa56dda92472e9d6f7b1e6331f4e2d51a67caafff4d4c5121cadac03941e"},
-    {file = "regex-2020.10.23-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:c30d8766a055c22e39dd7e1a4f98f6266169f2de05db737efe509c2fb9c8a3c8"},
-    {file = "regex-2020.10.23-cp36-cp36m-win32.whl", hash = "sha256:1a065e7a6a1b4aa851a0efa1a2579eabc765246b8b3a5fd74000aaa3134b8b4e"},
-    {file = "regex-2020.10.23-cp36-cp36m-win_amd64.whl", hash = "sha256:c95d514093b80e5309bdca5dd99e51bcf82c44043b57c34594d9d7556bd04d05"},
-    {file = "regex-2020.10.23-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:f4b1c65ee86bfbf7d0c3dfd90592a9e3d6e9ecd36c367c884094c050d4c35d04"},
-    {file = "regex-2020.10.23-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:d62205f00f461fe8b24ade07499454a3b7adf3def1225e258b994e2215fd15c5"},
-    {file = "regex-2020.10.23-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:b706c70070eea03411b1761fff3a2675da28d042a1ab7d0863b3efe1faa125c9"},
-    {file = "regex-2020.10.23-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:d43cf21df524283daa80ecad551c306b7f52881c8d0fe4e3e76a96b626b6d8d8"},
-    {file = "regex-2020.10.23-cp37-cp37m-win32.whl", hash = "sha256:570e916a44a361d4e85f355aacd90e9113319c78ce3c2d098d2ddf9631b34505"},
-    {file = "regex-2020.10.23-cp37-cp37m-win_amd64.whl", hash = "sha256:1c447b0d108cddc69036b1b3910fac159f2b51fdeec7f13872e059b7bc932be1"},
-    {file = "regex-2020.10.23-cp38-cp38-manylinux1_i686.whl", hash = "sha256:8469377a437dbc31e480993399fd1fd15fe26f382dc04c51c9cb73e42965cc06"},
-    {file = "regex-2020.10.23-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:59d5c6302d22c16d59611a9fd53556554010db1d47e9df5df37be05007bebe75"},
-    {file = "regex-2020.10.23-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:a973d5a7a324e2a5230ad7c43f5e1383cac51ef4903bf274936a5634b724b531"},
-    {file = "regex-2020.10.23-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:97a023f97cddf00831ba04886d1596ef10f59b93df7f855856f037190936e868"},
-    {file = "regex-2020.10.23-cp38-cp38-win32.whl", hash = "sha256:e289a857dca3b35d3615c3a6a438622e20d1bf0abcb82c57d866c8d0be3f44c4"},
-    {file = "regex-2020.10.23-cp38-cp38-win_amd64.whl", hash = "sha256:0cb23ed0e327c18fb7eac61ebbb3180ebafed5b9b86ca2e15438201e5903b5dd"},
-    {file = "regex-2020.10.23-cp39-cp39-manylinux1_i686.whl", hash = "sha256:c53dc8ee3bb7b7e28ee9feb996a0c999137be6c1d3b02cb6b3c4cba4f9e5ed09"},
-    {file = "regex-2020.10.23-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:6a46eba253cedcbe8a6469f881f014f0a98819d99d341461630885139850e281"},
-    {file = "regex-2020.10.23-cp39-cp39-manylinux2010_i686.whl", hash = "sha256:240509721a663836b611fa13ca1843079fc52d0b91ef3f92d9bba8da12e768a0"},
-    {file = "regex-2020.10.23-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:6f567df0601e9c7434958143aebea47a9c4b45434ea0ae0286a4ec19e9877169"},
-    {file = "regex-2020.10.23-cp39-cp39-win32.whl", hash = "sha256:bfd7a9fddd11d116a58b62ee6c502fd24cfe22a4792261f258f886aa41c2a899"},
-    {file = "regex-2020.10.23-cp39-cp39-win_amd64.whl", hash = "sha256:1a511470db3aa97432ac8c1bf014fcc6c9fbfd0f4b1313024d342549cf86bcd6"},
-    {file = "regex-2020.10.23.tar.gz", hash = "sha256:2278453c6a76280b38855a263198961938108ea2333ee145c5168c36b8e2b376"},
+    {file = "regex-2020.10.28-cp27-cp27m-win32.whl", hash = "sha256:4b5a9bcb56cc146c3932c648603b24514447eafa6ce9295234767bf92f69b504"},
+    {file = "regex-2020.10.28-cp27-cp27m-win_amd64.whl", hash = "sha256:c13d311a4c4a8d671f5860317eb5f09591fbe8259676b86a85769423b544451e"},
+    {file = "regex-2020.10.28-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:c8a2b7ccff330ae4c460aff36626f911f918555660cc28163417cb84ffb25789"},
+    {file = "regex-2020.10.28-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:4afa350f162551cf402bfa3cd8302165c8e03e689c897d185f16a167328cc6dd"},
+    {file = "regex-2020.10.28-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:b88fa3b8a3469f22b4f13d045d9bd3eda797aa4e406fde0a2644bc92bbdd4bdd"},
+    {file = "regex-2020.10.28-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:f43109822df2d3faac7aad79613f5f02e4eab0fc8ad7932d2e70e2a83bd49c26"},
+    {file = "regex-2020.10.28-cp36-cp36m-win32.whl", hash = "sha256:8092a5a06ad9a7a247f2a76ace121183dc4e1a84c259cf9c2ce3bbb69fac3582"},
+    {file = "regex-2020.10.28-cp36-cp36m-win_amd64.whl", hash = "sha256:49461446b783945597c4076aea3f49aee4b4ce922bd241e4fcf62a3e7c61794c"},
+    {file = "regex-2020.10.28-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:8ca9dca965bd86ea3631b975d63b0693566d3cc347e55786d5514988b6f5b84c"},
+    {file = "regex-2020.10.28-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:ea37320877d56a7f0a1e6a625d892cf963aa7f570013499f5b8d5ab8402b5625"},
+    {file = "regex-2020.10.28-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:3a5f08039eee9ea195a89e180c5762bfb55258bfb9abb61a20d3abee3b37fd12"},
+    {file = "regex-2020.10.28-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:cb905f3d2e290a8b8f1579d3984f2cfa7c3a29cc7cba608540ceeed18513f520"},
+    {file = "regex-2020.10.28-cp37-cp37m-win32.whl", hash = "sha256:a62162be05edf64f819925ea88d09d18b09bebf20971b363ce0c24e8b4aa14c0"},
+    {file = "regex-2020.10.28-cp37-cp37m-win_amd64.whl", hash = "sha256:03855ee22980c3e4863dc84c42d6d2901133362db5daf4c36b710dd895d78f0a"},
+    {file = "regex-2020.10.28-cp38-cp38-manylinux1_i686.whl", hash = "sha256:625116aca6c4b57c56ea3d70369cacc4d62fead4930f8329d242e4fe7a58ce4b"},
+    {file = "regex-2020.10.28-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:2dc522e25e57e88b4980d2bdd334825dbf6fa55f28a922fc3bfa60cc09e5ef53"},
+    {file = "regex-2020.10.28-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:119e0355dbdd4cf593b17f2fc5dbd4aec2b8899d0057e4957ba92f941f704bf5"},
+    {file = "regex-2020.10.28-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:cfcf28ed4ce9ced47b9b9670a4f0d3d3c0e4d4779ad4dadb1ad468b097f808aa"},
+    {file = "regex-2020.10.28-cp38-cp38-win32.whl", hash = "sha256:06b52815d4ad38d6524666e0d50fe9173533c9cc145a5779b89733284e6f688f"},
+    {file = "regex-2020.10.28-cp38-cp38-win_amd64.whl", hash = "sha256:c3466a84fce42c2016113101018a9981804097bacbab029c2d5b4fcb224b89de"},
+    {file = "regex-2020.10.28-cp39-cp39-manylinux1_i686.whl", hash = "sha256:c2c6c56ee97485a127555c9595c069201b5161de9d05495fbe2132b5ac104786"},
+    {file = "regex-2020.10.28-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:1ec66700a10e3c75f1f92cbde36cca0d3aaee4c73dfa26699495a3a30b09093c"},
+    {file = "regex-2020.10.28-cp39-cp39-manylinux2010_i686.whl", hash = "sha256:11116d424734fe356d8777f89d625f0df783251ada95d6261b4c36ad27a394bb"},
+    {file = "regex-2020.10.28-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:f1fce1e4929157b2afeb4bb7069204d4370bab9f4fc03ca1fbec8bd601f8c87d"},
+    {file = "regex-2020.10.28-cp39-cp39-win32.whl", hash = "sha256:832339223b9ce56b7b15168e691ae654d345ac1635eeb367ade9ecfe0e66bee0"},
+    {file = "regex-2020.10.28-cp39-cp39-win_amd64.whl", hash = "sha256:654c1635f2313d0843028487db2191530bca45af61ca85d0b16555c399625b0e"},
+    {file = "regex-2020.10.28.tar.gz", hash = "sha256:dd3e6547ecf842a29cf25123fbf8d2461c53c8d37aa20d87ecee130c89b7079b"},
 ]
 requests = [
     {file = "requests-2.24.0-py2.py3-none-any.whl", hash = "sha256:fe75cc94a9443b9246fc7049224f75604b113c36acb93f87b80ed42c44cbb898"},

--- a/splitgraph/commandline/__init__.py
+++ b/splitgraph/commandline/__init__.py
@@ -40,7 +40,7 @@ from splitgraph.commandline.misc import (
 from splitgraph.commandline.mount import mount_c
 from splitgraph.commandline.push_pull import pull_c, clone_c, push_c, upstream_c
 from splitgraph.commandline.splitfile import build_c, provenance_c, rebuild_c, dependents_c
-from splitgraph.ingestion.singer import singer_group
+from splitgraph.ingestion.singer.commandline import singer_group
 
 logger = logging.getLogger()
 

--- a/splitgraph/config/config.py
+++ b/splitgraph/config/config.py
@@ -147,7 +147,7 @@ def get_singleton(config: ConfigDict, item: str) -> str:
 
 def get_all_in_section(config: ConfigDict, section: str) -> Dict[str, Union[str, Dict[str, str]]]:
     """
-    Get all subsections from a config (e.g. config["mount_handlers"])
+    Get all subsections from a config (e.g. config["data_sources"])
     """
     result: Dict[str, Union[str, Dict[str, str]]] = cast(
         Dict[str, Union[str, Dict[str, str]]], config.get(section, {})

--- a/splitgraph/config/config_file_config.py
+++ b/splitgraph/config/config_file_config.py
@@ -144,10 +144,10 @@ def get_config_dict_from_file(sg_file: str, **kwargs) -> Dict[str, Dict[str, str
     config_dict = {s: dict(config.items(s, False)) for s in config.sections()}
 
     # Fix certain sections to have lower case by convention
-    if "mount_handlers" in config_dict:
-        handlers = config_dict["mount_handlers"]
+    if "data_sources" in config_dict:
+        handlers = config_dict["data_sources"]
         assert isinstance(handlers, dict)
-        config_dict["mount_handlers"] = cast(
+        config_dict["data_sources"] = cast(
             Dict[str, str], {k.lower(): v for k, v in handlers.items()}
         )
 

--- a/splitgraph/config/export.py
+++ b/splitgraph/config/export.py
@@ -74,10 +74,10 @@ def serialize_config(
         for command_name, command_class in get_all_in_section(config, "commands").items():
             result += _kv_to_str(command_name, cast(str, command_class), no_shielding) + "\n"
 
-    # Print mount handlers
-    if "mount_handlers" in config:
-        result += "\nFDW Mount handlers:\n" if not config_format else "[mount_handlers]\n"
-        for handler_name, handler_func in get_all_in_section(config, "mount_handlers").items():
+    # Print data sources
+    if "data_sources" in config:
+        result += "\nData sources:\n" if not config_format else "[data_sources]\n"
+        for handler_name, handler_func in get_all_in_section(config, "data_sources").items():
             result += _kv_to_str(handler_name, cast(str, handler_func), no_shielding) + "\n"
 
     # Print external object handlers

--- a/splitgraph/config/keys.py
+++ b/splitgraph/config/keys.py
@@ -165,4 +165,5 @@ This can also be changed by passing `--verbosity` to `sgr`, e.g. `sgr --verbosit
     "SG_UPDATE_FREQUENCY": "How often to check for updates when sgr is run, in seconds. Set to 0 to disable.",
     "SG_UPDATE_LAST": "Last timestamp an update check was performed. Internal.",
     "SG_UPDATE_ANONYMOUS": "Set to `true` to disable sending the user's ID to the update checker.",
+    "SG_PLUGIN_DIR": "Extra directory to look for plugins in. Each subdirectory must have a plugin.py file with a top-level __plugin__ variable pointing at the plugin class",
 }

--- a/splitgraph/config/keys.py
+++ b/splitgraph/config/keys.py
@@ -56,7 +56,7 @@ DEFAULTS: ConfigDict = {
     "SG_UPDATE_ANONYMOUS": "false",
     # Some default sections: these can't be overridden via envvars.
     "external_handlers": {"S3": "splitgraph.hooks.s3.S3ExternalObjectHandler"},
-    "mount_handlers": {
+    "data_sources": {
         "postgres_fdw": "splitgraph.hooks.data_source.PostgreSQLDataSource",
         "mongo_fdw": "splitgraph.hooks.data_source.MongoDataSource",
         "mysql_fdw": "splitgraph.hooks.data_source.MySQLDataSource",
@@ -66,7 +66,7 @@ DEFAULTS: ConfigDict = {
 }
 
 ALL_KEYS = list(DEFAULTS.keys())
-KEYS = [k for k in ALL_KEYS if k not in ["remotes", "external_handlers", "mount_handlers"]]
+KEYS = [k for k in ALL_KEYS if k not in ["remotes", "external_handlers", "data_sources"]]
 # Keys whose contents we don't print fully
 SENSITIVE_KEY_SUFFIXES = ["_PWD", "_TOKEN"]
 

--- a/splitgraph/config/keys.py
+++ b/splitgraph/config/keys.py
@@ -54,6 +54,7 @@ DEFAULTS: ConfigDict = {
     "SG_UPDATE_FREQUENCY": "86400",
     "SG_UPDATE_LAST": "0",
     "SG_UPDATE_ANONYMOUS": "false",
+    "SG_PLUGIN_DIR": "",
     # Some default sections: these can't be overridden via envvars.
     "external_handlers": {"S3": "splitgraph.hooks.s3.S3ExternalObjectHandler"},
     "data_sources": {

--- a/splitgraph/core/image.py
+++ b/splitgraph/core/image.py
@@ -31,7 +31,6 @@ from .common import set_tag, manage_audit, set_head
 from .sql import select, prepare_splitfile_sql, POSTGRES_MAX_IDENTIFIER
 from .table import Table
 from .types import TableColumn, ProvenanceLine
-from ..hooks.data_source.fdw import init_fdw
 
 if TYPE_CHECKING:
     from .repository import Repository
@@ -175,6 +174,10 @@ class Image(NamedTuple):
         # assumes that we got to the point in the normal checkout where we're about to materialize the tables
         # (e.g. the schemata are cleared)
         # Use a per-schema "foreign server" for layered queries for now
+
+        # Circular import
+        from splitgraph.hooks.data_source.fdw import init_fdw
+
         target_schema = target_schema or self.repository.to_schema()
         server_id = "%s_lq_checkout_server" % target_schema
         engine = self.repository.engine

--- a/splitgraph/core/image.py
+++ b/splitgraph/core/image.py
@@ -5,7 +5,6 @@ from contextlib import contextmanager
 from datetime import datetime
 from random import getrandbits
 from typing import (
-    Any,
     Dict,
     Iterator,
     List,
@@ -28,11 +27,11 @@ from splitgraph.config import (
 )
 from splitgraph.engine import ResultShape
 from splitgraph.exceptions import SplitGraphError, TableNotFoundError
-from ..hooks.data_source import init_fdw
 from .common import set_tag, manage_audit, set_head
 from .sql import select, prepare_splitfile_sql, POSTGRES_MAX_IDENTIFIER
 from .table import Table
 from .types import TableColumn, ProvenanceLine
+from ..hooks.data_source.fdw import init_fdw
 
 if TYPE_CHECKING:
     from .repository import Repository

--- a/splitgraph/core/metadata_manager.py
+++ b/splitgraph/core/metadata_manager.py
@@ -122,7 +122,7 @@ class MetadataManager:
         repository: "Repository",
         image_hash: str,
         table_name: str,
-        table_schema: str,
+        table_schema: TableSchema,
         objects: List[str],
     ):
         self.metadata_engine.run_sql(

--- a/splitgraph/core/table.py
+++ b/splitgraph/core/table.py
@@ -33,7 +33,6 @@ from splitgraph.core.types import TableSchema, Quals
 from splitgraph.engine import ResultShape
 from splitgraph.engine.postgres.engine import get_change_key
 from splitgraph.exceptions import ObjectIndexingError
-from splitgraph.hooks.data_source.fdw import create_foreign_table
 
 if TYPE_CHECKING:
     from splitgraph.core.image import Image
@@ -281,6 +280,9 @@ class Table:
         :param destination_schema: Name of the destination schema.
         :param lq_server: If set, sets up a layered querying FDW for the table instead using this foreign server.
         """
+        # Circular import
+        from splitgraph.hooks.data_source.fdw import create_foreign_table
+
         destination_schema = destination_schema or self.repository.to_schema()
         engine = self.repository.object_engine
         object_manager = self.repository.objects

--- a/splitgraph/core/table.py
+++ b/splitgraph/core/table.py
@@ -33,7 +33,7 @@ from splitgraph.core.types import TableSchema, Quals
 from splitgraph.engine import ResultShape
 from splitgraph.engine.postgres.engine import get_change_key
 from splitgraph.exceptions import ObjectIndexingError
-from splitgraph.hooks.data_source import create_foreign_table
+from splitgraph.hooks.data_source.fdw import create_foreign_table
 
 if TYPE_CHECKING:
     from splitgraph.core.image import Image

--- a/splitgraph/exceptions.py
+++ b/splitgraph/exceptions.py
@@ -57,7 +57,7 @@ class ExternalHandlerError(SplitGraphError):
     """Exceptions raised by external object handlers."""
 
 
-class MountHandlerError(SplitGraphError):
+class DataSourceError(SplitGraphError):
     """Exceptions raised by mount handlers."""
 
 

--- a/splitgraph/hooks/__init__.py
+++ b/splitgraph/hooks/__init__.py
@@ -3,8 +3,8 @@ Various hooks for extending Splitgraph, including:
 
   * External object handlers (:mod:`splitgraph.hooks.external_objects`) allowing to download/upload objects
     to locations other than the remote Splitgraph engine.
-  * FDW handlers (:mod:`splitgraph.hooks.mount_handlers`) that allow to use the Postgres engine's FDW interface
-    to mount other external databases on the engine.
+  * Data sources (:mod:`splitgraph.hooks.data_sources`) that allow to add data to Splitgraph, e.g.
+   using the Postgres engine's FDW interface to mount other external databases on the engine.
   * Splitfile commands (:mod:`splitgraph.hooks.splitfile_commands`) to define custom data transformation steps
     compatible with the Splitfile framework.
 """

--- a/splitgraph/hooks/data_source/__init__.py
+++ b/splitgraph/hooks/data_source/__init__.py
@@ -2,7 +2,7 @@ import logging
 import os
 import types
 from importlib import import_module
-from typing import Dict, Type, List, Any
+from typing import Dict, Type, List
 
 from .base import DataSource
 from .fdw import PostgreSQLDataSource, MongoDataSource, ElasticSearchDataSource, MySQLDataSource
@@ -55,12 +55,14 @@ def _register_default_data_sources() -> None:
             raise DataSourceError("Error loading custom data source {0}".format(source_name)) from e
 
     # Load data sources from the additional path
+    _register_plugin_dir_data_sources()
+
+
+def _register_plugin_dir_data_sources():
     plugin_dir = get_singleton(CONFIG, "SG_PLUGIN_DIR")
     if not plugin_dir:
         return
-
     logging.debug("Looking up plugins in %s", plugin_dir)
-
     for plugin in os.listdir(plugin_dir):
         plugin_file = os.path.join(plugin_dir, plugin, "plugin.py")
         if os.path.exists(plugin_file):

--- a/splitgraph/hooks/data_source/__init__.py
+++ b/splitgraph/hooks/data_source/__init__.py
@@ -1,0 +1,93 @@
+import logging
+import types
+from importlib import import_module
+from typing import Dict, Type, List
+
+from .base import DataSource
+from .fdw import PostgreSQLDataSource, MongoDataSource, ElasticSearchDataSource, MySQLDataSource
+from ...config import CONFIG, get_singleton
+from ...config.config import get_all_in_section
+from ...config.keys import DEFAULTS
+from ...exceptions import DataSourceError
+
+_DATA_SOURCES: Dict[str, Type[DataSource]] = {}
+
+
+def get_data_source(data_source: str) -> Type[DataSource]:
+    """Returns a class for a given data source"""
+    try:
+        return _DATA_SOURCES[data_source]
+    except KeyError:
+        raise DataSourceError("Data source %s not supported!" % data_source)
+
+
+def get_data_sources() -> List[str]:
+    """Returns the names of all registered data sources."""
+    return list(_DATA_SOURCES.keys())
+
+
+def register_data_source(name: str, data_source_class: Type[DataSource]) -> None:
+    """Returns a data source under a given name."""
+    global _DATA_SOURCES
+    _DATA_SOURCES[name] = data_source_class
+
+
+def _register_default_data_sources() -> None:
+    # Register the data sources from the config.
+    for source_name, source_class_name in get_all_in_section(CONFIG, "data_sources").items():
+        assert isinstance(source_class_name, str)
+
+        try:
+            data_source = _load_source(source_name, source_class_name)
+
+            assert issubclass(data_source, DataSource)
+            register_data_source(source_name.lower(), data_source)
+        except (ImportError, AttributeError) as e:
+            raise DataSourceError("Error loading custom data source {0}".format(source_name)) from e
+
+
+def _load_source(source_name, source_class_name):
+    # Hack for old-style data sources that have now been moved -- don't crash and instead
+    # replace them in the config on the fly
+    source_defaults = get_all_in_section(DEFAULTS, "data_sources")
+
+    fallback_used = False
+
+    try:
+        ix = source_class_name.rindex(".")
+        data_source = getattr(import_module(source_class_name[:ix]), source_class_name[ix + 1 :])
+    except (ImportError, AttributeError):
+        if source_name not in source_defaults:
+            raise
+        source_class_name = source_defaults[source_name]
+        ix = source_class_name.rindex(".")
+        data_source = getattr(import_module(source_class_name[:ix]), source_class_name[ix + 1 :])
+        fallback_used = True
+
+    if isinstance(data_source, types.FunctionType):
+        if source_name not in source_defaults:
+            raise DataSourceError(
+                "Handler %s uses the old-style function interface which is not"
+                " compatible with this version of Splitgraph. "
+                "Delete it from your .sgconfig's [data_sources] section (%s)"
+                % (source_name, get_singleton(CONFIG, "SG_CONFIG_FILE"))
+            )
+        source_class_name = source_defaults[source_name]
+        ix = source_class_name.rindex(".")
+        data_source = getattr(import_module(source_class_name[:ix]), source_class_name[ix + 1 :])
+        fallback_used = True
+    if fallback_used:
+        logging.warning(
+            "Data source %s uses the old-style function interface and was automatically replaced.",
+            source_name,
+        )
+        logging.warning(
+            "Replace it with %s=%s in your .sgconfig's [data_sources] section (%s)",
+            source_name,
+            source_class_name,
+            get_singleton(CONFIG, "SG_CONFIG_FILE"),
+        )
+    return data_source
+
+
+_register_default_data_sources()

--- a/splitgraph/hooks/data_source/base.py
+++ b/splitgraph/hooks/data_source/base.py
@@ -36,6 +36,16 @@ class DataSource(ABC):
     supports_sync = False
     supports_load = False
 
+    @classmethod
+    @abstractmethod
+    def get_name(cls) -> str:
+        pass
+
+    @classmethod
+    @abstractmethod
+    def get_description(cls) -> str:
+        pass
+
     def __init__(self, engine: "PostgresEngine", credentials: Credentials, params: Params):
         import jsonschema
 

--- a/splitgraph/hooks/data_source/base.py
+++ b/splitgraph/hooks/data_source/base.py
@@ -1,0 +1,66 @@
+from abc import ABC, abstractmethod
+from typing import Dict, Any, Union, List, Optional, TYPE_CHECKING, cast
+
+from splitgraph.core.repository import Repository
+from splitgraph.core.types import TableSchema
+if TYPE_CHECKING:
+    from splitgraph.engine.postgres.engine import PostgresEngine
+    from splitgraph.core.repository import Repository
+
+Credentials = Dict[str, Any]
+Params = Dict[str, Any]
+TableInfo = Union[List[str], Dict[str, TableSchema]]
+SyncState = Dict[str, Any]
+
+
+class DataSource(ABC):
+    params_schema: Dict[str, Any]
+    credentials_schema: Dict[str, Any]
+
+    supports_mount = False
+    supports_sync = False
+    supports_load = False
+
+    def __init__(self, engine: "PostgresEngine", credentials: Credentials, params: Params):
+        import jsonschema
+
+        self.engine = engine
+
+        jsonschema.validate(instance=credentials, schema=self.credentials_schema)
+        jsonschema.validate(instance=params, schema=self.params_schema)
+
+        self.credentials = credentials
+        self.params = params
+
+    @abstractmethod
+    def introspect(self) -> Dict[str, TableSchema]:
+        pass
+
+    def mount(
+        self,
+        schema: str,
+        tables: Optional[TableInfo] = None,
+        overwrite: bool = True,
+    ):
+        """Instantiate the data source as foreign tables in a schema"""
+        raise NotImplemented
+
+    def _sync(
+        self, schema: str, state: Optional[SyncState] = None, tables: Optional[TableInfo] = None
+    ) -> SyncState:
+        """Incremental load"""
+        raise NotImplemented
+
+    def sync(self, repository: Repository, image_hash: Optional[str]):
+        # load "state" from the image
+        # checkout the repo
+        # pass state to sync
+        # commit the repo
+        # override with singer
+        pass
+
+    def load(self, schema: str, tables: Optional[TableInfo] = None):
+        if self.supports_sync:
+            self._sync(schema, tables=tables)
+
+        raise NotImplemented

--- a/splitgraph/hooks/data_source/base.py
+++ b/splitgraph/hooks/data_source/base.py
@@ -18,6 +18,7 @@ Credentials = Dict[str, Any]
 Params = Dict[str, Any]
 TableInfo = Union[List[str], Dict[str, TableSchema]]
 SyncState = Dict[str, Any]
+PreviewResult = Dict[str, Union[str, List[Dict[str, Any]]]]
 
 
 INGESTION_STATE_TABLE = "_sg_ingestion_state"

--- a/splitgraph/hooks/data_source/base.py
+++ b/splitgraph/hooks/data_source/base.py
@@ -1,3 +1,4 @@
+import json
 from abc import ABC, abstractmethod
 from random import getrandbits
 from typing import Dict, Any, Union, List, Optional, TYPE_CHECKING, cast, Tuple
@@ -131,6 +132,10 @@ def get_ingestion_state(repository, image_hash) -> Optional[SyncState]:
                     ),
                     return_shape=ResultShape.ONE_ONE,
                 )
+                # TODO sometimes (some weird psycopg2 adapter interaction?)
+                #   this is not loaded as JSON immediately?
+                if state:
+                    state = json.loads(state)
     return cast(SyncState, state)
 
 

--- a/splitgraph/hooks/data_source/base.py
+++ b/splitgraph/hooks/data_source/base.py
@@ -135,7 +135,7 @@ def get_ingestion_state(repository, image_hash) -> Optional[SyncState]:
 
 
 def prepare_new_image(
-    repository: Repository, hash_or_tag: Optional[str]
+    repository: "Repository", hash_or_tag: Optional[str]
 ) -> Tuple[Optional[Image], str]:
     new_image_hash = "{:064x}".format(getrandbits(256))
     if repository_exists(repository):

--- a/splitgraph/hooks/data_source/base.py
+++ b/splitgraph/hooks/data_source/base.py
@@ -1,4 +1,5 @@
 import json
+import logging
 from abc import ABC, abstractmethod
 from random import getrandbits
 from typing import Dict, Any, Union, List, Optional, TYPE_CHECKING, cast, Tuple
@@ -127,7 +128,7 @@ def get_ingestion_state(repository, image_hash) -> Optional[SyncState]:
         if INGESTION_STATE_TABLE in image.get_tables():
             with image.query_schema() as s:
                 state = repository.object_engine.run_sql(
-                    SQL("SELECT state FROM {}.{} LIMIT 1").format(
+                    SQL("SELECT state FROM {}.{} ORDER BY timestamp DESC LIMIT 1").format(
                         Identifier(s), Identifier(INGESTION_STATE_TABLE)
                     ),
                     return_shape=ResultShape.ONE_ONE,

--- a/splitgraph/hooks/data_source/fdw.py
+++ b/splitgraph/hooks/data_source/fdw.py
@@ -8,11 +8,11 @@ from psycopg2.sql import SQL, Identifier
 
 from splitgraph.core.types import dict_to_tableschema, TableSchema, TableColumn
 from splitgraph.hooks.data_source.base import (
-    DataSource,
     Credentials,
     Params,
     TableInfo,
     PreviewResult,
+    MountableDataSource,
 )
 
 if TYPE_CHECKING:
@@ -27,7 +27,7 @@ _table_options_schema = {
 }
 
 
-class ForeignDataWrapperDataSource(DataSource, ABC):
+class ForeignDataWrapperDataSource(MountableDataSource, ABC):
     credentials_schema = {
         "type": "object",
         "properties": {"username": {"type": "string"}, "password": {"type": "string"}},
@@ -104,7 +104,7 @@ class ForeignDataWrapperDataSource(DataSource, ABC):
 
     def get_remote_schema_name(self) -> str:
         """Override this if the FDW supports IMPORT FOREIGN SCHEMA"""
-        raise NotImplemented
+        raise NotImplementedError
 
     @abstractmethod
     def get_fdw_name(self):
@@ -135,8 +135,8 @@ class ForeignDataWrapperDataSource(DataSource, ABC):
         if isinstance(tables, list):
             try:
                 remote_schema = self.get_remote_schema_name()
-            except NotImplemented:
-                raise NotImplemented(
+            except NotImplementedError:
+                raise NotImplementedError(
                     "The FDW does not support IMPORT FOREIGN SCHEMA! Pass a tables dictionary."
                 )
             _import_foreign_schema(self.engine, schema, remote_schema, server_id, tables)

--- a/splitgraph/hooks/data_source/fdw.py
+++ b/splitgraph/hooks/data_source/fdw.py
@@ -54,16 +54,6 @@ class ForeignDataWrapperDataSource(DataSource, ABC):
         super().__init__(engine, credentials or {}, params or {})
 
     @classmethod
-    @abstractmethod
-    def get_name(cls) -> str:
-        pass
-
-    @classmethod
-    @abstractmethod
-    def get_description(cls) -> str:
-        pass
-
-    @classmethod
     def from_commandline(cls, engine, commandline_kwargs) -> "ForeignDataWrapperDataSource":
         """Instantiate an FDW data source from commandline arguments."""
         # Normally these are supposed to be more user-friendly and FDW-specific (e.g.

--- a/splitgraph/hooks/data_source/fdw.py
+++ b/splitgraph/hooks/data_source/fdw.py
@@ -7,7 +7,13 @@ import psycopg2
 from psycopg2.sql import SQL, Identifier
 
 from splitgraph.core.types import dict_to_tableschema, TableSchema, TableColumn
-from splitgraph.hooks.data_source.base import DataSource, Credentials, Params, TableInfo
+from splitgraph.hooks.data_source.base import (
+    DataSource,
+    Credentials,
+    Params,
+    TableInfo,
+    PreviewResult,
+)
 
 if TYPE_CHECKING:
     from splitgraph.engine.postgres.engine import PostgresEngine
@@ -115,10 +121,7 @@ class ForeignDataWrapperDataSource(DataSource, ABC):
         pass
 
     def mount(
-        self,
-        schema: str,
-        tables: Optional[TableInfo] = None,
-        overwrite: bool = True,
+        self, schema: str, tables: Optional[TableInfo] = None, overwrite: bool = True,
     ):
         tables = tables or self.tables or []
 
@@ -194,9 +197,7 @@ class ForeignDataWrapperDataSource(DataSource, ABC):
         )
         return result_json
 
-    def preview(
-        self, schema: Dict[str, TableSchema]
-    ) -> Dict[str, Union[str, List[Dict[str, Any]]]]:
+    def preview(self, schema: Dict[str, TableSchema]) -> PreviewResult:
         # Preview data in tables mounted by this FDW / data source
 
         # Local import here since this data source gets imported by the commandline entry point
@@ -312,9 +313,7 @@ def create_foreign_table(
     for col in schema_spec:
         if col.comment:
             query += SQL("COMMENT ON COLUMN {}.{}.{} IS %s;").format(
-                Identifier(schema),
-                Identifier(table_name),
-                Identifier(col.name),
+                Identifier(schema), Identifier(table_name), Identifier(col.name),
             )
             args.append(col.comment)
     return query, args

--- a/splitgraph/ingestion/singer/__init__.py
+++ b/splitgraph/ingestion/singer/__init__.py
@@ -3,7 +3,7 @@
 import click
 
 from splitgraph.commandline.common import ImageType
-from splitgraph.ingestion.singer._utils import prepare_new_image
+from splitgraph.hooks.data_source.base import prepare_new_image
 
 
 @click.group(name="singer")

--- a/splitgraph/ingestion/singer/_utils.py
+++ b/splitgraph/ingestion/singer/_utils.py
@@ -1,5 +1,6 @@
 import logging
 import traceback
+from collections import Callable
 from functools import wraps
 
 from psycopg2.sql import SQL, Identifier
@@ -19,6 +20,18 @@ def log_exception(f):
         except Exception:
             logging.error(traceback.format_exc())
             raise
+
+    return wrapped
+
+
+def rollback_at_end(func: Callable) -> Callable:
+    @wraps(func)
+    def wrapped(self, *args, **kwargs):
+        repository = self.image.repository
+        try:
+            return func(self, *args, **kwargs)
+        finally:
+            repository.rollback_engines()
 
     return wrapped
 

--- a/splitgraph/ingestion/singer/_utils.py
+++ b/splitgraph/ingestion/singer/_utils.py
@@ -96,3 +96,28 @@ def _make_changeset(
     args = [c.name for c in schema_spec if c.name not in change_key]
     result = engine.run_sql(query, args)
     return {tuple(row[:-2]): (row[-2], row[-1], {}) for row in result}
+
+
+def prepare_new_image(repository, hash_or_tag):
+    from splitgraph.core.engine import repository_exists
+
+    from random import getrandbits
+    from typing import Optional
+    from splitgraph.core.image import Image
+
+    new_image_hash = "{:064x}".format(getrandbits(256))
+    if repository_exists(repository):
+        # Clone the base image and delta compress against it
+        base_image: Optional[Image] = repository.images[hash_or_tag]
+        repository.images.add(parent_id=None, image=new_image_hash, comment="Singer tap ingestion")
+        repository.engine.run_sql(
+            "INSERT INTO splitgraph_meta.tables "
+            "(SELECT namespace, repository, %s, table_name, table_schema, object_ids "
+            "FROM splitgraph_meta.tables "
+            "WHERE namespace = %s AND repository = %s AND image_hash = %s)",
+            (new_image_hash, repository.namespace, repository.repository, base_image.image_hash,),
+        )
+    else:
+        base_image = None
+        repository.images.add(parent_id=None, image=new_image_hash, comment="Singer tap ingestion")
+    return base_image, new_image_hash

--- a/splitgraph/ingestion/singer/commandline.py
+++ b/splitgraph/ingestion/singer/commandline.py
@@ -1,5 +1,4 @@
 """Command line tools for building Splitgraph images from Singer taps, including using Splitgraph as a Singer target."""
-
 import click
 
 from splitgraph.commandline.common import ImageType

--- a/splitgraph/ingestion/singer/data_source.py
+++ b/splitgraph/ingestion/singer/data_source.py
@@ -144,11 +144,12 @@ class SingerDataSource(SyncableDataSource, ABC):
             schema_spec=INGESTION_STATE_SCHEMA,
             temporary=True,
         )
+        # NB: new_state here is a JSON-serialized string, so we don't wrap it into psycopg2.Json()
         repository.object_engine.run_sql(
             SQL("INSERT INTO pg_temp.{} (timestamp, state) VALUES(now(), %s)").format(
                 Identifier(INGESTION_STATE_TABLE)
             ),
-            (Json(new_state),),
+            (new_state,),
         )
 
         object_id = repository.objects.create_base_fragment(

--- a/splitgraph/ingestion/singer/data_source.py
+++ b/splitgraph/ingestion/singer/data_source.py
@@ -111,7 +111,7 @@ class SingerDataSource(DataSource, ABC):
         repository: Repository,
         image_hash: Optional[str] = None,
         tables: Optional[TableInfo] = None,
-    ):
+    ) -> str:
         config = self.get_singer_config()
         properties = self.get_singer_properties(tables=tables)
 
@@ -170,6 +170,7 @@ class SingerDataSource(DataSource, ABC):
             )
 
         repository.commit_engines()
+        return new_image_hash
 
     def introspect(self) -> Dict[str, TableSchema]:
         config = self.get_singer_config()

--- a/splitgraph/ingestion/singer/data_source.py
+++ b/splitgraph/ingestion/singer/data_source.py
@@ -12,7 +12,6 @@ from psycopg2._json import Json
 from psycopg2.sql import Identifier, SQL
 
 from splitgraph.core.repository import Repository
-from splitgraph.core.sql import insert
 from splitgraph.core.types import TableSchema
 from splitgraph.exceptions import DataSourceError
 from splitgraph.hooks.data_source import DataSource
@@ -185,6 +184,14 @@ class SingerDataSource(DataSource, ABC):
 
 
 class GenericSingerDataSource(SingerDataSource):
+    @classmethod
+    def get_name(cls) -> str:
+        return "Generic Singer tap"
+
+    @classmethod
+    def get_description(cls) -> str:
+        return "Generic Singer tap"
+
     def get_singer_executable(self):
         return self.params["tap_path"]
 

--- a/splitgraph/ingestion/singer/data_source.py
+++ b/splitgraph/ingestion/singer/data_source.py
@@ -21,8 +21,8 @@ from splitgraph.hooks.data_source.base import (
     INGESTION_STATE_TABLE,
     INGESTION_STATE_SCHEMA,
     TableInfo,
+    prepare_new_image,
 )
-from splitgraph.ingestion.singer import prepare_new_image
 from splitgraph.ingestion.singer.db_sync import get_table_name, get_sg_schema, run_patched_sync
 
 SingerConfig = Dict[str, Any]

--- a/splitgraph/ingestion/singer/data_source.py
+++ b/splitgraph/ingestion/singer/data_source.py
@@ -86,7 +86,7 @@ class SingerDataSource(DataSource, ABC):
 
             def _emit_output(pipe):
                 for line in iter(pipe.readline, b""):
-                    logging.info(line.decode("utf-8"))
+                    logging.info(line.decode("utf-8").rstrip("\n"))
 
             # Emit stderr as a separate thread.
             t = Thread(target=_emit_output, args=(proc.stderr,))

--- a/splitgraph/ingestion/singer/data_source.py
+++ b/splitgraph/ingestion/singer/data_source.py
@@ -7,9 +7,8 @@ from abc import ABC, abstractmethod
 from contextlib import contextmanager
 from io import StringIO
 from threading import Thread
-from typing import Dict, Any, Optional, cast, List
+from typing import Dict, Any, Optional, cast
 
-from psycopg2._json import Json
 from psycopg2.sql import Identifier, SQL
 
 from splitgraph.core.repository import Repository
@@ -29,6 +28,7 @@ from splitgraph.ingestion.singer.db_sync import (
     get_sg_schema,
     run_patched_sync,
     get_key_properties,
+    select_breadcrumb,
 )
 
 SingerConfig = Dict[str, Any]
@@ -286,7 +286,7 @@ class MySQLSingerDataSource(SingerDataSource):
 
             # tap-mysql requires the table metadata to contain the replication type
             if not tables or stream_name in tables:
-                stream["metadata"][0]["metadata"]["selected"] = True
+                select_breadcrumb(stream, [])["selected"] = True
 
                 replication_method = self.params["replication_method"]
                 replication_key: Optional[str] = None
@@ -311,7 +311,7 @@ class MySQLSingerDataSource(SingerDataSource):
                     else:
                         replication_key = key_properties[0]
 
-                stream["metadata"][0]["metadata"]["replication-method"] = replication_method
+                select_breadcrumb(stream, [])["replication-method"] = replication_method
                 if replication_key:
-                    stream["metadata"][0]["metadata"]["replication-key"] = replication_key
+                    select_breadcrumb(stream, [])["replication-key"] = replication_key
         return catalog

--- a/splitgraph/ingestion/singer/data_source.py
+++ b/splitgraph/ingestion/singer/data_source.py
@@ -1,0 +1,154 @@
+import json
+import os
+import subprocess
+import tempfile
+from abc import ABC, abstractmethod
+from contextlib import contextmanager
+from io import StringIO
+from typing import Dict, Any, Optional
+
+from psycopg2._json import Json
+
+from splitgraph.core.repository import Repository
+from splitgraph.core.sql import insert
+from splitgraph.core.types import TableSchema
+from splitgraph.hooks.data_source import DataSource
+from splitgraph.hooks.data_source.base import (
+    get_ingestion_state,
+    INGESTION_STATE_TABLE,
+    INGESTION_STATE_SCHEMA,
+)
+from splitgraph.ingestion.singer import prepare_new_image
+from splitgraph.ingestion.singer.db_sync import get_table_name, get_sg_schema, run_patched_sync
+
+SingerConfig = Dict[str, Any]
+SingerProperties = Dict[str, Any]
+SingerState = Dict[str, Any]
+
+
+class SingerDataSource(DataSource, ABC):
+
+    supports_load = True
+    supports_sync = True
+
+    @abstractmethod
+    def get_singer_executable(self):
+        pass
+
+    def get_singer_config(self):
+        return {**self.params, **self.credentials}
+
+    def _run_singer_discovery(self, config: Optional[SingerConfig] = None):
+        executable = self.get_singer_executable()
+        args = []
+
+        with tempfile.TemporaryDirectory() as d:
+            if config:
+                with open(os.path.join(d, "config.json")) as f:
+                    json.dump(config, f)
+                args.extend(["--config", "config.json"])
+
+            catalog = subprocess.check_output([executable] + args)
+
+        return json.loads(catalog)
+
+    @contextmanager
+    def _run_singer(
+        self,
+        config: Optional[SingerConfig] = None,
+        state: Optional[SingerState] = None,
+        properties: Optional[SingerProperties] = None,
+    ):
+        executable = self.get_singer_executable()
+
+        args = [executable]
+
+        with tempfile.TemporaryDirectory() as d:
+            if config:
+                with open(os.path.join(d, "config.json")) as f:
+                    json.dump(config, f)
+                args.extend(["--config", "config.json"])
+
+            if state:
+                with open(os.path.join(d, "state.json")) as f:
+                    json.dump(state, f)
+                args.extend(["--state", "state.json"])
+
+            if properties:
+                with open(os.path.join(d, "properties.json")) as f:
+                    json.dump(properties, f)
+                args.extend(["--properties", "properties.json"])
+
+            proc = subprocess.Popen(args, stdin=subprocess.PIPE, stdout=subprocess.PIPE)
+            yield proc
+
+    def sync(self, repository: Repository, image_hash: Optional[str]):
+        config = self.get_singer_config()
+        state = None
+        properties = None
+
+        state = get_ingestion_state(repository, image_hash)
+
+        base_image, new_image_hash = prepare_new_image(repository, image_hash)
+
+        # Run the sink + target and capture the stdout (new state)
+        output_stream = StringIO()
+        with self._run_singer(config, state, properties) as proc:
+            run_patched_sync(
+                repository,
+                base_image,
+                new_image_hash,
+                delete_old=True,
+                failure="keep_both",
+                input_stream=proc.stdout,
+                output_stream=output_stream,
+            )
+
+        new_state = output_stream.read()
+
+        # Add a table to the new image with the new state
+        repository.object_engine.create_table(
+            schema=None,
+            table=INGESTION_STATE_TABLE,
+            schema_spec=INGESTION_STATE_SCHEMA,
+            temporary=True,
+        )
+        repository.object_engine.run_sql(
+            insert(INGESTION_STATE_TABLE, ["state"], "pg_temp"), (Json(new_state),)
+        )
+
+        object_id = repository.objects.create_base_fragment(
+            "pg_temp",
+            INGESTION_STATE_TABLE,
+            repository.namespace,
+            table_schema=INGESTION_STATE_SCHEMA,
+        )
+        # Overwrite the existing table
+        repository.objects.overwrite_table(
+            repository, new_image_hash, INGESTION_STATE_TABLE, INGESTION_STATE_SCHEMA, [object_id]
+        )
+
+        repository.commit_engines()
+
+    def introspect(self) -> Dict[str, TableSchema]:
+        config = self.get_singer_config()
+        singer_schema = self._run_singer_discovery(config)
+
+        result = {}
+        for stream in singer_schema["streams"]:
+            stream_name = get_table_name(stream)
+            stream_schema = get_sg_schema(stream)
+            result[stream_name] = stream_schema
+        return result
+
+
+class GenericSingerDataSource(SingerDataSource):
+    def get_singer_executable(self):
+        return self.params["tap_path"]
+
+    credentials_schema = {"type": "object"}
+    params_schema = {
+        "type": "object",
+        "properties": {"tap_path": {"type": "string"}},
+        "required": "tap_path",
+    }

--- a/splitgraph/ingestion/singer/db_sync.py
+++ b/splitgraph/ingestion/singer/db_sync.py
@@ -8,12 +8,12 @@ import target_postgres
 from target_postgres import DbSync
 from target_postgres.db_sync import column_type, flatten_schema
 
+from splitgraph.core.image import Image
+from splitgraph.core.repository import Repository
 from splitgraph.core.types import TableSchema, TableColumn
 from splitgraph.exceptions import TableNotFoundError
 from splitgraph.ingestion.common import merge_tables
 from ._utils import _migrate_schema, log_exception, _make_changeset
-from ...core.image import Image
-from ...core.repository import Repository
 
 
 class DbSyncProxy(DbSync):
@@ -91,7 +91,7 @@ class DbSyncProxy(DbSync):
                 table.table_schema,
                 schema_spec,
             )
-            self.image.repository.commit_engines()
+        self.image.repository.commit_engines()
 
     @log_exception
     def load_csv(self, file, count, size_bytes):
@@ -104,7 +104,7 @@ class DbSyncProxy(DbSync):
 
         old_table = self.image.get_table(table_name)
 
-        self.image.repository.engine.create_table(
+        self.image.repository.object_engine.create_table(
             schema="pg_temp", table=temp_table, schema_spec=schema_spec, temporary=True
         )
 

--- a/splitgraph/ingestion/socrata/mount.py
+++ b/splitgraph/ingestion/socrata/mount.py
@@ -7,7 +7,7 @@ from typing import Optional, Dict
 from psycopg2.sql import SQL, Identifier
 
 from splitgraph.exceptions import RepositoryNotFoundError
-from splitgraph.hooks.data_source import ForeignDataWrapperDataSource, create_foreign_table
+from splitgraph.hooks.data_source.fdw import create_foreign_table, ForeignDataWrapperDataSource
 
 
 class SocrataDataSource(ForeignDataWrapperDataSource):
@@ -29,7 +29,9 @@ class SocrataDataSource(ForeignDataWrapperDataSource):
                 "type": "integer",
                 "description": "Amount of rows to fetch from Socrata per request (limit parameter). Maximum 50000.",
             },
-            "tables": {"type": "object",},
+            "tables": {
+                "type": "object",
+            },
         },
         "required": ["domain"],
     }

--- a/splitgraph/splitfile/execution.py
+++ b/splitgraph/splitfile/execution.py
@@ -21,7 +21,7 @@ from splitgraph.core.sql import prepare_splitfile_sql, validate_import_sql
 from splitgraph.engine import get_engine
 from splitgraph.engine.postgres.engine import PostgresEngine
 from splitgraph.exceptions import ImageNotFoundError, SplitfileError
-from splitgraph.hooks.mount_handlers import get_mount_handler, mount
+from splitgraph.hooks.mount_handlers import mount
 from ._parsing import (
     parse_commands,
     extract_nodes,

--- a/test/resources/custom_plugin_dir/some_plugin/plugin.py
+++ b/test/resources/custom_plugin_dir/some_plugin/plugin.py
@@ -1,0 +1,32 @@
+from typing import Dict
+
+from splitgraph.core.types import TableSchema
+from splitgraph.hooks.data_source import DataSource
+
+
+class TestDataSource(DataSource):
+    def introspect(self) -> Dict[str, TableSchema]:
+        return {"some_table": []}
+
+    @classmethod
+    def get_name(cls) -> str:
+        return "Test Data Source"
+
+    @classmethod
+    def get_description(cls) -> str:
+        return "Data source for testing"
+
+    credentials_schema = {
+        "type": "object",
+        "properties": {"access_token": {"type": "string"}},
+        "required": ["access_token"],
+    }
+
+    params_schema = {
+        "type": "object",
+        "properties": {"some_field": {"type": "string"}},
+        "required": ["some_field"],
+    }
+
+
+__plugin__ = TestDataSource

--- a/test/resources/ingestion/singer/discover.json
+++ b/test/resources/ingestion/singer/discover.json
@@ -1,0 +1,336 @@
+{
+  "streams": [
+    {
+      "stream": "stargazers",
+      "tap_stream_id": "stargazers",
+      "schema": {
+        "type": [
+          "null",
+          "object"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "_sdc_repository": {
+            "type": [
+              "string"
+            ]
+          },
+          "user": {
+            "type": [
+              "null",
+              "object"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "id": {
+                "type": [
+                  "null",
+                  "integer"
+                ]
+              }
+            }
+          },
+          "starred_at": {
+            "type": [
+              "null",
+              "string"
+            ],
+            "format": "date-time"
+          },
+          "user_id": {
+            "type": [
+              "null",
+              "integer"
+            ]
+          }
+        }
+      },
+      "metadata": [
+        {
+          "breadcrumb": [],
+          "metadata": {
+            "table-key-properties": [
+              "user_id"
+            ]
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "_sdc_repository"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "user"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "starred_at"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "user_id"
+          ],
+          "metadata": {
+            "inclusion": "automatic"
+          }
+        }
+      ],
+      "key_properties": [
+        "user_id"
+      ]
+    },
+    {
+      "stream": "releases",
+      "tap_stream_id": "releases",
+      "schema": {
+        "type": [
+          "null",
+          "object"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "_sdc_repository": {
+            "type": [
+              "string"
+            ]
+          },
+          "id": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "url": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "html_url": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "target_commitish": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "tag_name": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "name": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "body": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "draft": {
+            "type": [
+              "null",
+              "boolean"
+            ]
+          },
+          "prerelease": {
+            "type": [
+              "null",
+              "boolean"
+            ]
+          },
+          "author": {
+            "type": [
+              "null",
+              "object"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "login": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "id": {
+                "type": [
+                  "null",
+                  "integer"
+                ]
+              }
+            }
+          },
+          "created_at": {
+            "type": [
+              "null",
+              "string"
+            ],
+            "format": "date-time"
+          },
+          "published_at": {
+            "type": [
+              "null",
+              "string"
+            ],
+            "format": "date-time"
+          }
+        }
+      },
+      "metadata": [
+        {
+          "breadcrumb": [],
+          "metadata": {
+            "table-key-properties": [
+              "id"
+            ]
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "_sdc_repository"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "id"
+          ],
+          "metadata": {
+            "inclusion": "automatic"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "url"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "html_url"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "target_commitish"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "tag_name"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "name"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "body"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "draft"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "prerelease"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "author"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "created_at"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        },
+        {
+          "breadcrumb": [
+            "properties",
+            "published_at"
+          ],
+          "metadata": {
+            "inclusion": "available"
+          }
+        }
+      ],
+      "key_properties": [
+        "id"
+      ]
+    }
+  ]
+}

--- a/test/resources/ingestion/singer/fake_tap.py
+++ b/test/resources/ingestion/singer/fake_tap.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python
+import json
+import os
+
+import click
+
+
+@click.command(name="tap")
+@click.option("-c", "--config", type=click.File("r"))
+@click.option("-s", "--state", type=click.File("r"))
+@click.option("--catalog", type=click.File("r"))
+@click.option("-d", "--discover", is_flag=True)
+def tap(state, config, catalog, discover):
+    basepath = os.path.dirname(__file__)
+    json.load(config)
+
+    if discover:
+        with open(os.path.join(basepath, "discover.json")) as f:
+            click.echo(f.read(), nl=False)
+        return
+
+    assert catalog
+    catalog_j = json.load(catalog)
+    assert len(catalog_j["streams"]) == 2
+
+    if state:
+        json.load(state)
+        with open(os.path.join(basepath, "update.json")) as f:
+            click.echo(f.read(), nl=False)
+        return
+
+    with open(os.path.join(basepath, "initial.json")) as f:
+        click.echo(f.read(), nl=False)
+
+
+if __name__ == "__main__":
+    tap()

--- a/test/resources/ingestion/singer/fake_tap.py
+++ b/test/resources/ingestion/singer/fake_tap.py
@@ -9,8 +9,9 @@ import click
 @click.option("-c", "--config", type=click.File("r"))
 @click.option("-s", "--state", type=click.File("r"))
 @click.option("--catalog", type=click.File("r"))
+@click.option("-p", "--properties", type=click.File("r"))
 @click.option("-d", "--discover", is_flag=True)
-def tap(state, config, catalog, discover):
+def tap(state, config, catalog, properties, discover):
     basepath = os.path.dirname(__file__)
     json.load(config)
 
@@ -19,8 +20,8 @@ def tap(state, config, catalog, discover):
             click.echo(f.read(), nl=False)
         return
 
-    assert catalog
-    catalog_j = json.load(catalog)
+    assert catalog or properties
+    catalog_j = json.load(catalog or properties)
     assert len(catalog_j["streams"]) == 2
 
     if state:

--- a/test/splitgraph/commandline/test_cloud.py
+++ b/test/splitgraph/commandline/test_cloud.py
@@ -398,7 +398,7 @@ def _make_dummy_config_dict():
     source_config = create_config_dict()
     source_config["SG_CONFIG_FILE"] = ".sgconfig"
     source_config["remotes"] = {_REMOTE: source_config["remotes"][_REMOTE]}
-    del source_config["mount_handlers"]
+    del source_config["data_sources"]
     del source_config["commands"]
     del source_config["external_handlers"]
     return source_config

--- a/test/splitgraph/commandline/test_engine.py
+++ b/test/splitgraph/commandline/test_engine.py
@@ -206,7 +206,7 @@ _PULL_PROGRESS = [
 ]
 
 
-_HANDLER_CONFIG = """[mount_handlers]
+_HANDLER_CONFIG = """[data_sources]
 postgres_fdw=splitgraph.hooks.data_source.PostgreSQLDataSource
 mongo_fdw=splitgraph.hooks.data_source.MongoDataSource
 mysql_fdw=splitgraph.hooks.data_source.MySQLDataSource

--- a/test/splitgraph/commandline/test_misc.py
+++ b/test/splitgraph/commandline/test_misc.py
@@ -309,7 +309,7 @@ def test_config_dumping():
     assert "[defaults]" in result.output
     assert "[commands]" in result.output
     assert "[external_handlers]" in result.output
-    assert "[mount_handlers]" in result.output
+    assert "[data_sources]" in result.output
     assert "S3=splitgraph.hooks.s3" in result.output
 
     # sgr config -n (print connection string to engine)

--- a/test/splitgraph/commandline/test_mount.py
+++ b/test/splitgraph/commandline/test_mount.py
@@ -9,8 +9,8 @@ from test.splitgraph.conftest import OUTPUT, MG_MNT
 from splitgraph.commandline import status_c, rm_c, cleanup_c, init_c, mount_c, import_c
 from splitgraph.core.engine import repository_exists
 from splitgraph.core.repository import Repository
-from splitgraph.hooks.data_source import PostgreSQLDataSource
-from splitgraph.hooks.mount_handlers import get_mount_handlers, _load_handler
+from splitgraph.hooks.data_source.fdw import PostgreSQLDataSource
+from splitgraph.hooks.data_source import get_data_sources, _load_source
 from splitgraph.ingestion.socrata.mount import SocrataDataSource
 
 _MONGO_PARAMS = {
@@ -106,7 +106,7 @@ def test_mount_docstring_generation():
     # General mount help: should have all the handlers autoregistered and listed
     result = runner.invoke(mount_c, ["--help"])
     assert result.exit_code == 0
-    for handler_name in get_mount_handlers():
+    for handler_name in get_data_sources():
         assert handler_name in result.output
 
     # Test the reserved params (that we parse separately) don't make it into the help text
@@ -122,11 +122,11 @@ def test_mount_fallback(local_engine_empty):
     # as classes (the default overrides them in this case and emits a warning).
 
     assert (
-        _load_handler("postgres_fdw", "splitgraph.hooks.mount_handlers.mount_postgres")
-        == PostgreSQLDataSource
+            _load_source("postgres_fdw", "splitgraph.hooks.mount_handlers.mount_postgres")
+            == PostgreSQLDataSource
     )
 
     assert (
-        _load_handler("socrata", "splitgraph.ingestion.socrata.mount.mount_socrata")
-        == SocrataDataSource
+            _load_source("socrata", "splitgraph.ingestion.socrata.mount.mount_socrata")
+            == SocrataDataSource
     )

--- a/test/splitgraph/commands/test_mounting.py
+++ b/test/splitgraph/commands/test_mounting.py
@@ -6,7 +6,7 @@ from test.splitgraph.conftest import _mount_postgres, _mount_mysql, _mount_mongo
 from splitgraph.core.repository import Repository
 from splitgraph.core.types import TableColumn
 from splitgraph.engine import get_engine
-from splitgraph.hooks.data_source import PostgreSQLDataSource
+from splitgraph.hooks.data_source.fdw import PostgreSQLDataSource
 from splitgraph.hooks.mount_handlers import mount
 
 PG_MNT = Repository.from_schema("test/pg_mount")

--- a/test/splitgraph/ingestion/test_common.py
+++ b/test/splitgraph/ingestion/test_common.py
@@ -1,0 +1,104 @@
+from typing import Optional, Dict, Any
+
+from splitgraph.core.repository import Repository
+from splitgraph.core.types import TableSchema, TableColumn
+from splitgraph.engine import ResultShape
+from splitgraph.hooks.data_source.base import SyncState, TableInfo, SyncableDataSource
+
+SCHEMA = {
+    "test_table": [
+        TableColumn(1, "key", "integer", True),
+        TableColumn(2, "value", "character varying", False),
+    ]
+}
+TEST_REPO = "test/generic_sync"
+
+
+class IngestionTestSource(SyncableDataSource):
+    params_schema: Dict[str, Any] = {}
+    credentials_schema: Dict[str, Any] = {}
+
+    @classmethod
+    def get_name(cls) -> str:
+        return "Test ingestion"
+
+    @classmethod
+    def get_description(cls) -> str:
+        return "Test ingestion"
+
+    def introspect(self) -> Dict[str, TableSchema]:
+        return SCHEMA
+
+    def _sync(
+        self, schema: str, state: Optional[SyncState] = None, tables: Optional[TableInfo] = None
+    ) -> SyncState:
+        if not self.engine.table_exists(schema, "test_table"):
+            self.engine.create_table(schema, "test_table", SCHEMA["test_table"])
+
+        if not state:
+            self.engine.run_sql_in(
+                schema, "INSERT INTO test_table (key, value) " "VALUES (1, 'one')"
+            )
+            return {"last_value": 1}
+        else:
+            last_value = state["last_value"]
+            assert last_value == 1
+            self.engine.run_sql_in(
+                schema, "INSERT INTO test_table (key, value) " "VALUES (2, 'two')"
+            )
+            return {"last_value": 2}
+
+
+def _get_state(repo):
+    return repo.run_sql(
+        "SELECT state FROM _sg_ingestion_state ORDER BY timestamp DESC LIMIT 1",
+        return_shape=ResultShape.ONE_ONE,
+    )
+
+
+def test_syncable_data_source(local_engine_empty):
+    source = IngestionTestSource(engine=local_engine_empty, credentials={}, params={})
+
+    # Initial sync
+    repo = Repository.from_schema(TEST_REPO)
+    repo.init()
+
+    image_hash_1 = source.sync(repo, "latest")
+
+    assert len(repo.images()) == 2
+    image = repo.images[image_hash_1]
+    assert sorted(image.get_tables()) == ["_sg_ingestion_state", "test_table"]
+    image.checkout()
+
+    assert repo.run_sql("SELECT * FROM test_table") == [(1, "one")]
+    assert _get_state(repo) == {"last_value": 1}
+
+    # Load the data anew into a different image
+    repo.images["0" * 64].checkout()
+    source.load(repo.to_schema())
+    repo.commit_engines()
+
+    assert repo.run_sql("SELECT * FROM test_table") == [(1, "one")]
+
+    repo.uncheckout(force=True)
+    # Perform a sync based on the empty image
+    image_hash_2 = source.sync(repo, "0" * 64)
+    assert image_hash_2 != image_hash_1
+
+    image = repo.images[image_hash_2]
+    assert sorted(image.get_tables()) == ["_sg_ingestion_state", "test_table"]
+    image.checkout()
+
+    assert repo.run_sql("SELECT * FROM test_table") == [(1, "one")]
+    assert _get_state(repo) == {"last_value": 1}
+
+    # Perform a sync based on the ingested image
+    image_hash_3 = source.sync(repo, image_hash_1)
+    assert image_hash_3 != image_hash_1
+
+    image = repo.images[image_hash_3]
+    assert sorted(image.get_tables()) == ["_sg_ingestion_state", "test_table"]
+    image.checkout()
+
+    assert repo.run_sql("SELECT * FROM test_table ORDER BY key ASC") == [(1, "one"), (2, "two")]
+    assert _get_state(repo) == {"last_value": 2}

--- a/test/splitgraph/ingestion/test_singer.py
+++ b/test/splitgraph/ingestion/test_singer.py
@@ -395,6 +395,7 @@ def _source(local_engine_empty):
 
 
 @pytest.mark.skipif(shutil.which("tap-mysql") is None, reason="tap-mysql is missing in PATH")
+@pytest.mark.mounting
 def test_singer_tap_mysql_introspection(local_engine_empty):
     source = _source(local_engine_empty)
     assert source.introspect() == {
@@ -501,6 +502,7 @@ def test_singer_tap_mysql_introspection(local_engine_empty):
 
 
 @pytest.mark.skipif(shutil.which("tap-mysql") is None, reason="tap-mysql is missing in PATH")
+@pytest.mark.mounting
 def test_singer_tap_mysql_sync(local_engine_empty):
     source = _source(local_engine_empty)
     repo = Repository.from_schema(TEST_REPO)

--- a/test/splitgraph/ingestion/test_singer.py
+++ b/test/splitgraph/ingestion/test_singer.py
@@ -9,9 +9,9 @@ import psycopg2
 from splitgraph.core.repository import Repository
 from splitgraph.core.types import TableColumn
 from splitgraph.engine import ResultShape
-from splitgraph.ingestion.singer import singer_target
 from test.splitgraph.conftest import INGESTION_RESOURCES
 
+from splitgraph.ingestion.singer.commandline import singer_target
 from splitgraph.ingestion.singer.data_source import GenericSingerDataSource
 
 TEST_REPO = "test/singer"
@@ -351,7 +351,7 @@ def test_singer_data_source_sync(local_engine_empty):
     assert repo.run_sql("SELECT COUNT(1) FROM releases", return_shape=ResultShape.ONE_ONE) == 6
     assert repo.run_sql("SELECT COUNT(1) FROM stargazers", return_shape=ResultShape.ONE_ONE) == 5
 
-    assert json.loads(repo.run_sql("SELECT state FROM _sg_ingestion_state")[0][0]) == {
+    assert repo.run_sql("SELECT state FROM _sg_ingestion_state")[0][0] == {
         "bookmarks": {
             "splitgraph/splitgraph": {
                 "stargazers": {"since": "2020-10-14T11:06:40.852311Z"},
@@ -370,7 +370,7 @@ def test_singer_data_source_sync(local_engine_empty):
     assert repo.run_sql("SELECT COUNT(1) FROM releases", return_shape=ResultShape.ONE_ONE) == 9
     assert repo.run_sql("SELECT COUNT(1) FROM stargazers", return_shape=ResultShape.ONE_ONE) == 6
 
-    assert json.loads(repo.run_sql("SELECT state FROM _sg_ingestion_state")[0][0]) == {
+    assert repo.run_sql("SELECT state FROM _sg_ingestion_state")[0][0] == {
         "bookmarks": {
             "splitgraph/splitgraph": {
                 "releases": {"since": "2020-10-14T11:06:42.786589Z"},

--- a/test/splitgraph/ingestion/test_singer.py
+++ b/test/splitgraph/ingestion/test_singer.py
@@ -330,7 +330,9 @@ def test_singer_ingestion_errors(local_engine_empty):
 
 def test_singer_data_source_introspect(local_engine_empty):
     source = GenericSingerDataSource(
-        local_engine_empty, credentials={}, params={"tap_path": TEST_TAP}
+        local_engine_empty,
+        credentials={"some": "credential"},
+        params={"tap_path": TEST_TAP, "other": "param"},
     )
 
     schema = source.introspect()
@@ -339,7 +341,9 @@ def test_singer_data_source_introspect(local_engine_empty):
 
 def test_singer_data_source_sync(local_engine_empty):
     source = GenericSingerDataSource(
-        local_engine_empty, credentials={}, params={"tap_path": TEST_TAP}
+        local_engine_empty,
+        credentials={"some": "credential"},
+        params={"tap_path": TEST_TAP, "other": "param"},
     )
 
     repo = Repository.from_schema(TEST_REPO)


### PR DESCRIPTION
  * Rename `mount_handlers` to `data_sources` and expand the `DataSource` class to allow for capabilities like incremental loads that don't have to use FDWs.
  * Write `SingerDataSource`, a data source that wraps around Singer taps and handles property file generation, state storage (inside the Splitgraph image) and incremental loads. Not exposed in the command line but usable through Python. See https://github.com/splitgraph/splitgraph/blob/3cc8df5ade507f0736b3b687bf86c6a7a8d7cb8c/splitgraph/ingestion/singer/data_source.py#L249-L317 for a full example.
  * Add support for dynamically loading plugins without specifying them in the `.sgconfig`. file. Point `SG_PLUGIN_DIR` to the directory with the plugins. Each directory must have a file `plugin.py` with a top-level `__plugin__` global pointing to the plugin class. For example:

```python
import os

from splitgraph.hooks.data_source import DataSource


class SampleDataSource(DataSource):
    @classmethod
    def get_name(cls) -> str:
        return "Sample data source"

    @classmethod
    def get_description(cls) -> str:
        return "Does nothing"

    credentials_schema = {
        "type": "object",
        "properties": {"access_token": {"type": "string"}},
        "required": ["access_token"],
    }

    params_schema = {
        "type": "object",
        "properties": {"some_field": {"type": "string"}},
        "required": ["some_field"],
    }

__plugin__ = SampleDataSource
```

