### PR TITLE
More CSV fixes

### DIFF
--- a/splitgraph/ingestion/csv/__init__.py
+++ b/splitgraph/ingestion/csv/__init__.py
@@ -99,6 +99,10 @@ class CSVDataSource(ForeignDataWrapperDataSource):
                 "description": "Sample size, in bytes, for encoding/dialect/header detection",
             },
             "encoding": {"type": "string", "description": "Encoding of the CSV file"},
+            "ignore_decode_errors": {
+                "type": "bool",
+                "description": "Ignore errors when decoding the file",
+            },
             "header": {
                 "type": "boolean",
                 "description": "First line of the CSV file is its header",
@@ -191,6 +195,7 @@ EOF
             "header",
             "separator",
             "quotechar",
+            "ignore_decode_errors",
             "dialect",
         ]:
             if k in self.params:

--- a/splitgraph/ingestion/csv/__init__.py
+++ b/splitgraph/ingestion/csv/__init__.py
@@ -100,7 +100,7 @@ class CSVDataSource(ForeignDataWrapperDataSource):
             },
             "encoding": {"type": "string", "description": "Encoding of the CSV file"},
             "ignore_decode_errors": {
-                "type": "bool",
+                "type": "boolean",
                 "description": "Ignore errors when decoding the file",
             },
             "header": {


### PR DESCRIPTION
Set default dialect to None (otherwise we always use 'excel' when not inferring the dialect). Also add a special `ignore_decode_errors` flag to ignore decoding errors and fall back to UTF-8 if chardet can't detect an encoding.