### PR TITLE
Improved support for Windows systems

### DIFF
--- a/splitgraph/config/system_config.py
+++ b/splitgraph/config/system_config.py
@@ -128,10 +128,10 @@ def get_config_file(default_return: None = None) -> Optional[str]:
 
     valid_dirs = [os.getcwd()]
 
-    if os.environ.get("HOME", None) and os.path.isdir(
-        os.path.join(os.environ["HOME"], HOME_SUB_DIR)
-    ):
-        valid_dirs.append(os.path.join(os.environ["HOME"], HOME_SUB_DIR))
+    home = os.path.expanduser("~")
+    directory = os.path.join(home, HOME_SUB_DIR)
+    if home and os.path.isdir(directory):
+        valid_dirs.append(directory)
 
     explicit_dirs = get_explicit_config_file_dirs()
 


### PR DESCRIPTION
I was using the helper class `class RESTAPIClient` in some of my Python code. It worked fine for me, but failed on some of my colleagues which have Windows machines. Even though they had run `sgr cloud add` and `sgr cloud login` and their `~/.splitgraph/.sgconfig` files looked fine, splitgraph code complained that it couldn't find any configuration for the remote.

While digging into this I discovered that the .sgconfig file is only loaded if the environment variable HOME is set, since it looks in `os.environ["HOME"]`. Adding the environment variable to my collegues' systems fixed the problem. However, this environment variable is not standard on Windows systems.

A better, cross-platform, way of finding the user's home directory is `os.path.expanduser(~)`.

There is one more instance of `os.environ["HOME"]` in the codebase but it's in the code for the engine, which I presume always runs on a Unix system anyway.