### PR TITLE
Fix a query performance issue with tables without a PK.

### DIFF
--- a/splitgraph/core/table.py
+++ b/splitgraph/core/table.py
@@ -183,6 +183,11 @@ class QueryPlan:
         # Get fragment boundaries (min-max PKs of every fragment).
         table_pk = get_change_key(self.table.table_schema)
         object_pks = self.object_manager.get_min_max_pks(self.filtered_objects, table_pk)
+
+        surrogate_pk = not any(t.is_pk for t in self.table.table_schema)
+        if surrogate_pk:
+            object_pks = self.table.repository.objects.generate_surrogate_pk(self.table, object_pks)
+
         # Group fragments into non-overlapping groups: those can be applied independently of each other.
         object_groups = get_chunk_groups(
             [


### PR DESCRIPTION
When partitioning data, if the table doesn't have a primary key, we use a "surrogate"
primary key by concatenating the whole row as a string on the PG side (this is because
the whole row can sometimes contain NULLs which we can't compare in PG).

The query planner used to use the non-textual composite PK to figure out which
chunks overlapped in order to materialize them. This meant false positives where
something like (2, 'orange') would force a materialization because numerically,
it's greater than 10 and lexicographically, it isn't.

To fix this, regenerate the textual surrogate PK at query plan time and use it
to figure out when chunks overlap.