### PR TITLE
Ctrl+c handling in sgr

### DIFF
--- a/splitgraph/engine/postgres/engine.py
+++ b/splitgraph/engine/postgres/engine.py
@@ -27,6 +27,7 @@ from typing import (
 )
 
 import psycopg2
+import psycopg2.extensions
 from packaging.version import Version
 from psycopg2 import DatabaseError
 from psycopg2.errors import InvalidSchemaName, UndefinedTable
@@ -212,6 +213,10 @@ class PsycopgEngine(SQLEngine):
         :param autocommit: If True, the engine will not use transactions for its operation.
         """
         super().__init__()
+
+        # Allow users to send SIGINT to quickly terminate sgr (instead of waiting for a PG
+        # statement to finish)
+        psycopg2.extensions.set_wait_callback(psycopg2.extras.wait_select)
 
         if not conn_params and not pool:
             raise ValueError("One of conn_params/pool must be specified!")

--- a/splitgraph/ingestion/csv/__init__.py
+++ b/splitgraph/ingestion/csv/__init__.py
@@ -37,7 +37,7 @@ def copy_csv_buffer(
     data, engine: "PsycopgEngine", schema: str, table: str, no_header: bool = False, **kwargs
 ):
     """Copy CSV data from a buffer into a given schema/table"""
-    with engine.connection.cursor() as cur:
+    with engine.copy_cursor() as cur:
         extra_args = [not no_header]
 
         copy_command = SQL("COPY {}.{} FROM STDIN WITH (FORMAT CSV, HEADER %s").format(
@@ -59,7 +59,7 @@ def query_to_csv(engine: "PsycopgEngine", query, buffer, schema: Optional[str] =
     if schema:
         copy_query = SQL("SET search_path TO {},public;").format(Identifier(schema)) + copy_query
 
-    with engine.connection.cursor() as cur:
+    with engine.copy_cursor() as cur:
         cur.copy_expert(copy_query, buffer)
 
 


### PR DESCRIPTION
Allow users to send SIGINT to quickly terminate sgr (instead of waiting for a PG statement to finish).