### PR TITLE
Connection handling fixes

### DIFF
--- a/splitgraph/hooks/s3.py
+++ b/splitgraph/hooks/s3.py
@@ -30,6 +30,7 @@ def get_object_upload_urls(remote_engine, objects):
         chunk_position=1,
     )
     remote_engine.commit()
+    remote_engine.close()
     return urls
 
 
@@ -42,6 +43,7 @@ def get_object_download_urls(remote_engine, remote_object_ids):
         chunk_position=1,
     )
     remote_engine.commit()
+    remote_engine.close()
     return urls
 
 


### PR DESCRIPTION
Make remote connection handling more robust:

  * If the registry closes an idle connection after 30s, don't err out the next time we try to use it and get a psycopg error, log and retry once
  * close the remote engine connection as well as commit it after we used it to pre-sign object download/upload URLs. The commit is enough for consistency, but I don't think it actually closes the connection (commit also puts the conn into the pool).

