### PR TITLE
Relax schema change detection in FDW sync

### DIFF
--- a/splitgraph/hooks/data_source/fdw.py
+++ b/splitgraph/hooks/data_source/fdw.py
@@ -422,7 +422,10 @@ class ForeignDataWrapperDataSource(MountableDataSource, SyncableDataSource, ABC)
                 if base_image:
                     try:
                         current_schema = base_image.get_table(table_name).table_schema
-                        if current_schema != new_schema:
+                        # Compare schemas ignoring ordinals/comments
+                        if [(c.name, c.pg_type, c.is_pk) for c in current_schema] != [
+                            (c.name, c.pg_type, c.is_pk) for c in new_schema
+                        ]:
                             raise AssertionError(
                                 "Schema for %s changed! Old: %s, new: %s"
                                 % (


### PR DESCRIPTION
Ignore ordinals/comments (we only care about the column order, not the exact
ordinals, since we want to know that attaching an object directly won't break
the table)