### PR TITLE
Add support for `is_live` to repositories.yml

### DIFF
--- a/splitgraph/cloud/models.py
+++ b/splitgraph/cloud/models.py
@@ -197,7 +197,7 @@ def make_repositories(
 class ListExternalCredentialsResponse(BaseModel):
     class ExternalCredential(BaseModel):
         plugin_name: str
-        credential_name: str
+        credential_name: Optional[str]
         credential_id: str
 
     credentials: List[ExternalCredential]

--- a/splitgraph/cloud/models.py
+++ b/splitgraph/cloud/models.py
@@ -38,6 +38,7 @@ class External(BaseModel):
     plugin: str
     params: Dict[str, Any]
     tables: Dict[str, Table]
+    is_live: bool = True
     schedule: Optional[IngestionSchedule]
 
 
@@ -265,7 +266,7 @@ class AddExternalRepositoryRequest(BaseModel):
                 for table_name, table in external.tables.items()
             },
             credential_id=credential_id,
-            is_live=True,
+            is_live=external.is_live,
             schedule=external.schedule,
         )
 


### PR DESCRIPTION
This lets users set it to False for non-live datasets (e.g. Airbyte/Singer loads). Note that this doesn't roundtrip right now (sgr cloud dump won't output the table back because of where the table schema is stored on the server in the case of non-live datasets).