### PR TITLE
Fix Docker network mode discovery for sibling containers.

### DIFF
--- a/splitgraph/ingestion/airbyte/data_source.py
+++ b/splitgraph/ingestion/airbyte/data_source.py
@@ -174,7 +174,7 @@ class AirbyteDataSource(SyncableDataSource, ABC):
 
     def _run_discovery(self, config: Optional[AirbyteConfig] = None) -> AirbyteCatalog:
         client = get_docker_client()
-        network_mode = detect_network_mode(client)
+        network_mode = detect_network_mode()
 
         with self._source_container(
             client,
@@ -246,7 +246,7 @@ class AirbyteDataSource(SyncableDataSource, ABC):
         staging_schema = "sg_tmp_" + repository.to_schema().replace("/", "_").replace("-", "_")
         dst_config = self._make_postgres_config(repository.object_engine, staging_schema)
         client = get_docker_client()
-        network_mode = detect_network_mode(client)
+        network_mode = detect_network_mode()
 
         with delete_schema_at_end(repository.object_engine, staging_schema):
             repository.object_engine.delete_schema(staging_schema)

--- a/splitgraph/ingestion/dbt/utils.py
+++ b/splitgraph/ingestion/dbt/utils.py
@@ -147,7 +147,7 @@ def run_dbt_transformation_from_git(
 
     # Clone the repo into a temporary location and patch it to point to our staging schema
     client = get_docker_client()
-    network_mode = detect_network_mode(client)
+    network_mode = detect_network_mode()
     with TemporaryDirectory() as tmp_dir:
         # Prepare the target directory that we'll copy into the dbt container.
         # We can't bind mount it since we ourselves could be running inside of Docker.
@@ -203,7 +203,7 @@ def compile_dbt_manifest(
 
     # Clone the repo into a temporary location and patch it to point to our staging schema
     client = get_docker_client()
-    network_mode = detect_network_mode(client)
+    network_mode = detect_network_mode()
     with TemporaryDirectory() as tmp_dir:
         # Prepare the target directory that we'll copy into the dbt container.
         # We can't bind mount it since we ourselves could be running inside of Docker.


### PR DESCRIPTION
In nomad, `/proc/1/cpuset` is `/nomad/shared`, use a more robust method for
discovering the container ID.