### PR TITLE
Use the `local` logging driver by default on Airbyte containers so th…

### DIFF
--- a/splitgraph/ingestion/airbyte/data_source.py
+++ b/splitgraph/ingestion/airbyte/data_source.py
@@ -11,6 +11,7 @@ import docker.errors
 import pydantic
 from docker import DockerClient
 from docker.models.containers import Container
+from docker.types import LogConfig
 
 from splitgraph.core.repository import Repository
 from splitgraph.core.types import (
@@ -390,6 +391,7 @@ class AirbyteDataSource(SyncableDataSource, ABC):
             command=command,
             network_mode=network_mode,
             environment=self.docker_environment,
+            log_config=LogConfig(type="local"),
         )
         with remove_at_end(container):
             yield container
@@ -413,6 +415,7 @@ class AirbyteDataSource(SyncableDataSource, ABC):
             network_mode=network_mode,
             stdin_open=True,
             environment=self.docker_environment,
+            log_config=LogConfig(type="local"),
         )
         with remove_at_end(container):
             yield container
@@ -436,6 +439,7 @@ class AirbyteDataSource(SyncableDataSource, ABC):
             command=command,
             network_mode=network_mode,
             environment=self.docker_environment,
+            log_config=LogConfig(type="local"),
         )
 
         with remove_at_end(container):


### PR DESCRIPTION
…at Docker rotates the log files where they currently output the raw records.