### PR TITLE
In `adapt()`, bypass casting if the value isn't a string already (whe…

### DIFF
--- a/splitgraph/core/common.py
+++ b/splitgraph/core/common.py
@@ -362,6 +362,8 @@ def adapt(value: Any, pg_type: str) -> Any:
     """
     if value is None:
         return None
+    if not isinstance(value, str):
+        return value
     if pg_type in _TYPE_MAP:
         return _TYPE_MAP[pg_type](value)
     return value


### PR DESCRIPTION
…n we fake a changeset, we already do it with the parsed datetimes etc, so adapt() crashes).