### PR TITLE
Add new artifact `sgr-osx-x86_64.tgz` to releases, compiled with `pyinstaller --onedir`, and default to it in `install.sh` on Darwin

### DIFF
--- a/.ci/build_wheel.sh
+++ b/.ci/build_wheel.sh
@@ -5,7 +5,14 @@ DEFAULT_PYPI_URL="https://test.pypi.org/legacy/"
 CI_DIR=$(cd -P -- "$(dirname -- "$0")" && pwd -P)
 REPO_ROOT_DIR="${CI_DIR}/.."
 
-test -z "$PYPI_PASSWORD" && { echo "Fatal Error: No PYPI_PASSWORD set" ; exit 1 ; }
+# By default, will configure PyPi for publishing.
+# To skip publishing setup, set NO_PUBLISH=1 .ci/build_wheel.sh
+NO_PUBLISH_FLAG="${NO_PUBLISH}"
+
+test -n "$NO_PUBLISH_FLAG" && { echo "Skipping publish because \$NO_PUBLISH is set" ; }
+test -z "$PYPI_PASSWORD" && \
+    ! test -n "$NO_PUBLISH_FLAG" \
+    && { echo "Fatal Error: No PYPI_PASSWORD set. To skip, set NO_PUBLISH=1" ; exit 1 ; }
 test -z "$PYPI_URL" && { echo "No PYPI_URL set. Defaulting to ${DEFAULT_PYPI_URL}" ; }
 
 PYPI_URL=${PYPI_URL-"${DEFAULT_PYPI_URL}"}
@@ -13,12 +20,21 @@ PYPI_URL=${PYPI_URL-"${DEFAULT_PYPI_URL}"}
 source "$HOME"/.poetry/env
 
 # Configure pypi for deployment
-pushd "$REPO_ROOT_DIR" \
-    && poetry config repositories.testpypi "$PYPI_URL" \
-    && poetry config http-basic.testpypi splitgraph "$PYPI_PASSWORD" \
-    && poetry config http-basic.pypi splitgraph "$PYPI_PASSWORD" \
-    && poetry build \
-    && popd \
-    && exit 0
+pushd "$REPO_ROOT_DIR"
 
-exit 1
+set -e
+if ! test -n "$NO_PUBLISH_FLAG" ; then
+    echo "Configuring poetry with password from \$PYPI_PASSWORD"
+    echo "To skip, try: NO_PUBLISH=1 $0 $*"
+    poetry config http-basic.testpypi splitgraph "$PYPI_PASSWORD"
+    poetry config http-basic.pypi splitgraph "$PYPI_PASSWORD"
+fi
+
+# Set the PyPi URL because it can't hurt (we skipped setting the credentials)
+poetry config repositories.testpypi "$PYPI_URL"
+
+poetry build
+popd
+
+set +e
+exit 0

--- a/.github/workflows/build_and_test_and_release.yml
+++ b/.github/workflows/build_and_test_and_release.yml
@@ -8,8 +8,8 @@ jobs:
     runs-on: ubuntu-18.04
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
     env:
-      COMPOSE_VERSION: '1.25.4'
-      POETRY_VERSION: '1.1.6'
+      COMPOSE_VERSION: "1.25.4"
+      POETRY_VERSION: "1.1.6"
       DOCKER_REPO: splitgraph
       DOCKER_ENGINE_IMAGE: engine
       DOCKER_TAG: development
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Python 3.8
         uses: actions/setup-python@v2
         with:
-          python-version: '3.8'
+          python-version: "3.8"
       - uses: actions/cache@v1
         with:
           path: ~/.cache/pip
@@ -212,7 +212,16 @@ jobs:
         with:
           name: sgr-osx
           path: dist/sgr
-
+      - name: Build the multi-file binary
+        run: |
+          pyinstaller --clean --noconfirm --onedir splitgraph.osx.spec
+          dist/sgr-pkg/sgr --version
+          cd dist/sgr-pkg && tar zcvf ../sgr.tgz .
+      - name: Upload multi-file binary.gz as artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: sgr-osx.tgz
+          path: dist/sgr.tgz
 
   upload_release:
     runs-on: ubuntu-18.04

--- a/.github/workflows/build_and_test_and_release.yml
+++ b/.github/workflows/build_and_test_and_release.yml
@@ -113,6 +113,15 @@ jobs:
           # TODO figure out if we want to do poetry upload here (can only do once, so will fail
           # if we're retrying an upload)
           # "$HOME"/.poetry/bin/poetry build
+      - name: "Build wheel only (do not configure publish)"
+        # The {windows,linux,osx}_binary stage will run if ref is tag, or msg contains "[artifacts]""
+        # If no tag, but [artifacts], we still need to build the wheel, but with NO_PUBLISH=1
+        # But if tag _and_ [artifacts], we want to skip this stage, to not build the wheel twice
+        if: "!startsWith(github.ref, 'refs/tags/') && contains(github.event.head_commit.message, '[artifacts]')"
+        env:
+          NO_PUBLISH: "1"
+        run: |
+          ./.ci/build_wheel.sh
       - name: "Upload release artifacts"
         uses: actions/upload-artifact@v2
         with:
@@ -121,7 +130,7 @@ jobs:
 
   windows_binary:
     runs-on: windows-latest
-    if: "startsWith(github.ref, 'refs/tags/')"
+    if: "startsWith(github.ref, 'refs/tags/') || contains(github.event.head_commit.message, '[artifacts]')"
     needs: build_and_test
     steps:
       - uses: actions/checkout@v1
@@ -150,7 +159,7 @@ jobs:
 
   linux_binary:
     runs-on: ubuntu-18.04
-    if: "startsWith(github.ref, 'refs/tags/')"
+    if: "startsWith(github.ref, 'refs/tags/') || contains(github.event.head_commit.message, '[artifacts]')"
     needs: build_and_test
     steps:
       - uses: actions/checkout@v1
@@ -188,7 +197,7 @@ jobs:
 
   osx_binary:
     runs-on: macOS-latest
-    if: "startsWith(github.ref, 'refs/tags/')"
+    if: "startsWith(github.ref, 'refs/tags/') || contains(github.event.head_commit.message, '[artifacts]')"
     needs: build_and_test
     steps:
       - uses: actions/checkout@v1
@@ -201,20 +210,20 @@ jobs:
         with:
           name: dist
           path: dist
-      - name: Build the binary
+      - name: Build the single-file binary
         run: |
           pip install dist/splitgraph-*-py3-none-any.whl
           pip install pyinstaller
           pyinstaller -F splitgraph.spec
           dist/sgr --version
-      - name: Upload binary as artifact
+      - name: Upload single-file binary as artifact
         uses: actions/upload-artifact@v2
         with:
           name: sgr-osx
           path: dist/sgr
-      - name: Build the multi-file binary
+      - name: Build the multi-file binary.gz
         run: |
-          pyinstaller --clean --noconfirm --onedir splitgraph.osx.spec
+          pyinstaller --clean --noconfirm --onedir splitgraph.spec
           dist/sgr-pkg/sgr --version
           cd dist/sgr-pkg && tar zcvf ../sgr.tgz .
       - name: Upload multi-file binary.gz as artifact
@@ -240,6 +249,7 @@ jobs:
           mv artifacts/sgr-windows/sgr.exe artifacts/sgr-windows-x86_64.exe
           mv artifacts/sgr-linux/sgr artifacts/sgr-linux-x86_64
           mv artifacts/sgr-osx/sgr artifacts/sgr-osx-x86_64
+          mv artifacts/sgr-osx/sgr.tgz artifacts/sgr-osx-x86_64.tgz
       - name: Release artifacts
         uses: softprops/action-gh-release@v1
         with:
@@ -247,6 +257,7 @@ jobs:
             artifacts/sgr-windows-x86_64.exe
             artifacts/sgr-linux-x86_64
             artifacts/sgr-osx-x86_64
+            artifacts/sgr-osx-x86_64.tgz
             artifacts/dist/sgr-docs-bin.tar.gz
             artifacts/dist/install.sh
           draft: true

--- a/install.sh
+++ b/install.sh
@@ -62,7 +62,15 @@ _get_binary_name() {
   if [ "$os" == Linux ]; then
     BINARY="sgr-linux-x86_64"
   elif [ "$os" == Darwin ]; then
-    BINARY="sgr-osx-x86_64"
+    if [ -n "$FORCE_ONEFILE" ] ; then
+      echo "Forcing --onefile installation on OS X because \$FORCE_ONEFILE is set."
+      BINARY="sgr-osx-x86_64"
+    else
+      # OS X has bad single-file executable support (pyinstaller --onefile), so we default to --onedir variant
+      echo "Installing optimized package for OS X (built with pyinstaller --onedir instead of --onefile)"
+      echo "To force install single-file executable (not recommended), set FORCE_ONEFILE=1"
+      BINARY="sgr-osx-x86_64.tgz"
+    fi
   else
     _die "This installation method only supported on Linux/OSX. Please see https://www.splitgraph.com/docs/installation/ for other installation methods."
   fi
@@ -81,8 +89,30 @@ _install_binary () {
   if [ "$BINARY" == "sgr-osx-x86_64.tgz" ] ; then
     echo "Installing the compressed sgr binary and deps from $URL into $INSTALL_DIR"
     echo "Installing sgr binary and deps into $INSTALL_DIR/pkg"
+
+    if [ -d "$INSTALL_DIR/pkg/sgr" ] ; then
+      echo "Removing existing $INSTALL_DIR/pkg/sgr"
+      rm -rf "$INSTALL_DIR/pkg/sgr"
+    fi
+
+    mkdir -p "$INSTALL_DIR/pkg/sgr"
+
+    curl -fsL "$URL" > "$INSTALL_DIR/pkg/sgr/sgr.tgz"
+
+    echo "Extract sgr binary and deps into $INSTALL_DIR/pkg/sgr (necessary on MacOS)"
+    (cd "$INSTALL_DIR"/pkg/sgr && tar xfz sgr.tgz && rm sgr.tgz)
+    echo "Main sgr binary is at $INSTALL_DIR/pkg/sgr/sgr"
+    echo "Link $INSTALL_DIR/sgr -> $INSTALL_DIR/pkg/sgr/sgr"
+    ln -fs "$INSTALL_DIR"/pkg/sgr/sgr "$INSTALL_DIR"/sgr
+  else
+    echo "Installing the sgr binary from $URL into $INSTALL_DIR"
+    mkdir -p "$INSTALL_DIR"
+    curl -fsL "$URL" > "$INSTALL_DIR/sgr"
+    chmod +x "$INSTALL_DIR/sgr"
   fi
 
+  "$INSTALL_DIR/sgr" --version && echo "sgr binary installed." && echo && return 0
+  _die "Installation apparently failed. got non-zero exit code from: $INSTALL_DIR/sgr --version"
 }
 
 _setup_engine() {

--- a/install.sh
+++ b/install.sh
@@ -77,13 +77,11 @@ _install_binary () {
   _check_sgr_exists
 
   URL="https://github.com/splitgraph/splitgraph/releases/download/v${SGR_VERSION}"/$BINARY
-  echo "Installing the sgr binary from $URL into $INSTALL_DIR"
-  mkdir -p "$INSTALL_DIR"
-  curl -fsL "$URL" > "$INSTALL_DIR/sgr"
-  chmod +x "$INSTALL_DIR/sgr"
-  "$INSTALL_DIR/sgr" --version
-  echo "sgr binary installed."
-  echo
+  # on OS X, splitgraph.spec is called with --onedir to output .tgz of exe and shlibs
+  if [ "$BINARY" == "sgr-osx-x86_64.tgz" ] ; then
+    echo "Installing the compressed sgr binary and deps from $URL into $INSTALL_DIR"
+    echo "Installing sgr binary and deps into $INSTALL_DIR/pkg"
+  fi
 
 }
 

--- a/splitgraph.spec
+++ b/splitgraph.spec
@@ -3,9 +3,22 @@
 # * LD_LIBRARY_PATH=`echo $(python3-config --prefix)/lib` pyinstaller -F splitgraph.spec produces a single sgr binary in the dist/ folder
 #   with libc being the only dynamic dependency (python interpreter included)
 # * can also do poetry install && poetry run pyinstaller -F splitgraph.spec to build the binary inside of the poetry's venv.
+# * specifying `--onedir` instead of `-F` will compile a multi-file executable with COLLECT()
+# * e.g. : pyinstaller --clean --noconfirm --onedir splitgraph.spec
 
+import sys
 import os
 import importlib
+
+# Pass --onedir or -D to build a multi-file executable (dir with shlibs + exe)
+# Note: This is the same flag syntax as pyinstaller uses, but when using a
+#       .spec file with pyinstaller, the flag is normally ignored, so we
+#       explicitly check for it here. This way we can pass different arguments
+#       to EXE() and conditionally call COLLECTION() without duplicating code.
+MAKE_EXE_COLLECTION = False
+if "--onedir" in sys.argv or "-D" in sys.argv:
+    print("splitgraph.spec : --onedir was specified. Will build a multi-file executable...")
+    MAKE_EXE_COLLECTION = True
 
 block_cipher = None
 
@@ -43,18 +56,36 @@ a = Analysis(
 a.datas += Tree("./splitgraph/resources", "splitgraph/resources")
 
 pyz = PYZ(a.pure, a.zipped_data, cipher=block_cipher)
-exe = EXE(
-    pyz,
-    a.scripts,
-    a.binaries,
-    a.zipfiles,
-    a.datas,
-    [],
-    name="sgr",
-    debug=False,
-    bootloader_ignore_signals=False,
-    strip=False,
-    upx=True,
-    runtime_tmpdir=None,
-    console=True,
-)
+
+# Note: `exe` global is injected by pyinstaller. Can see the code for EXE at:
+# https://github.com/pyinstaller/pyinstaller/blob/15f23a8a89be5453b3520df8fc3e667346e103a6/PyInstaller/building/api.py
+
+# TOCS to include in EXE() when in single-file mode (default, i.e. no --onedir flag)
+all_tocs = [a.scripts, a.binaries, a.zipfiles, a.datas]
+# TOCS to include in EXE() when in multi-file mode (i.e., --onedir flag)
+exe_tocs = [a.scripts]
+# TOCS to include in COLL() when in multi-file mode (i.e., --onedir flag)
+coll_tocs = [a.binaries, a.zipfiles, a.datas]
+
+# When compiling single-file executable, we include every TOC in the EXE
+# When compiling multi-file executable, include some TOC in EXE, and rest in COLL
+exe_args = [pyz, *exe_tocs, []] if MAKE_EXE_COLLECTION else [pyz, *all_tocs, []]
+
+exe_kwargs_base = {
+    "name": "sgr",
+    "debug": False,
+    "bootloader_ignore_signals": False,
+    "strip_binaries": False,
+    "runtime_tmpdir": None,
+    "console": True,
+}
+# In multi-file mode, we exclude_binaries from EXE since they will be in COLL
+exe_kwargs_onedir = {**exe_kwargs_base, "upx": False, "exclude_binaries": True}
+# In single-file mode, we set upx: true because it works. (It might actually work in multi-file mode too)
+exe_kwargs_onefile = {**exe_kwargs_base, "upx": True, "exclude_binaries": False}
+exe_kwargs = exe_kwargs_onedir if MAKE_EXE_COLLECTION else exe_kwargs_onefile
+
+exe = EXE(*exe_args, **exe_kwargs)
+
+if MAKE_EXE_COLLECTION:
+    coll = COLLECT(exe, *coll_tocs, name="sgr-pkg", strip=False, upx=False)


### PR DESCRIPTION
todo:

- [x] Rebase and cleanup the commits slightly - changes will stay the same though

follow-up PR:

- [ ] Make sure `sgr upgrade` works with multi-file executable mode (preferably in a backwards compatible way so existing OS X installations can move seamlessly from single-file to multi-file exec)
- [ ] Verify `install.sh` script works end to end

-----------------------

## Summary

- New releases will include an additional artifact `sgr-osx-x86_64.tgz`
- Archive is a directory including executable `sgr`, shared libraries, and resources
- For `Darwin` OS, `install.sh` will:
  - download `sgr-osx-x86_64.tgz` unless `$FORCE_ONEFILE` is non-empty
  - extract the multi-file directory to `~/.splitgraph/pkg/sgr` (overwrite if exist)
  - create symlink `~/.splitgraph/sgr -> ~/.splitgraph/pkg/sgr/sgr`
- The recommended install method continues to be running `install.sh`
- Add new commit message pragma `[artifacts]` to build all artifacts but not release them

## Why

The single-file executable performs poorly on Mac OS. Most noticeably,
every invocation of a single-file `sgr` starts with a 6-10 second delay
while Apple verifies the binary (I think with `gatekeeper`). Whereas
with a multi-file `sgr`, only the first invocation has this delay,
and all subsequent invocations are `< 1000ms` without any verification
overhead.

The reason for this is because the act of verifying the binary
changes its headers in such a way that it needs to be re-verified
before the next invocation. At least, that's what I read in a GitHub
issue in one of the browser tabs that I've since closed.

## How

- In `osx_binary` workflow stage, add steps to build artifact `sgr-osx/sgr.tgz`
- In `upload_release` workflow stage, release `sgr-osx/sgr.tgz` artifact as `sgr-osx-x86_64.tgz`
- In `splitgraph.spec`, when `--onedir` is specified, use the `COLLECTION()` target

## Also

- Add `NO_PUBLISH` flag to `.ci/build_wheel.sh` to not configure any PyPi parameters
- In `build_and_test` workflow stage, add step to build wheel without publish

## Note on using `pyinstaller` locally on Mac with `pyenv`

If developing `splitgraph.spec` and iterating with `pyinstaller`, it helps
to have a local environment setup to closely simulate the CI environment,
so in general, try to match whatever steps the workflow is doing. Basically,
this is a summary of the gotchas:

- Make sure to use two virtual environments
  - Use the normal splitgraph dev environment with Poetry to build the Splitgraph wheel and `bin/sgr`
  - Create a new virtualenv just for pyinstaller to create exe from the wheel and `bin/sgr`
- Create the virtual environments from a build of Python with `--enable-framework`
  - See [PyInstaller docs](https://pyinstaller.readthedocs.io/en/stable/development/venv.html)
    - Note: This page is wrong for OS X. On Darwin, flag is `--enable-framework`, not `--enable-shared`

Here is a rough set of post-hoc notes of the commands I used to get
this working locally. It might be missing some details – make sure
after each time switching a virtualenv, that you're in the right one:

```bash
# Build Python with the --enable-framework option, and create the dev venv from it
env PYTHON_CONFIGURE_OPTS="--enable-framework" pyenv install 3.7.12
pyenv shell 3.7.12
pyenv virtualenv splitgraph-dev-3.7.12
pyenv shell splitgraph-dev-3.7.12

# <<make sure poetry is installed>> (can be done out of band)
curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python
. ~/.poetry/env

# Run commands that are basically copied from CI:
poetry export --dev -f requirements.txt --without-hashes -o /tmp/requirements.txt -E pandas
# note: doesn't appear to be needed (no @ in requirements.txt last checked).
# if needed, will need to change -i to be correct mac syntax (I think switch to -e)
# sed -i "/ @ \//d" /tmp/requirements.txt
python -m pip install -U pip
pip install --no-deps -r /tmp/requirements.txt
poetry install -E pandas

# Build the wheel
poetry build

# Create a separate venv for pyinstaller
pyenv shell 3.7.12
pyenv virtualenv sgr-pyinstaller-3.7.12
pyenv shell sgr-pyinstaller-3.7.12

# Install it (note: unsure if installing pip is required. But I omitted it once, and install
# took 100x more time due to building packages after since it was "missing package `wheel`")
python -m pip install -U pip
pip install dist/splitgraph-*-py3-none-any.whl
pip install pyinstaller

# Compile a single-file executable into `dist/sgr`:
pyinstaller --clean --noconfirm splitgraph.spec

# Compile a multi-file executable into `dist/sgr-pkg`
pyinstaller --clean --noconfirm --onedir splitgraph.spec
```

You can make sure that your Python installation was compiled with
the correct configuration flags by running the correct `python3-config`
for your environment (unfortunately not exposed as `python3-config` by `pyenv`):

```bash
~/.pyenv/versions/3.7.12/bin/python3.7-config --cflags
```

The output should contain an include path that looks like:

```
-I/Users/johnnyappleseed/.pyenv/versions/3.7.12/Library/Frameworks/Python.framework/Versions/3.7/include/python3.7m -I/Users/johnnyappleseed/.pyenv/versions/3.7.12/include/python3.7m -Wno-unused-result -Wsign-compare -Wunreachable-code -fno-common -dynamic -DNDEBUG -g -fwrapv -O3 -Wall -I/Library/Developer/CommandLineTools/SDKs/MacOSX12.1.sdk/usr/include -I/Library/Developer/CommandLineTools/SDKs/MacOSX12.1.sdk/usr/include
```

## Note on gatekeeper

### Problem

If you download an artifact from Mac using a web browser, then
you will not be able to execute the artifact, whether downloaded
directly as `sgr-osx-x86_64` or extracted from `sgr-osx-x86_64.tgz`.
This restriction does not apply when downloading a file with `curl`.

### Resolution

Since it only affects files downloaded from web browsers, it does not
affect the `install.sh` script, so that continues to be the recommended
installation method.

We could change `install.sh` to remove the `com.apple.quarantine` flag
from the downloaded binary if it exists, but we don't expect it to
exist when downloading via `curl`, so it wouldn't make sense.

We could join the Apple Developer Program and pay for the privilege
of signing executables with a certificate they will sign too.

We should add a note to each release, and should update the installation
documentation to warn about downloading binaries from a web browser.

### Background

Background: On Mac, some files have "extra attributes" set. The `xattr`
command can inspect and modify them. One of these attributes
is `com.apple.quarantine`, which web browsers set for any downloaded file.

So if you use your web browser to download `sgr-osx-x86_64` from
the releases page, then even after `chmod +x`, you will not be
able to execute it. Attempts to execute the file will cause the OS
to render a pop-up window refusing to allow it.

### Troubleshooting `com.apple.quarantine` and gatekeeper

To check if a file has the `com.apple.quarantine` bit set, run `xattr $filename`,
for example, to check the `sgr` executable in the local directory. If you
see `com.apple.quarantine`, it's set:

```bash
❯ xattr sgr
com.apple.quarantine
```

You can remove it with the `-d` flag. If you remove the flag from a `.tgz` archive,
then none of the extracted files will have it set. If you do not remove it, then
all of the extracted files will each have it set:

```
xattr sgr -d com.apple.quarantine sgr
```

You can recursively remove the flag on all files in a directory:

```bash
xattr sgr -dr com.apple.quarantine sgr-pkg
```

You can also inspect it further:

```bash
# See value of specific flag
❯ xattr -p com.apple.quarantine sgr
0081;6232d9e5;Chrome;418DB2BC-FCB9-4806-852A-1144DFFC6CA0

# See value of all flags (note the metadata about original download location) (truncated by me)
❯ xattr -l com.apple.quarantine sgr
com.apple.metadata:kMDItemWhereFroms: bplist00_(https://objects.githubusercontent.com/github-production-release-asset-2e65be/153455875/08645532-6041-4acb-be59-40a5545b2b43?X-Amz-Algorithm=xxx&X-Amz-Credential=xxx&X-Amz-Date=xx&X-Amz-Expires=300&X-Amz-Signature=xx&X-Amz-SignedHeaders=host&actor_id=xx&key_id=0&repo_id=153455875&response-content-disposition=attachment%3B%20filename%3Dsgr-osx-x86_64&response-content-type=application%2Foctet-stream_<https://github.com/splitgraph/splitgraph/releases/tag/v0.3.7
com.apple.quarantine: 0081;6232d9e5;Chrome;418DB2BC-FCB9-4806-852A-1144DFFC6CA0
```
