### PR TITLE
Fix mount for data source with empty credentials schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ To run the test suite related to "mounting" and importing data from other databa
 (PostgreSQL, MySQL, Mongo), do
 
 ```
-docker-compose -f test/architecture/docker-compose.core.yml -f test/architecture/docker-compose.core.yml up -d
+docker-compose -f test/architecture/docker-compose.core.yml -f test/architecture/docker-compose.mounting.yml up -d
 poetry run pytest -m mounting
 ```
 

--- a/splitgraph/hooks/data_source/fdw.py
+++ b/splitgraph/hooks/data_source/fdw.py
@@ -68,7 +68,7 @@ class ForeignDataWrapperDataSource(MountableDataSource, LoadableDataSource, ABC)
 
         # Extract credentials from the cmdline params
         credentials = Credentials({})
-        for k in cast(Dict[str, Any], cls.credentials_schema["properties"]).keys():
+        for k in cast(Dict[str, Any], cls.credentials_schema.get("properties", {})).keys():
             if k in params:
                 credentials[k] = params[k]
 

--- a/test/splitgraph/commands/test_mounting.py
+++ b/test/splitgraph/commands/test_mounting.py
@@ -197,3 +197,25 @@ def test_mount_elasticsearch(local_engine_empty):
 
     finally:
         repo.delete()
+
+
+@pytest.mark.mounting
+def test_mount_with_empty_credentials(local_engine_empty):
+    class EmptyCredentialsSchemaDataSource(PostgreSQLDataSource):
+        credentials_schema = {"type": "object"}
+
+        def get_user_options(self):
+            return {"user": "originro", "password": "originpass"}
+
+    handler = EmptyCredentialsSchemaDataSource(
+        engine=local_engine_empty,
+        credentials={},
+        params={"host": "pgorigin", "port": 5432, "dbname": "origindb", "remote_schema": "public"},
+    )
+
+    tables = handler.introspect()
+    assert tables
+    assert handler.from_commandline(
+        handler.engine,
+        {"host": "pgorigin", "port": 5432, "dbname": "origindb", "remote_schema": "public"},
+    )


### PR DESCRIPTION
When I was checking [the hn example](https://www.splitgraph.com/blog/foreign-data-wrappers) I got an error
```
root@b809fd2dba0c:/# sgr mount hackernews hackernews
error: KeyError: 'properties'

root@b809fd2dba0c:/# sgr -v DEBUG mount hackernews hackernews
error: Traceback (most recent call last):
error:   File "/usr/local/lib/python3.8/site-packages/splitgraph/commandline/__init__.py", line 115, in invoke
error:     result = super(click.Group, self).invoke(ctx)
error:   File "/usr/local/lib/python3.8/site-packages/click/core.py", line 1259, in invoke
error:     return _process_result(sub_ctx.command.invoke(sub_ctx))
error:   File "/usr/local/lib/python3.8/site-packages/click/core.py", line 1259, in invoke
error:     return _process_result(sub_ctx.command.invoke(sub_ctx))
error:   File "/usr/local/lib/python3.8/site-packages/click/core.py", line 1066, in invoke
error:     return ctx.invoke(self.callback, **ctx.params)
error:   File "/usr/local/lib/python3.8/site-packages/click/core.py", line 610, in invoke
error:     return callback(*args, **kwargs)
error:   File "/usr/local/lib/python3.8/site-packages/splitgraph/commandline/mount.py", line 69, in _callback
error:     mount(schema, mount_handler=handler_name, handler_kwargs=handler_options)
error:   File "/usr/local/lib/python3.8/site-packages/splitgraph/hooks/mount_handlers.py", line 68, in mount
error:     source = data_source.from_commandline(engine, handler_kwargs)
error:   File "/hn_fdw/hn_fdw/mount.py", line 42, in from_commandline
error:     self = super().from_commandline(*args, **kwargs)
error:   File "/usr/local/lib/python3.8/site-packages/splitgraph/hooks/data_source/fdw.py", line 71, in from_commandline
error:     for k in cast(Dict[str, Any], cls.credentials_schema["properties"]).keys():
error: KeyError: 'properties'
```

I was thinking about just fixing `HackerNewsDataSource` like this:
```diff
--- a/examples/custom_fdw/src/hn_fdw/mount.py
+++ b/examples/custom_fdw/src/hn_fdw/mount.py
@@ -34,7 +34,7 @@ _all_endpoints = [
 
 
 class HackerNewsDataSource(ForeignDataWrapperDataSource):
-    credentials_schema = {"type": "object"}
+    credentials_schema = {"type": "object", "properties": {}}
 
     @classmethod
     def from_commandline(cls, *args, **kwargs):

```

But decided to go a little bit further and create a test reproducing error and more general fix.