### PR TITLE
Start table column ordinals from 1 instead of 0 ...

### DIFF
--- a/splitgraph/core/types.py
+++ b/splitgraph/core/types.py
@@ -28,7 +28,7 @@ class Comparable(metaclass=ABCMeta):
 def dict_to_tableschema(tables: Dict[str, Dict[str, Any]]) -> Dict[str, TableSchema]:
     return {
         t: [
-            TableColumn(i, cname, ctype, False, None)
+            TableColumn(i + 1, cname, ctype, False, None)
             for (i, (cname, ctype)) in enumerate(ts.items())
         ]
         for t, ts in tables.items()

--- a/test/splitgraph/test_misc.py
+++ b/test/splitgraph/test_misc.py
@@ -9,7 +9,7 @@ from splitgraph.core.output import parse_dt
 from splitgraph.core.engine import lookup_repository
 from splitgraph.core.metadata_manager import Object
 from splitgraph.core.repository import Repository
-from splitgraph.core.types import TableColumn, tableschema_to_dict
+from splitgraph.core.types import TableColumn, tableschema_to_dict, dict_to_tableschema
 from splitgraph.engine.postgres.engine import API_MAX_QUERY_LENGTH
 from splitgraph.exceptions import RepositoryNotFoundError
 from splitgraph.hooks.s3 import get_object_upload_urls
@@ -333,4 +333,28 @@ def test_tableschema_to_dict():
     ) == {
         "fruits": {"fruit_id": "integer", "name": "character varying"},
         "vegetables": {"name": "character varying", "vegetable_id": "integer"},
+    }
+
+
+def test_dict_to_tableschema():
+    assert dict_to_tableschema(
+        {
+            "fruits": {"fruit_id": "integer", "name": "character varying"},
+            "vegetables": {"name": "character varying", "vegetable_id": "integer"},
+        }
+    ) == {
+        "fruits": [
+            TableColumn(ordinal=1, name="fruit_id", pg_type="integer", is_pk=False, comment=None),
+            TableColumn(
+                ordinal=2, name="name", pg_type="character varying", is_pk=False, comment=None
+            ),
+        ],
+        "vegetables": [
+            TableColumn(
+                ordinal=1, name="name", pg_type="character varying", is_pk=False, comment=None
+            ),
+            TableColumn(
+                ordinal=2, name="vegetable_id", pg_type="integer", is_pk=False, comment=None
+            ),
+        ],
     }


### PR DESCRIPTION
... in `dict_to_tableschema` (used in some mounting routines).

This is because they normally start from 1 in PostgreSQL. Some tools explicitly filter on attnum > 0 too.