### PR TITLE
Extra fields for sgr cloud metadata

### DIFF
--- a/engine/etc/postgresql/pg_hba.conf
+++ b/engine/etc/postgresql/pg_hba.conf
@@ -1,3 +1,4 @@
 host    all             all             0.0.0.0/0               md5
+host    all             all             ::0/0                   md5
 local   all             all             md5
 local   replication     all             trust


### PR DESCRIPTION
Add support for more fields in the `sgr cloud metadata` command:

```yaml
readme: dataset-readme.md
description: Dataset description (160 characters max).
topics:
  - topic_1
  - topic_2
sources:
  - anchor: Source
    href: https://www.splitgraph.com
    isCreator: true
    isSameAs: false
  - anchor: Source 2
    href: https://www.splitgraph.com
    isCreator: false
    isSameAs: true
license: Public Domain
extra_metadata:
  key_1:
    key_1_1: value_1_1
    key_1_2: value_1_2
  key_2:
    key_2_1: value_2_1
    key_2_2: value_2_2
```

Also fix pg_hba.conf to allow accessing the engine over IPv6. 