### PR TITLE
Allow reintrospecting datasets when running `sgr cloud load`

### DIFF
--- a/.ci/prepare_doc_bundle.sh
+++ b/.ci/prepare_doc_bundle.sh
@@ -26,8 +26,9 @@ python generate_reference.py sgr "$TARGET_DIR"/sgr
 echo "Generating configuration reference"
 python generate_reference.py config "$TARGET_DIR"/0100_config-flag-reference.mdx
 
-echo "Building Asciinema casts"
-TARGET_DIR=$TARGET_DIR "$CI_DIR"/rebuild_asciicasts.sh
+# Temporarily disabled: these take way too much time and aren't used by the website.
+# echo "Building Asciinema casts"
+# TARGET_DIR=$TARGET_DIR "$CI_DIR"/rebuild_asciicasts.sh
 
 echo "Archiving the bundle $OUTPUT.tar.gz"
 cd "$TARGET_DIR"/..

--- a/splitgraph/cloud/__init__.py
+++ b/splitgraph/cloud/__init__.py
@@ -36,6 +36,7 @@ from splitgraph.cloud.models import (
     ExportJobStatus,
     ExternalResponse,
     IngestionJobStatus,
+    IntrospectionMode,
     ListExternalCredentialsResponse,
     MetadataResponse,
     Plugin,
@@ -530,8 +531,14 @@ class RESTAPIClient:
                 raise JSONSchemaValidationError(message="[MASKED]")
             raise
 
-    def bulk_upsert_external(self, repositories: List[AddExternalRepositoryRequest]):
-        request = AddExternalRepositoriesRequest(repositories=repositories)
+    def bulk_upsert_external(
+        self,
+        repositories: List[AddExternalRepositoryRequest],
+        introspection_mode: IntrospectionMode = IntrospectionMode.EMPTY,
+    ):
+        request = AddExternalRepositoriesRequest(
+            repositories=repositories, introspection_mode=introspection_mode
+        )
         self._perform_request(
             "/bulk-add",
             self.access_token,

--- a/splitgraph/cloud/models.py
+++ b/splitgraph/cloud/models.py
@@ -16,7 +16,7 @@ from splitgraph.cloud.project.models import (
     Source,
     Table,
 )
-from splitgraph.core.types import Params, TableSchema
+from splitgraph.core.types import MountError, Params, TableSchema
 
 
 class Plugin(BaseModel):
@@ -301,3 +301,13 @@ class AddExternalRepositoryRequest(BaseModel):
 class AddExternalRepositoriesRequest(BaseModel):
     repositories: List[AddExternalRepositoryRequest]
     introspection_mode: IntrospectionMode = IntrospectionMode.EMPTY
+
+
+class AddExternalRepositoriesResponse(BaseModel):
+    class RepositoryMountError(BaseModel):
+        namespace: str
+        repository: str
+        errors: List[MountError]
+
+    live_image_hashes: List[Optional[str]]
+    errors: Optional[List[RepositoryMountError]] = None

--- a/splitgraph/cloud/models.py
+++ b/splitgraph/cloud/models.py
@@ -1,6 +1,7 @@
 """
 Definitions for responses from the cloud GQL/REST APIs
 """
+import enum
 import logging
 from datetime import datetime
 from typing import Any, Dict, List, Optional
@@ -28,6 +29,16 @@ class Plugin(BaseModel):
     supports_mount: bool
     supports_load: bool
     supports_sync: bool
+
+
+class IntrospectionMode(str, enum.Enum):
+    """
+    Which tables to (re)introspect when adding an external.
+    """
+
+    NONE = "none"  # Don't reintrospect any tables
+    EMPTY = "empty"  # Introspect tables with an empty schema
+    ALL = "all"  # Reintrospect all tables
 
 
 # GQL response for the catalog metadata
@@ -289,3 +300,4 @@ class AddExternalRepositoryRequest(BaseModel):
 
 class AddExternalRepositoriesRequest(BaseModel):
     repositories: List[AddExternalRepositoryRequest]
+    introspection_mode: IntrospectionMode = IntrospectionMode.EMPTY

--- a/splitgraph/commandline/cloud.py
+++ b/splitgraph/commandline/cloud.py
@@ -15,7 +15,7 @@ from urllib.parse import quote, urlparse
 import click
 from click import wrap_text
 
-from splitgraph.cloud.models import AddExternalRepositoryRequest
+from splitgraph.cloud.models import AddExternalRepositoryRequest, IntrospectionMode
 from splitgraph.cloud.project.models import Metadata, SplitgraphYAML
 from splitgraph.commandline.common import (
     ImageType,
@@ -613,9 +613,22 @@ def dump_c(remote, readme_dir, repositories_file, limit_repositories):
     is_flag=True,
     help="Only set up the metadata, not the external data source settings",
 )
+@click.option(
+    "--introspection-mode",
+    type=click.Choice(IntrospectionMode),
+    default=IntrospectionMode.EMPTY,
+    help="Whether to reintrospect tables. none: never reintrospect. all: reintrospect all tables. "
+    "empty: only reintrospect tables with an empty schema.",
+)
 @click.argument("limit_repositories", type=str, nargs=-1)
 def load_c(
-    remote, readme_dir, skip_external, initial_private, repositories_file, limit_repositories
+    remote,
+    readme_dir,
+    skip_external,
+    initial_private,
+    repositories_file,
+    limit_repositories,
+    introspection_mode,
 ):
     """
     Load a Splitgraph catalog from a YAML file.
@@ -666,7 +679,9 @@ def load_c(
                     initial_private=initial_private,
                 )
                 external_repositories.append(external_repository)
-        rest_client.bulk_upsert_external(repositories=external_repositories)
+        rest_client.bulk_upsert_external(
+            repositories=external_repositories, introspection_mode=introspection_mode
+        )
         logging.info(f"Uploaded images for {pluralise('repository', len(external_repositories))}")
 
     logging.info("Updating metadata...")

--- a/splitgraph/commandline/cloud.py
+++ b/splitgraph/commandline/cloud.py
@@ -620,6 +620,11 @@ def dump_c(remote, readme_dir, repositories_file, limit_repositories):
     help="Whether to reintrospect tables. none: never reintrospect. all: reintrospect all tables. "
     "empty: only reintrospect tables with an empty schema.",
 )
+@click.option(
+    "--ignore-introspection-errors",
+    is_flag=True,
+    help="If set, will ignore errors when introspecting tables.",
+)
 @click.argument("limit_repositories", type=str, nargs=-1)
 def load_c(
     remote,
@@ -629,6 +634,7 @@ def load_c(
     repositories_file,
     limit_repositories,
     introspection_mode,
+    ignore_introspection_errors,
 ):
     """
     Load a Splitgraph catalog from a YAML file.
@@ -680,7 +686,9 @@ def load_c(
                 )
                 external_repositories.append(external_repository)
         rest_client.bulk_upsert_external(
-            repositories=external_repositories, introspection_mode=introspection_mode
+            repositories=external_repositories,
+            introspection_mode=introspection_mode,
+            raise_errors=not ignore_introspection_errors,
         )
         logging.info(f"Uploaded images for {pluralise('repository', len(external_repositories))}")
 

--- a/test/splitgraph/commandline/http_fixtures.py
+++ b/test/splitgraph/commandline/http_fixtures.py
@@ -399,7 +399,7 @@ def add_external_credential(request, uri, response_headers):
     ]
 
 
-def add_external_repo(initial_private=False):
+def add_external_repo(initial_private=False, error=False):
     def cb(request, uri, response_headers):
         data = json.loads(request.body)
 
@@ -451,7 +451,26 @@ def add_external_repo(initial_private=False):
         return [
             200,
             response_headers,
-            json.dumps({"live_image_hashes": ["abcdef12" * 8, "ghijkl34" * 8, "mnoprs56" * 8]}),
+            json.dumps(
+                {
+                    "live_image_hashes": ["abcdef12" * 8, "ghijkl34" * 8, "mnoprs56" * 8],
+                    "errors": [
+                        {
+                            "namespace": "otheruser",
+                            "repository": "somerepo_2",
+                            "errors": [
+                                {
+                                    "table_name": "table_1",
+                                    "error": "SomeError",
+                                    "error_text": "Something bad happened",
+                                }
+                            ],
+                        }
+                    ]
+                    if not error
+                    else [],
+                }
+            ),
         ]
 
     return cb

--- a/test/splitgraph/commandline/http_fixtures.py
+++ b/test/splitgraph/commandline/http_fixtures.py
@@ -404,6 +404,7 @@ def add_external_repo(initial_private=False):
         data = json.loads(request.body)
 
         assert data["repositories"] is not None
+        assert data["introspection_mode"] == "empty"
         assert data["repositories"] == [
             {
                 "credential_id": "98765432-aaaa-bbbb-a456-000000000000",

--- a/test/splitgraph/commandline/test_cloud_metadata.py
+++ b/test/splitgraph/commandline/test_cloud_metadata.py
@@ -273,8 +273,9 @@ def test_commandline_dump(snapshot):
 
 
 @pytest.mark.parametrize("initial_private", [True, False])
+@pytest.mark.parametrize("errors", [True, False])
 @httpretty.activate(allow_net_connect=False)
-def test_commandline_load(initial_private):
+def test_commandline_load(initial_private, errors):
     runner = CliRunner()
 
     httpretty.register_uri(
@@ -326,6 +327,7 @@ def test_commandline_load(initial_private):
                 os.path.join(RESOURCES, "splitgraph_yml", "readmes"),
                 "-f",
                 os.path.join(RESOURCES, "splitgraph_yml", "splitgraph.yml"),
+                "--ignore-introspection-errors",
             ],
             catch_exceptions=False,
         )
@@ -338,6 +340,12 @@ def test_commandline_load(initial_private):
         assert_repository_sources(reqs.pop())
         reqs.pop()  # discard duplicate request
         assert_repository_profiles(reqs.pop())
+
+        if errors:
+            assert (
+                "Error adding table otheruser/somerepo_2/table_1: "
+                "SomeError (Something bad happened)" in result.output
+            )
 
 
 def test_project_validate(snapshot):


### PR DESCRIPTION
New option `--introspection-mode` for `sgr cloud load` which allows picking which repositories to reintrospect when adding data to Splitgraph Cloud.

By default, we now reintrospect tables that don't have a schema (note this only currently works for the csv plugin, as it supports partial reintrospection. Previous behaviour was that we'd not reintrospect tables with an empty schema and so
they'd be introspected at query time. This would mean that any errors introspecting
the tables (like wrong external settings) would show up at query time instead of
when the user adds the repository. We'd also do extra work reintrospecting on
every query.