### PR TITLE
Bump Multicorn and use our fork of snowflake-sqlalchemy that supports…

### DIFF
--- a/engine/Dockerfile
+++ b/engine/Dockerfile
@@ -186,8 +186,9 @@ RUN --mount=type=cache,id=pip-cache,target=/root/.cache/pip \
 COPY ./engine/src/postgres-elasticsearch-fdw/pg_es_fdw /pg_es_fdw/pg_es_fdw
 
 # Install the Snowflake SQLAlchemy connector
+# Use our fork that supports server-side cursors
 RUN --mount=type=cache,id=pip-cache,target=/root/.cache/pip \
-    pip install "snowflake-sqlalchemy>=1.2.4"
+    pip install "git+https://github.com/splitgraph/snowflake-sqlalchemy.git@14e64cc0ef7374df0cecc91923ff6901b0d721b7"
 
 ENV PATH "${PATH}:/splitgraph/bin"
 ENV PYTHONPATH "${PYTHONPATH}:/splitgraph:/pg_es_fdw"

--- a/splitgraph/core/migration.py
+++ b/splitgraph/core/migration.py
@@ -90,7 +90,7 @@ def set_installed_version(
     )
 
 
-def _get_version_tuples(filenames: List[str]) -> List[Tuple[Optional[str], str]]:
+def get_version_tuples(filenames: List[str]) -> List[Tuple[Optional[str], str]]:
     version_re = re.compile(r"\w+--([\w.]+)(--[\w.]+)?\.sql")
 
     result: List[Tuple[Optional[str], str]] = []
@@ -115,7 +115,7 @@ def source_files_to_apply(
     target_version: Optional[str] = None,
 ) -> Tuple[List[str], str]:
     """ Get the ordered list of .sql files to apply to the database"""
-    version_tuples = _get_version_tuples(schema_files)
+    version_tuples = get_version_tuples(schema_files)
     target_version = target_version or max([v[1] for v in version_tuples])
     if static:
         # For schemata like splitgraph_api which we want to apply in any

--- a/splitgraph/ingestion/snowflake/__init__.py
+++ b/splitgraph/ingestion/snowflake/__init__.py
@@ -117,6 +117,13 @@ EOF
             if "schema" in self.params:
                 db_url += f"/{self.params['schema']}"
 
+        # For some reason, in SQLAlchemy, if this is not passed
+        # to the FDW params (even if it is in the DB URL), it doesn't
+        # schema-qualify tables and server-side cursors don't work for scanning
+        # (loads the whole table instead of scrolling through it).
+        if "schema" in self.params:
+            options["schema"] = self.params["schema"]
+
         extra_params = {}
         if "warehouse" in self.params:
             extra_params["warehouse"] = self.params["warehouse"]

--- a/test/splitgraph/commandline/test_cloud.py
+++ b/test/splitgraph/commandline/test_cloud.py
@@ -128,32 +128,31 @@ def test_commandline_registration_normal():
 
     runner = CliRunner()
 
-    with patch("splitgraph.config.export.overwrite_config"):
-        with patch("splitgraph.config.config.patch_config") as pc:
-            with patch("splitgraph.config.CONFIG", source_config):
-                with patch("splitgraph.commandline.cloud.inject_config_into_engines") as ic:
-                    # First don't agree to ToS, then agree
-                    args = [
-                        "--username",
-                        "someuser",
-                        "--password",
-                        "somepassword",
-                        "--email",
-                        "someuser@example.com",
-                        "--remote",
-                        _REMOTE,
-                    ]
-                    result = runner.invoke(
-                        register_c, args=args, catch_exceptions=False, input="n",
-                    )
-                    assert result.exit_code == 1
-                    assert "Sample ToS message" in result.output
+    with patch("splitgraph.config.export.overwrite_config"), patch(
+        "splitgraph.config.config.patch_config"
+    ) as pc, patch("splitgraph.config.CONFIG", source_config), patch(
+        "splitgraph.cloud.create_config_dict", return_value=source_config
+    ), patch(
+        "splitgraph.commandline.cloud.inject_config_into_engines"
+    ) as ic:
+        # First don't agree to ToS, then agree
+        args = [
+            "--username",
+            "someuser",
+            "--password",
+            "somepassword",
+            "--email",
+            "someuser@example.com",
+            "--remote",
+            _REMOTE,
+        ]
+        result = runner.invoke(register_c, args=args, catch_exceptions=False, input="n",)
+        assert result.exit_code == 1
+        assert "Sample ToS message" in result.output
 
-                    result = runner.invoke(
-                        register_c, args=args, catch_exceptions=False, input="y",
-                    )
-                    assert result.exit_code == 0
-                    assert "Sample ToS message" in result.output
+        result = runner.invoke(register_c, args=args, catch_exceptions=False, input="y",)
+        assert result.exit_code == 0
+        assert "Sample ToS message" in result.output
     assert pc.mock_calls == [
         call(
             source_config,

--- a/test/splitgraph/ingestion/test_snowflake.py
+++ b/test/splitgraph/ingestion/test_snowflake.py
@@ -21,6 +21,7 @@ def test_snowflake_data_source_dburl_conversion():
 
     assert source.get_server_options() == {
         "db_url": "snowflake://username:password@abcdef.eu-west-1.aws/SOME_DB/TPCH_SF100warehouse=my_warehouse&role=role",
+        "schema": "TPCH_SF100",
         "wrapper": "multicorn.sqlalchemyfdw.SqlAlchemyFdw",
     }
 


### PR DESCRIPTION
… server-side cursors.

Most interesting changes are in

  * Multicorn (support for ORDER BY pushdown and LIMIT/OFFSET hack for dialects that don't support server-side cursors): https://github.com/splitgraph/Multicorn/blob/master/python/multicorn/sqlalchemyfdw.py#L396-L421
  * Snowflake SQLAlchemy adapter (support for server-side cursors): https://github.com/splitgraph/snowflake-sqlalchemy/commit/14e64cc0ef7374df0cecc91923ff6901b0d721b7

This makes LIMIT scans actually not fetch the whole result set. Rough speeds:

  * `EXPLAIN ANALYZE SELECT * FROM test_snowflake.lineitem LIMIT ...`
    * 100: 800-1000ms
    * 1000: 1-1.5s
    * 10000: 2-3s
    * 100000: 10s
    * 1000000: 75s
