### PR TITLE
Predetect Airbyte connection errors by running check

### DIFF
--- a/splitgraph/ingestion/airbyte/data_source.py
+++ b/splitgraph/ingestion/airbyte/data_source.py
@@ -236,7 +236,6 @@ class AirbyteDataSource(SyncableDataSource, ABC):
             for message in self._run_and_read_from_container(
                 container, config, raise_on_status=False
             ):
-                breakpoint()
                 if message.catalog:
                     logging.info("Catalog: %s", message.catalog)
                     return message.catalog

--- a/splitgraph/ingestion/dbt/utils.py
+++ b/splitgraph/ingestion/dbt/utils.py
@@ -13,7 +13,7 @@ from ruamel.yaml import YAMLError
 from splitgraph.ingestion.airbyte.docker_utils import (
     detect_network_mode,
     remove_at_end,
-    wait_not_failed,
+    wait_container,
 )
 from splitgraph.utils.docker import (
     copy_dir_to_container,
@@ -193,7 +193,7 @@ def run_dbt_transformation_from_git(
         with remove_at_end(container):
             copy_dir_to_container(container, tmp_dir, "/data", exclude_names=[".git"])
             container.start()
-            wait_not_failed(container, mirror_logs=True)
+            wait_container(container, mirror_logs=True)
 
 
 def compile_dbt_manifest(
@@ -244,7 +244,7 @@ def compile_dbt_manifest(
         with remove_at_end(container):
             copy_dir_to_container(container, tmp_dir, "/data", exclude_names=[".git"])
             container.start()
-            wait_not_failed(container, mirror_logs=True)
+            wait_container(container, mirror_logs=True)
             # Extract the manifest
             return cast(
                 Dict[str, Any],

--- a/test/splitgraph/ingestion/test_airbyte.py
+++ b/test/splitgraph/ingestion/test_airbyte.py
@@ -12,6 +12,7 @@ from psycopg2.sql import SQL, Identifier
 from splitgraph.core.repository import Repository
 from splitgraph.core.types import TableColumn, TableParams
 from splitgraph.engine import ResultShape
+from splitgraph.exceptions import DataSourceError
 from splitgraph.hooks.data_source import merge_jsonschema
 from splitgraph.ingestion.airbyte.data_source import AirbyteDataSource
 from splitgraph.ingestion.airbyte.docker_utils import SubprocessError
@@ -650,3 +651,12 @@ def test_airbyte_mysql_source_failure(local_engine_empty):
     assert re.match(r"Container sg-ab-src-\S+ exited with 1", str(e.value))
     # Check we didn't create an empty image
     assert len(repo.images()) == 0
+
+
+@pytest.mark.mounting
+def test_airbyte_mysql_source_introspection_failure(local_engine_empty):
+    source = _source(local_engine_empty)
+    source.credentials["password"] = "wrongpass"
+
+    with pytest.raises(DataSourceError) as e:
+        source.introspect()

--- a/test/splitgraph/ingestion/test_airbyte.py
+++ b/test/splitgraph/ingestion/test_airbyte.py
@@ -1,6 +1,5 @@
 import datetime
 import os
-import re
 from distutils.dir_util import copy_tree
 from test.splitgraph.conftest import INGESTION_RESOURCES
 from test.splitgraph.utils import reassign_ordinals
@@ -15,7 +14,6 @@ from splitgraph.engine import ResultShape
 from splitgraph.exceptions import DataSourceError
 from splitgraph.hooks.data_source import merge_jsonschema
 from splitgraph.ingestion.airbyte.data_source import AirbyteDataSource
-from splitgraph.ingestion.airbyte.docker_utils import SubprocessError
 from splitgraph.ingestion.airbyte.models import (
     AirbyteCatalog,
     AirbyteStream,
@@ -646,9 +644,8 @@ def test_airbyte_mysql_source_failure(local_engine_empty):
     source.credentials["password"] = "wrongpass"
     repo = Repository.from_schema(TEST_REPO)
 
-    with pytest.raises(SubprocessError) as e:
+    with pytest.raises(DataSourceError, match="Access denied for user 'originuser'"):
         source.sync(repo, "latest")
-    assert re.match(r"Container sg-ab-src-\S+ exited with 1", str(e.value))
     # Check we didn't create an empty image
     assert len(repo.images()) == 0
 
@@ -658,5 +655,5 @@ def test_airbyte_mysql_source_introspection_failure(local_engine_empty):
     source = _source(local_engine_empty)
     source.credentials["password"] = "wrongpass"
 
-    with pytest.raises(DataSourceError) as e:
+    with pytest.raises(DataSourceError, match="Access denied for user 'originuser'"):
         source.introspect()


### PR DESCRIPTION
Most SaaS connectors don't raise an error when running `discover` (they just
output the preset list of streams and their JSONSchemas). This means the
preview/introspect step doesn't actually test the connection is valid and the
user has to wait until the load to find it out. To fix, run the connector with
the `check` parameter before running it with `discover` and raise a
`DataSourceError` if it failed to connect to the source.