### PR TITLE
Add sgr cloud download (download query as CSV)

### DIFF
--- a/docs/generate_reference.py
+++ b/docs/generate_reference.py
@@ -30,6 +30,7 @@ from splitgraph.commandline.cloud import (
     stub_c,
     plugins_c,
     sync_c,
+    download_c,
 )
 from splitgraph.commandline.engine import (
     add_engine_c,
@@ -89,6 +90,7 @@ STRUCTURE = [
             "cloud status",
             "cloud logs",
             "cloud upload",
+            "cloud download",
             "cloud plugins",
             "cloud stub",
             "cloud validate",
@@ -127,6 +129,7 @@ STRUCTURE_CMD_OVERRIDE = {
     "cloud status": status_c,
     "cloud logs": logs_c,
     "cloud upload": upload_c,
+    "cloud download": download_c,
     "cloud sync": sync_c,
     "cloud plugins": plugins_c,
     "cloud stub": stub_c,

--- a/splitgraph/cloud/models.py
+++ b/splitgraph/cloud/models.py
@@ -155,12 +155,21 @@ class ExternalResponse(BaseModel):
         )
 
 
-class IngestionJobStatus(BaseModel):
+class JobStatus(BaseModel):
     task_id: str
     started: datetime
     finished: Optional[datetime]
-    is_manual: bool
     status: Optional[str]
+
+
+class IngestionJobStatus(JobStatus):
+    is_manual: bool
+
+
+class ExportJobStatus(JobStatus):
+    user_id: Optional[str]
+    export_format: str
+    output: Optional[Dict[str, Any]]
 
 
 class RepositoryIngestionJobStatusResponse(BaseModel):

--- a/splitgraph/cloud/queries.py
+++ b/splitgraph/cloud/queries.py
@@ -272,3 +272,23 @@ GET_PLUGIN = """query ExternalPlugin($pluginName: String!) {
     supportsLoad
   }
 }"""
+
+START_EXPORT = """mutation StartExport($query: String!) {
+  exportQuery(query: $query, exportFormat: "csv") {
+    id
+  }
+}
+"""
+
+EXPORT_JOB_STATUS = """query ExportJobStatus($taskId: UUID!) {
+  exportJobStatus(taskId: $taskId) {
+    taskId
+    started
+    finished
+    status
+    userId
+    exportFormat
+    output
+  }
+}
+"""

--- a/splitgraph/commandline/cloud.py
+++ b/splitgraph/commandline/cloud.py
@@ -980,8 +980,8 @@ def wait_for_download(client: "GQLAPIClient", task_id: str) -> str:
 @click.option("--remote", default="data.splitgraph.com", help="Name of the remote registry to use.")
 @click.option("--file-format", default="csv", type=click.Choice(["csv"]))
 @click.argument("query", type=str)
-@click.argument("output_filename", type=str, default=None, required=False)
-def download_c(remote, file_format, query, output_filename):
+@click.argument("output_path", type=str, default=None, required=False)
+def download_c(remote, file_format, query, output_path):
     """
     Download query results from Splitgraph.
 
@@ -993,7 +993,7 @@ def download_c(remote, file_format, query, output_filename):
 
     task_id = client.start_export(query=query)
     download_url = wait_for_download(client, task_id)
-    download_file(download_url, output_filename)
+    download_file(download_url, output_path)
 
 
 @click.command("sync")

--- a/splitgraph/commandline/common.py
+++ b/splitgraph/commandline/common.py
@@ -1,12 +1,29 @@
 """
 Various common functions used by the command line interface.
 """
+import itertools
 import json
+import os
+import sys
+import time
 from functools import wraps
-from typing import TYPE_CHECKING, Any, List, Optional, Tuple, Union
+from typing import (
+    IO,
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Iterator,
+    List,
+    Optional,
+    Tuple,
+    TypeVar,
+    Union,
+)
+from urllib.parse import urlparse
 
 import click
 from click.core import Context, Parameter
+from splitgraph.cloud.models import JobStatus
 from splitgraph.config import REMOTES
 from splitgraph.exceptions import RepositoryNotFoundError
 
@@ -188,3 +205,93 @@ def emit_sql_results(results, use_json=False, show_all=False):
             click.echo("...")
     else:
         click.echo(sql_results_to_str(results, use_json))
+
+
+GQL_POLL_TIME = 5
+SPINNER_FREQUENCY = 10
+
+
+def get_spinner_settings() -> Tuple[Iterator[str], int]:
+    from splitgraph.config import SG_CMD_ASCII
+
+    chars = ["|", "/", "-", "\\"] if SG_CMD_ASCII else ["⣾", "⣽", "⣻", "⢿", "⡿", "⣟", "⣯", "⣷"]
+    spinner = itertools.cycle(chars)
+    poll_interval = max(int(SPINNER_FREQUENCY * GQL_POLL_TIME), 1)
+    return spinner, poll_interval
+
+
+S = TypeVar("S", bound=JobStatus)
+
+
+def wait_for_job(task_id: str, status_callback: Callable[[], Optional[S]]) -> S:
+    """
+    Wait for a job to complete (with a CLI spinner) and return its final result.
+
+    :param task_id: ID of the task (used for display)
+    :param status_callback: Callback that returns a `JobStatus`
+    :return: Final `JobStatus`
+    """
+    spinner, poll_interval = get_spinner_settings()
+
+    interval = 0
+    status_str: Optional[str] = None
+    while True:
+        if interval % poll_interval == 0:
+            status = status_callback()
+            if not status:
+                raise AssertionError("Job not found")
+
+            if not sys.stdout.isatty() and status_str != status.status:
+                click.echo(
+                    f" ({status.status}) Waiting for task ID {task_id}",
+                )
+            status_str = status.status
+
+        if sys.stdout.isatty():
+            click.echo(f"\033[2K\033[1G{next(spinner)}", nl=False)
+            click.echo(f" ({status_str}) Waiting for task ID {task_id}", nl=False)
+            sys.stdout.flush()
+        time.sleep(1.0 / SPINNER_FREQUENCY)
+        interval += 1
+
+        if status_str in ("SUCCESS", "FAILURE"):
+            click.echo()
+            assert status
+            return status
+
+
+def upload_file(file: IO, upload_url: str) -> None:
+    """Upload a file to a presigned URL with a tqdm progress bar"""
+    import requests
+    from tqdm import tqdm
+    from tqdm.utils import CallbackIOWrapper
+
+    size = os.fstat(file.fileno()).st_size
+    with tqdm(total=size, unit="B", unit_scale=True, unit_divisor=1024) as t:
+        wrapped_file = CallbackIOWrapper(t.update, file, "read")
+        t.set_description(os.path.basename(file.name))
+        requests.put(upload_url, data=wrapped_file)
+
+
+def download_file(url: str, filename: Optional[str]) -> None:
+    """Download a file with a tqdm progress bar"""
+    import re
+
+    import requests
+    from tqdm import tqdm
+
+    response = requests.get(url, stream=True)
+    if not filename and "Content-Disposition" in response.headers.keys():
+        filename = re.findall("filename=(.+)", response.headers["Content-Disposition"])[0]
+    if not filename:
+        filename = urlparse(url).path.split("/")[-1]
+    with open(filename, "wb") as f:
+        with tqdm.wrapattr(
+            f,
+            "write",
+            miniters=1,
+            desc=filename,
+            total=int(response.headers.get("content-length", 0)),
+        ) as fout:
+            for chunk in response.iter_content(chunk_size=4096):
+                fout.write(chunk)

--- a/splitgraph/commandline/common.py
+++ b/splitgraph/commandline/common.py
@@ -243,13 +243,13 @@ def wait_for_job(task_id: str, status_callback: Callable[[], Optional[S]]) -> S:
 
             if not sys.stdout.isatty() and status_str != status.status:
                 click.echo(
-                    f" ({status.status}) Waiting for task ID {task_id}",
+                    f" ({status.status or 'PENDING'}) Waiting for task ID {task_id}",
                 )
             status_str = status.status
 
         if sys.stdout.isatty():
             click.echo(f"\033[2K\033[1G{next(spinner)}", nl=False)
-            click.echo(f" ({status_str}) Waiting for task ID {task_id}", nl=False)
+            click.echo(f" ({status_str or 'PENDING'}) Waiting for task ID {task_id}", nl=False)
             sys.stdout.flush()
         time.sleep(1.0 / SPINNER_FREQUENCY)
         interval += 1

--- a/splitgraph/commandline/common.py
+++ b/splitgraph/commandline/common.py
@@ -295,3 +295,4 @@ def download_file(url: str, filename: Optional[str]) -> None:
         ) as fout:
             for chunk in response.iter_content(chunk_size=4096):
                 fout.write(chunk)
+    click.echo("Downloaded query results to %s." % filename)

--- a/test/splitgraph/commandline/snapshots/test_cloud_jobs/test_csv_download/False/sgr_cloud_download_failure.txt
+++ b/test/splitgraph/commandline/snapshots/test_cloud_jobs/test_csv_download/False/sgr_cloud_download_failure.txt
@@ -1,0 +1,2 @@
+ (FAILURE) Waiting for task ID export_task
+

--- a/test/splitgraph/commandline/snapshots/test_cloud_jobs/test_csv_download/True/sgr_cloud_download_success.txt
+++ b/test/splitgraph/commandline/snapshots/test_cloud_jobs/test_csv_download/True/sgr_cloud_download_success.txt
@@ -1,0 +1,2 @@
+ (SUCCESS) Waiting for task ID export_task
+

--- a/test/splitgraph/commandline/snapshots/test_cloud_jobs/test_csv_download/True/sgr_cloud_download_success.txt
+++ b/test/splitgraph/commandline/snapshots/test_cloud_jobs/test_csv_download/True/sgr_cloud_download_success.txt
@@ -1,2 +1,3 @@
  (SUCCESS) Waiting for task ID export_task
 
+Downloaded query results to some-file.csv.gz.

--- a/test/splitgraph/commandline/snapshots/test_cloud_jobs/test_csv_upload/False/sgr_cloud_upload_failure.txt
+++ b/test/splitgraph/commandline/snapshots/test_cloud_jobs/test_csv_upload/False/sgr_cloud_upload_failure.txt
@@ -1,5 +1,5 @@
 Uploading the files...
- (STARTED) Loading someuser/somerepo_1, task ID ingest_task
- (FAILURE) Loading someuser/somerepo_1, task ID ingest_task
+ (STARTED) Waiting for task ID ingest_task
+ (FAILURE) Waiting for task ID ingest_task
 
 Logs for /someuser/somerepo_1/ingest_task

--- a/test/splitgraph/commandline/snapshots/test_cloud_jobs/test_csv_upload/True/sgr_cloud_upload_success.txt
+++ b/test/splitgraph/commandline/snapshots/test_cloud_jobs/test_csv_upload/True/sgr_cloud_upload_success.txt
@@ -1,6 +1,6 @@
 Uploading the files...
- (STARTED) Loading someuser/somerepo_1, task ID ingest_task
- (SUCCESS) Loading someuser/somerepo_1, task ID ingest_task
+ (STARTED) Waiting for task ID ingest_task
+ (SUCCESS) Waiting for task ID ingest_task
 
 
 Success. See the repository at http://www.example.com/someuser/somerepo_1/-/tables or query it with:

--- a/test/splitgraph/commandline/test_cloud_jobs.py
+++ b/test/splitgraph/commandline/test_cloud_jobs.py
@@ -154,7 +154,7 @@ def test_csv_upload(success, snapshot):
         new_callable=PropertyMock,
         return_value=ACCESS_TOKEN,
     ), patch("splitgraph.cloud.get_remote_param", return_value=GQL_ENDPOINT), patch(
-        "splitgraph.commandline.cloud.GQL_POLL_TIME", 0
+        "splitgraph.commandline.common.GQL_POLL_TIME", 0
     ):
         # Also patch out the poll frequency so that we don't wait between calls to the job
         # status endpoint.

--- a/test/splitgraph/commandline/test_cloud_jobs.py
+++ b/test/splitgraph/commandline/test_cloud_jobs.py
@@ -1,10 +1,12 @@
 import os
 import re
 from pathlib import Path
+from tempfile import TemporaryDirectory
 from test.splitgraph.commandline.http_fixtures import (
     ACCESS_TOKEN,
     GQL_ENDPOINT,
     STORAGE_ENDPOINT,
+    gql_download,
     gql_job_logs,
     gql_job_status,
     gql_sync,
@@ -23,6 +25,7 @@ from click.testing import CliRunner
 from splitgraph.commandline.cloud import (
     _deduplicate_items,
     _get_external_from_yaml,
+    download_c,
     logs_c,
     status_c,
     sync_c,
@@ -266,3 +269,60 @@ def test_get_external_from_yaml():
     external, credentials = _get_external_from_yaml([path], Repository("otheruser", "somerepo_2"))
     assert external.plugin == "plugin"
     assert credentials == {"username": "my_username", "password": "secret"}
+
+
+@httpretty.activate(allow_net_connect=False)
+@pytest.mark.parametrize("success", [True, False])
+def test_csv_download(success, snapshot):
+    gql_download_cb, file_download_cb = gql_download(
+        final_status="SUCCESS" if success else "FAILURE",
+    )
+
+    runner = CliRunner(mix_stderr=False)
+    httpretty.register_uri(
+        httpretty.HTTPretty.POST,
+        GQL_ENDPOINT + "/",
+        body=gql_download_cb,
+    )
+
+    httpretty.register_uri(
+        httpretty.HTTPretty.GET,
+        re.compile(re.escape(STORAGE_ENDPOINT + "/") + ".*"),
+        body=file_download_cb,
+    )
+
+    with patch(
+        "splitgraph.cloud.RESTAPIClient.access_token",
+        new_callable=PropertyMock,
+        return_value=ACCESS_TOKEN,
+    ), patch("splitgraph.cloud.get_remote_param", return_value=GQL_ENDPOINT), patch(
+        "splitgraph.commandline.common.GQL_POLL_TIME", 0
+    ):
+        # Also patch out the poll frequency so that we don't wait between calls to the job
+        # status endpoint.
+        with TemporaryDirectory() as tmpdir:
+            currdir = os.getcwd()
+            try:
+                os.chdir(tmpdir)
+                result = runner.invoke(
+                    download_c,
+                    [
+                        # Also check that we strip semicolons since the downloader uses
+                        # "COPY (query) TO ..."
+                        "SELECT * FROM some_table;"
+                    ],
+                )
+            finally:
+                os.chdir(currdir)
+
+            if success:
+                assert result.exit_code == 0
+                snapshot.assert_match(result.stdout, "sgr_cloud_download_success.txt")
+
+                assert os.listdir(tmpdir) == ["some-file.csv.gz"]
+                with open(os.path.join(tmpdir, "some-file.csv.gz"), "r") as f:
+                    assert f.read() == "fruit_id,timestamp,name"
+
+            else:
+                assert result.exit_code == 1
+                snapshot.assert_match(result.stdout, "sgr_cloud_download_failure.txt")


### PR DESCRIPTION
Use the GQL Export API to download query results as a `.csv.gz` file.

Sample usage:

```bash
$ cat test.sql
SELECT * FROM "some/repo".some_table

$ sgr cloud download "$(cat test.sql)"
⣯ (SUCCESS) Waiting for task ID 5ebe8857-5592-4271-a6af-0360f2b74692
query-e2abcf218bbc964ff9999b08c06c97447018c395-20211217-134600.csv.gz: 100%|██████████████████████████████████████| 104M/104M [00:07<00:00, 13.6MB/s]
Downloaded query results to query-e2abcf218bbc964ff9999b08c06c97447018c395-20211217-134600.csv.gz.

(splitgraph-3.9.4)  ~ $ cat query-e2abcf218bbc964ff9999b08c06c97447018c395-20211217-134600.csv.gz | gunzip | wc -l
12232602
```