### PR TITLE
Bugfix/nulls in pks

### DIFF
--- a/.ci/install.sh
+++ b/.ci/install.sh
@@ -12,7 +12,7 @@ poetry install -E pandas
 # Needed to test the dbt example, not required by core sg
 python -m venv "$DBT_VENV"
 . "$DBT_VENV"/bin/activate
-pip install dbt
+pip install dbt==0.18.0
 
 # Singer tap integration test
 python -m venv "$TAP_MYSQL_VENV"

--- a/.ci/rebuild_asciicasts.sh
+++ b/.ci/rebuild_asciicasts.sh
@@ -22,7 +22,7 @@ SG_CONFIG_FILE=$ASCIINEMA_CONFIG sgr --verbosity DEBUG cloud login-api --api-key
 
 # TODO the us-election asciicast requires scipy for the last part, consider replacing
 # dbt required by the dbt example
-pip install scipy dbt
+pip install scipy dbt==0.18.0
 
 cd "$REPO_ROOT_DIR"/examples
 for dir in $ASCIINEMA_CASTS; do

--- a/splitgraph/core/fragment_manager.py
+++ b/splitgraph/core/fragment_manager.py
@@ -109,7 +109,9 @@ def get_chunk_groups(chunks: List[Tuple[str, Any, Any]],) -> List[List[Tuple[str
             return tuple((ci is None, ci) for ci in c)
         return c is None, c
 
-    for original_id, chunk_id, start, end in sorted(chunks, key=_key):  # type:ignore
+    for original_id, chunk_id, start, end in sorted(
+        chunks, key=lambda c: _key([c[2]])
+    ):  # type:ignore
         if not current_group:
             current_group = [(original_id, chunk_id, start, end)]
             current_group_start = start

--- a/splitgraph/core/fragment_manager.py
+++ b/splitgraph/core/fragment_manager.py
@@ -110,8 +110,8 @@ def get_chunk_groups(chunks: List[Tuple[str, Any, Any]],) -> List[List[Tuple[str
         return c is None, c
 
     for original_id, chunk_id, start, end in sorted(
-        chunks, key=lambda c: _key([c[2]])
-    ):  # type:ignore
+        chunks, key=lambda c: _key([c[2]])  # type:ignore
+    ):
         if not current_group:
             current_group = [(original_id, chunk_id, start, end)]
             current_group_start = start

--- a/test/architecture/docker-compose.core.yml
+++ b/test/architecture/docker-compose.core.yml
@@ -19,8 +19,8 @@ services:
     # Uncomment this to mount the current Splitgraph code into the engine without
     # having to rebuild it. This shouldn't be done in CI, as we want to test the engine
     # that we've built.
-    # volumes:
-    #  - ../../splitgraph:/splitgraph/splitgraph
+    volumes:
+      - ../../splitgraph:/splitgraph/splitgraph
   remote_engine:
     build:
       context: ./src/


### PR DESCRIPTION
LQ hack-ish to work around Nones in long composite PKs. We need to be able to establish a consistent ordering on them anyway, so we make a fake key, prepending a boolean (is the item None?) to every item.

Also pin dbt to fix the examples build.