### PR TITLE
Fix deleting tags on remote registries

### DIFF
--- a/splitgraph/core/image.py
+++ b/splitgraph/core/image.py
@@ -69,10 +69,9 @@ class Image(NamedTuple):
         parent = self.parent_id
 
         children = self.engine.run_sql(
-            SQL(
-                """SELECT image_hash FROM {}.images
-                WHERE namespace = %s AND repository = %s AND parent_id = %s"""
-            ).format(Identifier(SPLITGRAPH_META_SCHEMA)),
+            SQL("SELECT image_hash FROM {}.get_images(%s,%s) WHERE parent_id = %s").format(
+                Identifier(SPLITGRAPH_API_SCHEMA)
+            ),
             (self.repository.namespace, self.repository.repository, self.image_hash),
             return_shape=ResultShape.MANY_ONE,
         )
@@ -261,9 +260,7 @@ class Image(NamedTuple):
         self.repository.images.by_tag(tag)
 
         self.engine.run_sql(
-            SQL("DELETE FROM {}.tags WHERE namespace = %s AND repository = %s AND tag = %s").format(
-                Identifier(SPLITGRAPH_META_SCHEMA)
-            ),
+            select("delete_tag", table_args="(%s,%s,%s)", schema=SPLITGRAPH_API_SCHEMA),
             (self.repository.namespace, self.repository.repository, tag),
             return_shape=None,
         )

--- a/splitgraph/resources/static/splitgraph_api.sql
+++ b/splitgraph/resources/static/splitgraph_api.sql
@@ -357,6 +357,24 @@ $$
 LANGUAGE plpgsql
 SECURITY DEFINER SET search_path = splitgraph_meta, pg_temp;
 
+CREATE OR REPLACE FUNCTION splitgraph_api.delete_tag (
+    _namespace varchar,
+    _repository varchar,
+    _tag varchar
+)
+    RETURNS void
+    AS $$
+BEGIN
+    PERFORM splitgraph_api.check_privilege (_namespace);
+    DELETE FROM splitgraph_meta.tags
+        WHERE namespace = _namespace
+        AND repository = _repository
+        AND tag = _tag;
+END
+$$
+LANGUAGE plpgsql
+SECURITY DEFINER SET search_path = splitgraph_meta, pg_temp;
+
 -- delete_repository(namespace, repository)
 CREATE OR REPLACE FUNCTION splitgraph_api.delete_repository (
     _namespace varchar,


### PR DESCRIPTION
Use Splitgraph SQL API calls in the `Repository` object instead of accessing tables directly (to allow hitting remote registries for some remaining untested code paths)