### PR TITLE
Ingestion and type fixes

### DIFF
--- a/splitgraph/cloud/models.py
+++ b/splitgraph/cloud/models.py
@@ -214,8 +214,8 @@ class UpdateExternalCredentialResponse(BaseModel):
 
 
 class ExternalTableRequest(BaseModel):
-    options: Dict[str, Any]
-    schema_: Dict[str, str] = Field(alias="schema")
+    options: Dict[str, Any] = {}
+    schema_: Optional[Dict[str, str]] = Field(alias="schema")
 
 
 class AddExternalRepositoryRequest(BaseModel):

--- a/splitgraph/cloud/models.py
+++ b/splitgraph/cloud/models.py
@@ -6,7 +6,7 @@ from typing import Dict, List, Optional, Any, Union
 
 from pydantic import BaseModel, Field
 
-from splitgraph.core.types import TableSchema
+from splitgraph.core.types import TableSchema, Params
 
 
 # Models for the externals API data (tables, plugin params etc)
@@ -222,7 +222,7 @@ class AddExternalRepositoryRequest(BaseModel):
     namespace: str
     repository: str
     plugin_name: str
-    params: Dict[str, Any]
+    params: Params
     is_live: bool
     tables: Optional[Dict[str, ExternalTableRequest]]
     credential_id: Optional[str]

--- a/splitgraph/cloud/models.py
+++ b/splitgraph/cloud/models.py
@@ -213,17 +213,18 @@ class UpdateExternalCredentialResponse(BaseModel):
     credential_id: str
 
 
-class AddExternalRepositoryRequest(BaseModel):
-    class Table(BaseModel):
-        options: Dict[str, Any]
-        schema_: Dict[str, str] = Field(alias="schema")
+class ExternalTableRequest(BaseModel):
+    options: Dict[str, Any]
+    schema_: Dict[str, str] = Field(alias="schema")
 
+
+class AddExternalRepositoryRequest(BaseModel):
     namespace: str
     repository: str
     plugin_name: str
     params: Dict[str, Any]
     is_live: bool
-    tables: Optional[Dict[str, Table]]
+    tables: Optional[Dict[str, ExternalTableRequest]]
     credential_id: Optional[str]
 
     @classmethod
@@ -251,7 +252,7 @@ class AddExternalRepositoryRequest(BaseModel):
             plugin_name=external.plugin,
             params=external.params,
             tables={
-                table_name: AddExternalRepositoryRequest.Table(
+                table_name: ExternalTableRequest(
                     options=table.options, schema={c.name: c.pg_type for c in table.schema_}
                 )
                 for table_name, table in external.tables.items()

--- a/splitgraph/commandline/__init__.py
+++ b/splitgraph/commandline/__init__.py
@@ -102,6 +102,12 @@ class WithExceptionHandler(click.Group):
 
     def invoke(self, ctx):
         from splitgraph.engine import get_engine
+        import psycopg2.extensions
+        import psycopg2.extras
+
+        # Allow users to send SIGINT to quickly terminate sgr (instead of waiting for a PG
+        # statement to finish)
+        psycopg2.extensions.set_wait_callback(psycopg2.extras.wait_select)
 
         engine = get_engine()
         try:

--- a/splitgraph/core/types.py
+++ b/splitgraph/core/types.py
@@ -78,7 +78,7 @@ def dict_to_table_schema_params(
         t: (
             [
                 TableColumn(i + 1, cname, ctype, False, None)
-                for (i, (cname, ctype)) in enumerate(tsp.schema_.items())
+                for (i, (cname, ctype)) in enumerate((tsp.schema_ or {}).items())
             ],
             tsp.options,
         )

--- a/splitgraph/core/types.py
+++ b/splitgraph/core/types.py
@@ -10,6 +10,7 @@ from typing import (
     Union,
     TypeVar,
     TYPE_CHECKING,
+    NewType,
 )
 
 if TYPE_CHECKING:
@@ -33,11 +34,11 @@ SourcesList = List[Dict[str, str]]
 ProvenanceLine = Dict[str, Union[str, List[str], List[bool], SourcesList]]
 
 # Ingestion-related params
-Credentials = Dict[str, Any]
-Params = Dict[str, Any]
-TableParams = Dict[str, Any]
+Credentials = NewType("Credentials", Dict[str, Any])
+Params = NewType("Params", Dict[str, Any])
+TableParams = NewType("TableParams", Dict[str, Any])
 TableInfo = Union[List[str], Dict[str, Tuple[TableSchema, TableParams]]]
-SyncState = Dict[str, Any]
+SyncState = NewType("SyncState", Dict[str, Any])
 
 
 class MountError(NamedTuple):
@@ -46,8 +47,10 @@ class MountError(NamedTuple):
     error_text: str
 
 
-PreviewResult = Dict[str, Union[MountError, List[Dict[str, Any]]]]
-IntrospectionResult = Dict[str, Union[Tuple[TableSchema, TableParams], MountError]]
+PreviewResult = NewType("PreviewResult", Dict[str, Union[MountError, List[Dict[str, Any]]]])
+IntrospectionResult = NewType(
+    "IntrospectionResult", Dict[str, Union[Tuple[TableSchema, TableParams], MountError]]
+)
 
 T = TypeVar("T")
 
@@ -80,7 +83,7 @@ def dict_to_table_schema_params(
                 TableColumn(i + 1, cname, ctype, False, None)
                 for (i, (cname, ctype)) in enumerate((tsp.schema_ or {}).items())
             ],
-            tsp.options,
+            TableParams(tsp.options),
         )
         for t, tsp in tables.items()
     }

--- a/splitgraph/core/types.py
+++ b/splitgraph/core/types.py
@@ -1,6 +1,8 @@
 from abc import ABCMeta, abstractmethod
 from typing import Dict, Tuple, Any, NamedTuple, Optional, List, Sequence, Union, TypeVar
 
+from splitgraph.cloud.models import ExternalTableRequest
+
 Changeset = Dict[Tuple[str, ...], Tuple[bool, Dict[str, Any], Dict[str, Any]]]
 
 
@@ -58,15 +60,15 @@ class Comparable(metaclass=ABCMeta):
 
 
 def dict_to_table_schema_params(
-    tables: Dict[str, Dict[str, Any]]
+    tables: Dict[str, ExternalTableRequest]
 ) -> Dict[str, Tuple[TableSchema, TableParams]]:
     return {
         t: (
             [
                 TableColumn(i + 1, cname, ctype, False, None)
-                for (i, (cname, ctype)) in enumerate(tsp["schema"].items())
+                for (i, (cname, ctype)) in enumerate(tsp.schema_.items())
             ],
-            tsp.get("options", {}),
+            tsp.options,
         )
         for t, tsp in tables.items()
     }

--- a/splitgraph/core/types.py
+++ b/splitgraph/core/types.py
@@ -1,7 +1,19 @@
 from abc import ABCMeta, abstractmethod
-from typing import Dict, Tuple, Any, NamedTuple, Optional, List, Sequence, Union, TypeVar
+from typing import (
+    Dict,
+    Tuple,
+    Any,
+    NamedTuple,
+    Optional,
+    List,
+    Sequence,
+    Union,
+    TypeVar,
+    TYPE_CHECKING,
+)
 
-from splitgraph.cloud.models import ExternalTableRequest
+if TYPE_CHECKING:
+    from splitgraph.cloud.models import ExternalTableRequest
 
 Changeset = Dict[Tuple[str, ...], Tuple[bool, Dict[str, Any], Dict[str, Any]]]
 
@@ -60,7 +72,7 @@ class Comparable(metaclass=ABCMeta):
 
 
 def dict_to_table_schema_params(
-    tables: Dict[str, ExternalTableRequest]
+    tables: Dict[str, "ExternalTableRequest"]
 ) -> Dict[str, Tuple[TableSchema, TableParams]]:
     return {
         t: (

--- a/splitgraph/engine/postgres/engine.py
+++ b/splitgraph/engine/postgres/engine.py
@@ -214,10 +214,6 @@ class PsycopgEngine(SQLEngine):
         """
         super().__init__()
 
-        # Allow users to send SIGINT to quickly terminate sgr (instead of waiting for a PG
-        # statement to finish)
-        psycopg2.extensions.set_wait_callback(psycopg2.extras.wait_select)
-
         if not conn_params and not pool:
             raise ValueError("One of conn_params/pool must be specified!")
 

--- a/splitgraph/hooks/data_source/fdw.py
+++ b/splitgraph/hooks/data_source/fdw.py
@@ -19,7 +19,7 @@ from splitgraph.core.types import (
     IntrospectionResult,
     Credentials,
 )
-from splitgraph.exceptions import get_exception_name
+from splitgraph.exceptions import get_exception_name, DataSourceError
 from splitgraph.hooks.data_source.base import (
     MountableDataSource,
     LoadableDataSource,
@@ -279,7 +279,10 @@ class ForeignDataWrapperDataSource(MountableDataSource, LoadableDataSource, ABC)
 
         tmp_schema = get_temporary_table_id()
         try:
-            self.mount(tmp_schema, tables=tables)
+            errors = self.mount(tmp_schema, tables=tables)
+            if errors:
+                raise DataSourceError("Error mounting tables for load")
+
             self.engine.commit()
 
             for t in self.engine.get_all_tables(tmp_schema):

--- a/splitgraph/hooks/data_source/fdw.py
+++ b/splitgraph/hooks/data_source/fdw.py
@@ -1,14 +1,13 @@
+from copy import deepcopy
+
 import json
 import logging
+import psycopg2
 import re
 from abc import ABC, abstractmethod
-from copy import deepcopy
+from psycopg2.sql import SQL, Identifier
 from typing import Optional, Mapping, Dict, List, Any, cast, TYPE_CHECKING, Tuple
 
-import psycopg2
-from psycopg2.sql import SQL, Identifier
-
-from splitgraph.cloud.models import ExternalTableRequest
 from splitgraph.core.types import (
     TableSchema,
     TableColumn,
@@ -51,6 +50,8 @@ class ForeignDataWrapperDataSource(MountableDataSource, LoadableDataSource, ABC)
     @classmethod
     def from_commandline(cls, engine, commandline_kwargs) -> "ForeignDataWrapperDataSource":
         """Instantiate an FDW data source from commandline arguments."""
+        from splitgraph.cloud.models import ExternalTableRequest
+
         # Normally these are supposed to be more user-friendly and FDW-specific (e.g.
         # not forcing the user to pass in a JSON with five levels of nesting etc).
         params = deepcopy(commandline_kwargs)

--- a/splitgraph/hooks/data_source/fdw.py
+++ b/splitgraph/hooks/data_source/fdw.py
@@ -8,6 +8,7 @@ from typing import Optional, Mapping, Dict, List, Any, cast, TYPE_CHECKING, Tupl
 import psycopg2
 from psycopg2.sql import SQL, Identifier
 
+from splitgraph.cloud.models import ExternalTableRequest
 from splitgraph.core.types import (
     TableSchema,
     TableColumn,
@@ -59,7 +60,9 @@ class ForeignDataWrapperDataSource(MountableDataSource, LoadableDataSource, ABC)
         #   * A dictionary table_name -> {"schema": schema, "options": table options}
         tables = params.pop("tables", None)
         if isinstance(tables, dict):
-            tables = dict_to_table_schema_params(tables)
+            tables = dict_to_table_schema_params(
+                {k: ExternalTableRequest.parse_obj(v) for k, v in tables.items()}
+            )
 
         # Extract credentials from the cmdline params
         credentials: Dict[str, Any] = {}

--- a/splitgraph/ingestion/csv/__init__.py
+++ b/splitgraph/ingestion/csv/__init__.py
@@ -4,7 +4,7 @@ from typing import Optional, TYPE_CHECKING, Dict, List, Tuple, Any
 
 from psycopg2.sql import SQL, Identifier
 
-from splitgraph.core.types import TableInfo, MountError
+from splitgraph.core.types import TableInfo, MountError, Credentials
 from splitgraph.hooks.data_source.fdw import ForeignDataWrapperDataSource, import_foreign_schema
 from splitgraph.ingestion.common import IngestionAdapter, build_commandline_help
 
@@ -178,7 +178,7 @@ EOF
     @classmethod
     def from_commandline(cls, engine, commandline_kwargs) -> "CSVDataSource":
         params = deepcopy(commandline_kwargs)
-        credentials = {}
+        credentials = Credentials({})
         for k in ["s3_access_key", "s3_secret_key"]:
             if k in params:
                 credentials[k] = params[k]

--- a/splitgraph/ingestion/singer/data_source.py
+++ b/splitgraph/ingestion/singer/data_source.py
@@ -199,7 +199,7 @@ class SingerDataSource(SyncableDataSource, ABC):
         config = self.get_singer_config()
         singer_schema = self._run_singer_discovery(config)
 
-        result: IntrospectionResult = {}
+        result = IntrospectionResult({})
         for stream in singer_schema["streams"]:
             stream_name = get_table_name(stream)
             stream_schema = get_sg_schema(stream)

--- a/splitgraph/ingestion/socrata/mount.py
+++ b/splitgraph/ingestion/socrata/mount.py
@@ -6,7 +6,7 @@ from typing import Optional, Dict, List
 
 from psycopg2.sql import SQL, Identifier
 
-from splitgraph.core.types import TableInfo, MountError
+from splitgraph.core.types import TableInfo, MountError, Credentials
 from splitgraph.exceptions import RepositoryNotFoundError
 from splitgraph.hooks.data_source.fdw import create_foreign_table, ForeignDataWrapperDataSource
 
@@ -67,7 +67,7 @@ class SocrataDataSource(ForeignDataWrapperDataSource):
         if isinstance(tables, dict) and isinstance(next(iter(tables.values())), str):
             tables = {k: ([], {"socrata_id": v}) for k, v in tables.items()}
 
-        credentials = {"app_token": params.pop("app_token", None)}
+        credentials = Credentials({"app_token": params.pop("app_token", None)})
         return cls(engine, credentials, params, tables)
 
     def get_server_options(self):

--- a/test/splitgraph/ingestion/test_snowflake.py
+++ b/test/splitgraph/ingestion/test_snowflake.py
@@ -4,7 +4,8 @@ from unittest.mock import Mock
 
 import pytest
 
-from splitgraph.core.types import dict_to_table_schema_params
+from splitgraph.cloud.models import ExternalTableRequest
+from splitgraph.core.types import dict_to_table_schema_params, Params, Credentials
 from splitgraph.ingestion.snowflake import SnowflakeDataSource
 
 _sample_privkey = """-----BEGIN PRIVATE KEY-----
@@ -43,17 +44,21 @@ _sample_privkey_b64 = "".join(l for l in _sample_privkey.strip().split("\n")[1:-
 def test_snowflake_data_source_dburl_conversion_warehouse():
     source = SnowflakeDataSource(
         Mock(),
-        credentials={
-            "username": "username",
-            "password": "password",
-            "account": "abcdef.eu-west-1.aws",
-        },
-        params={
-            "database": "SOME_DB",
-            "schema": "TPCH_SF100",
-            "warehouse": "my_warehouse",
-            "role": "role",
-        },
+        credentials=Credentials(
+            {
+                "username": "username",
+                "password": "password",
+                "account": "abcdef.eu-west-1.aws",
+            }
+        ),
+        params=Params(
+            {
+                "database": "SOME_DB",
+                "schema": "TPCH_SF100",
+                "warehouse": "my_warehouse",
+                "role": "role",
+            }
+        ),
     )
 
     assert source.get_server_options() == {
@@ -66,15 +71,19 @@ def test_snowflake_data_source_dburl_conversion_warehouse():
 def test_snowflake_data_source_dburl_conversion_no_warehouse():
     source = SnowflakeDataSource(
         Mock(),
-        credentials={
-            "username": "username",
-            "password": "password",
-            "account": "abcdef.eu-west-1.aws",
-        },
-        params={
-            "database": "SOME_DB",
-            "schema": "TPCH_SF100",
-        },
+        credentials=Credentials(
+            {
+                "username": "username",
+                "password": "password",
+                "account": "abcdef.eu-west-1.aws",
+            }
+        ),
+        params=Params(
+            {
+                "database": "SOME_DB",
+                "schema": "TPCH_SF100",
+            }
+        ),
     )
 
     assert source.get_server_options() == {
@@ -88,15 +97,19 @@ def test_snowflake_data_source_dburl_conversion_no_warehouse():
 def test_snowflake_data_source_private_key(private_key):
     source = SnowflakeDataSource(
         Mock(),
-        credentials={
-            "username": "username",
-            "private_key": private_key,
-            "account": "abcdef.eu-west-1.aws",
-        },
-        params={
-            "database": "SOME_DB",
-            "schema": "TPCH_SF100",
-        },
+        credentials=Credentials(
+            {
+                "username": "username",
+                "private_key": private_key,
+                "account": "abcdef.eu-west-1.aws",
+            }
+        ),
+        params=Params(
+            {
+                "database": "SOME_DB",
+                "schema": "TPCH_SF100",
+            }
+        ),
     )
 
     opts = source.get_server_options()
@@ -114,20 +127,27 @@ def test_snowflake_data_source_private_key(private_key):
 def test_snowflake_data_source_table_options():
     source = SnowflakeDataSource(
         Mock(),
-        credentials={
-            "username": "username",
-            "password": "password",
-            "account": "abcdef.eu-west-1.aws",
-        },
-        params={
-            "database": "SOME_DB",
-        },
+        credentials=Credentials(
+            {
+                "username": "username",
+                "password": "password",
+                "account": "abcdef.eu-west-1.aws",
+            }
+        ),
+        params=Params(
+            {
+                "database": "SOME_DB",
+            }
+        ),
         tables=dict_to_table_schema_params(
             {
-                "test_table": {
-                    "schema": {"col_1": "int", "col_2": "varchar"},
-                    "options": {"subquery": "SELECT col_1, col_2 FROM other_table"},
-                }
+                k: ExternalTableRequest.parse_obj(v)
+                for k, v in {
+                    "test_table": {
+                        "schema": {"col_1": "int", "col_2": "varchar"},
+                        "options": {"subquery": "SELECT col_1, col_2 FROM other_table"},
+                    }
+                }.items()
             }
         ),
     )

--- a/test/splitgraph/test_misc.py
+++ b/test/splitgraph/test_misc.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 import pytest
 from psycopg2.errors import CheckViolation
 
+from splitgraph.cloud.models import ExternalTableRequest
 from splitgraph.core.common import Tracer, adapt, coerce_val_to_json
 from splitgraph.core.output import parse_dt
 from splitgraph.core.engine import lookup_repository
@@ -368,14 +369,17 @@ def test_table_schema_params_to_dict():
 def test_dict_to_table_schema_params():
     assert dict_to_table_schema_params(
         {
-            "fruits": {
-                "schema": {"fruit_id": "integer", "name": "character varying"},
-                "options": {"key": "value"},
-            },
-            "vegetables": {
-                "schema": {"name": "character varying", "vegetable_id": "integer"},
-                "options": {"key": "value"},
-            },
+            k: ExternalTableRequest.parse_obj(v)
+            for k, v in {
+                "fruits": {
+                    "schema": {"fruit_id": "integer", "name": "character varying"},
+                    "options": {"key": "value"},
+                },
+                "vegetables": {
+                    "schema": {"name": "character varying", "vegetable_id": "integer"},
+                    "options": {"key": "value"},
+                },
+            }.items()
         }
     ) == {
         "fruits": (


### PR DESCRIPTION
* Move the wait_select callback injection to the interactive sgr entry point (breaks multithreaded CSV loading)
* Make some changes to types and strengthen typing (e.g. use `NewType` instead of type aliases in some places)
* Don't immediately crash on Singer ingestion failures, give it a chance to emit some state.