### PR TITLE
Add support for incremental loads to FDW plugins

### DIFF
--- a/splitgraph/hooks/data_source/__init__.py
+++ b/splitgraph/hooks/data_source/__init__.py
@@ -1,9 +1,8 @@
 import logging
 import os
 import types
-from copy import deepcopy
 from importlib import import_module
-from typing import Any, Dict, List, Optional, Type, cast
+from typing import Dict, List, Optional, Type, cast
 
 from ...config import CONFIG
 from ...config.config import get_all_in_section, get_singleton
@@ -151,12 +150,3 @@ def _load_source(source_name, source_class_name):
             get_singleton(CONFIG, "SG_CONFIG_FILE"),
         )
     return data_source
-
-
-def merge_jsonschema(left: Dict[str, Any], right: Dict[str, Any]) -> Dict[str, Any]:
-    result = deepcopy(left)
-    result["properties"] = {**result["properties"], **right.get("properties", {})}
-    result["required"] = result.get("required", []) + [
-        r for r in right.get("required", []) if r not in result.get("required", [])
-    ]
-    return result

--- a/splitgraph/hooks/data_source/fdw.py
+++ b/splitgraph/hooks/data_source/fdw.py
@@ -57,7 +57,7 @@ class ForeignDataWrapperDataSource(MountableDataSource, SyncableDataSource, ABC)
     table_params_schema: Dict[str, Any] = {
         "type": "object",
         "properties": {
-            "cursor_columns": {
+            "cursor_fields": {
                 "type": "array",
                 "items": {"type": "string"},
                 "title": "Replication cursor",
@@ -433,7 +433,8 @@ class ForeignDataWrapperDataSource(MountableDataSource, SyncableDataSource, ABC)
             cursor_fields: Dict[str, List[str]] = {}
             if tables and isinstance(tables, dict):
                 for table, (_, table_params) in tables.items():
-                    cursor_fields[table] = list(table_params["cursor_fields"])
+                    if "cursor_fields" in table_params:
+                        cursor_fields[table] = list(table_params["cursor_fields"])
 
             for table_name in repository.object_engine.get_all_tables(staging_schema):
                 if table_name in cursor_fields:

--- a/splitgraph/hooks/data_source/utils.py
+++ b/splitgraph/hooks/data_source/utils.py
@@ -1,0 +1,11 @@
+from copy import deepcopy
+from typing import Any, Dict
+
+
+def merge_jsonschema(left: Dict[str, Any], right: Dict[str, Any]) -> Dict[str, Any]:
+    result = deepcopy(left)
+    result["properties"] = {**result["properties"], **right.get("properties", {})}
+    result["required"] = result.get("required", []) + [
+        r for r in right.get("required", []) if r not in result.get("required", [])
+    ]
+    return result

--- a/splitgraph/ingestion/csv/__init__.py
+++ b/splitgraph/ingestion/csv/__init__.py
@@ -18,6 +18,7 @@ from splitgraph.hooks.data_source.fdw import (
     ForeignDataWrapperDataSource,
     import_foreign_schema,
 )
+from splitgraph.hooks.data_source.utils import merge_jsonschema
 from splitgraph.ingestion.common import IngestionAdapter, build_commandline_help
 from splitgraph.ingestion.csv.common import dump_options, load_options
 
@@ -217,19 +218,26 @@ class CSVDataSource(ForeignDataWrapperDataSource):
         },
     }
 
-    table_params_schema: Dict[str, Any] = {
-        "type": "object",
-        "properties": {
-            "url": {"type": "string", "description": "HTTP URL to the CSV file", "title": "URL"},
-            "s3_object": {
-                "type": "string",
-                "description": "S3 object of the CSV file",
-                "title": "S3 object",
+    table_params_schema: Dict[str, Any] = merge_jsonschema(
+        ForeignDataWrapperDataSource.table_params_schema,
+        {
+            "type": "object",
+            "properties": {
+                "url": {
+                    "type": "string",
+                    "description": "HTTP URL to the CSV file",
+                    "title": "URL",
+                },
+                "s3_object": {
+                    "type": "string",
+                    "description": "S3 object of the CSV file",
+                    "title": "S3 object",
+                },
+                # Add various CSV dialect overrides to the table params schema.
+                **{k: v for k, v in params_schema["properties"].items() if k != "connection"},
             },
-            # Add various CSV dialect overrides to the table params schema.
-            **{k: v for k, v in params_schema["properties"].items() if k != "connection"},
         },
-    }
+    )
 
     supports_mount = True
     supports_load = True

--- a/splitgraph/ingestion/snowflake/__init__.py
+++ b/splitgraph/ingestion/snowflake/__init__.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, Any, Dict, Optional
 
 from splitgraph.core.types import Credentials, Params, TableInfo
 from splitgraph.hooks.data_source.fdw import ForeignDataWrapperDataSource
+from splitgraph.hooks.data_source.utils import merge_jsonschema
 from splitgraph.ingestion.common import build_commandline_help
 
 if TYPE_CHECKING:
@@ -110,16 +111,19 @@ class SnowflakeDataSource(ForeignDataWrapperDataSource):
         "required": ["database"],
     }
 
-    table_params_schema = {
-        "type": "object",
-        "properties": {
-            "subquery": {
-                "type": "string",
-                "title": "Subquery",
-                "description": "Subquery for this table to run on the server side",
-            }
+    table_params_schema = merge_jsonschema(
+        ForeignDataWrapperDataSource.table_params_schema,
+        {
+            "type": "object",
+            "properties": {
+                "subquery": {
+                    "type": "string",
+                    "title": "Subquery",
+                    "description": "Subquery for this table to run on the server side",
+                }
+            },
         },
-    }
+    )
     supports_mount = True
     supports_load = True
     supports_sync = False

--- a/splitgraph/ingestion/socrata/mount.py
+++ b/splitgraph/ingestion/socrata/mount.py
@@ -12,6 +12,7 @@ from splitgraph.hooks.data_source.fdw import (
     ForeignDataWrapperDataSource,
     create_foreign_table,
 )
+from splitgraph.hooks.data_source.utils import merge_jsonschema
 
 
 class SocrataDataSource(ForeignDataWrapperDataSource):
@@ -38,13 +39,19 @@ class SocrataDataSource(ForeignDataWrapperDataSource):
         "required": ["domain"],
     }
 
-    table_params_schema = {
-        "type": "object",
-        "properties": {
-            "socrata_id": {"type": "string", "description": "Socrata dataset ID, e.g. xzkq-xp2w"}
+    table_params_schema = merge_jsonschema(
+        ForeignDataWrapperDataSource.table_params_schema,
+        {
+            "type": "object",
+            "properties": {
+                "socrata_id": {
+                    "type": "string",
+                    "description": "Socrata dataset ID, e.g. xzkq-xp2w",
+                }
+            },
+            "required": ["socrata_id"],
         },
-        "required": ["socrata_id"],
-    }
+    )
 
     _icon_file = "socrata.svg"
 

--- a/test/splitgraph/ingestion/test_airbyte.py
+++ b/test/splitgraph/ingestion/test_airbyte.py
@@ -12,7 +12,7 @@ from splitgraph.core.repository import Repository
 from splitgraph.core.types import TableColumn, TableParams
 from splitgraph.engine import ResultShape
 from splitgraph.exceptions import DataSourceError
-from splitgraph.hooks.data_source import merge_jsonschema
+from splitgraph.hooks.data_source.utils import merge_jsonschema
 from splitgraph.ingestion.airbyte.data_source import AirbyteDataSource
 from splitgraph.ingestion.airbyte.models import (
     AirbyteCatalog,


### PR DESCRIPTION
Add a `cursor_columns` field to the table parameters (used as a list
of columns that form an increasing-only replication bookmark). Store the
ingestion state in a table inside of the image, similarly to Airbyte.