### PR TITLE
Writable DDN accompanying changes

### DIFF
--- a/splitgraph/core/image.py
+++ b/splitgraph/core/image.py
@@ -174,6 +174,7 @@ class Image(NamedTuple):
         target_schema: Optional[str] = None,
         wrapper: Optional[str] = FDW_CLASS,
         only_tables: Optional[List[str]] = None,
+        ddn_layout: bool = False,
     ) -> None:
         """
         Intended to be run on the sgr side. Initializes the FDW for all tables in a given image,
@@ -218,10 +219,13 @@ class Image(NamedTuple):
                 target_schema,
             )
             table = self.get_table(table_name)
-            table.materialize(WRITE_LOWER_PREFIX + table_name, target_schema, lq_server=server_id)
+            foreign_table_name = table_name if ddn_layout else WRITE_LOWER_PREFIX + table_name
+            table.materialize(foreign_table_name, target_schema, lq_server=server_id)
 
             # Add overlay for writing
-            init_write_overlay(object_engine, target_schema, table_name, table.table_schema)
+            init_write_overlay(
+                object_engine, target_schema, table_name, table.table_schema, ddn_layout=ddn_layout
+            )
 
         object_engine.commit()
 

--- a/splitgraph/core/overlay.py
+++ b/splitgraph/core/overlay.py
@@ -10,15 +10,25 @@ if TYPE_CHECKING:
 SG_ROW_SEQ = "_sg_row_seq"
 WRITE_LOWER_PREFIX = "_sgov_lower_"
 WRITE_UPPER_PREFIX = "_sgov_upper_"
+WRITE_MERGED_PREFIX = "_sgov_merged"
 
 
 def init_write_overlay(
-    object_engine: "PostgresEngine", schema: str, table: str, table_schema: TableSchema
+    object_engine: "PostgresEngine",
+    schema: str,
+    table: str,
+    table_schema: TableSchema,
+    ddn_layout=False,
 ) -> None:
     from splitgraph.engine.postgres.engine import SG_UD_FLAG
 
     upper_table = WRITE_UPPER_PREFIX + table
-    lower_table = WRITE_LOWER_PREFIX + table
+    # LQ checkout with sgr vs DDN differ in that in the former case the user
+    # interacts with the overlay view directly, and can thus see the all pending
+    # changes at any time. In the latter case, the user interacts only with the
+    # foreign table backed by LQFDW, and the writes are not visible until flushed.
+    lower_table = table if ddn_layout else WRITE_LOWER_PREFIX + table
+    overlay_view = WRITE_MERGED_PREFIX + table if ddn_layout else table
 
     # Create the "upper" table that actual writes will be recorded in (staging area for
     # new objects)
@@ -67,7 +77,7 @@ def init_write_overlay(
         """
         ).format(
             schema=Identifier(schema),
-            table=Identifier(table),
+            table=Identifier(overlay_view),
             pks=pk_cols_s,
             all_cols=all_cols,
             lower=Identifier(lower_table),
@@ -83,7 +93,7 @@ def init_write_overlay(
     for col in table_schema:
         if col.comment:
             query += SQL("COMMENT ON COLUMN {}.{}.{} IS %s;").format(
-                Identifier(schema), Identifier(table), Identifier(col.name)
+                Identifier(schema), Identifier(overlay_view), Identifier(col.name)
             )
             args.append(col.comment)
     if len(args) > 0:
@@ -117,7 +127,7 @@ CREATE TRIGGER {1} INSTEAD OF INSERT OR UPDATE OR DELETE ON {0}.{1}
 """
         ).format(
             Identifier(schema),
-            Identifier(table),
+            Identifier(overlay_view),
             Identifier(upper_table),
         )
     )

--- a/splitgraph/core/overlay.py
+++ b/splitgraph/core/overlay.py
@@ -87,17 +87,18 @@ def init_write_overlay(
         )
     )
 
-    # Transfer comment from original table to the view
-    query = SQL("")
-    args = []
-    for col in table_schema:
-        if col.comment:
-            query += SQL("COMMENT ON COLUMN {}.{}.{} IS %s;").format(
-                Identifier(schema), Identifier(overlay_view), Identifier(col.name)
-            )
-            args.append(col.comment)
-    if len(args) > 0:
-        object_engine.run_sql(query, args)
+    if not ddn_layout:
+        # Transfer comment from original table to the view
+        query = SQL("")
+        args = []
+        for col in table_schema:
+            if col.comment:
+                query += SQL("COMMENT ON COLUMN {}.{}.{} IS %s;").format(
+                    Identifier(schema), Identifier(overlay_view), Identifier(col.name)
+                )
+                args.append(col.comment)
+        if len(args) > 0:
+            object_engine.run_sql(query, args)
 
     # Create a trigger
     object_engine.run_sql(

--- a/splitgraph/core/overlay.py
+++ b/splitgraph/core/overlay.py
@@ -10,7 +10,7 @@ if TYPE_CHECKING:
 SG_ROW_SEQ = "_sg_row_seq"
 WRITE_LOWER_PREFIX = "_sgov_lower_"
 WRITE_UPPER_PREFIX = "_sgov_upper_"
-WRITE_MERGED_PREFIX = "_sgov_merged"
+WRITE_MERGED_PREFIX = "_sgov_merged_"
 
 
 def init_write_overlay(

--- a/splitgraph/core/overlay.py
+++ b/splitgraph/core/overlay.py
@@ -18,7 +18,7 @@ def init_write_overlay(
     schema: str,
     table: str,
     table_schema: TableSchema,
-    ddn_layout=False,
+    ddn_layout: bool = False,
 ) -> None:
     from splitgraph.engine.postgres.engine import SG_UD_FLAG
 

--- a/splitgraph/engine/base.py
+++ b/splitgraph/engine/base.py
@@ -230,7 +230,7 @@ class SQLEngine(ABC):
         args = [schema]
 
         if not include_overlay_components:
-            query += SQL(" AND table_name NOT LIKE ALL (ARRAY[%s, %s])")
+            query += SQL(" AND table_name NOT LIKE ALL (ARRAY[%s, %s, %s])")
             args += [
                 WRITE_LOWER_PREFIX + "%",
                 WRITE_UPPER_PREFIX + "%",

--- a/splitgraph/engine/base.py
+++ b/splitgraph/engine/base.py
@@ -7,7 +7,11 @@ from typing import Any, Dict, Iterator, List, Optional, Sequence, Tuple, Union, 
 
 from psycopg2.sql import SQL, Composed, Identifier
 
-from splitgraph.core.overlay import WRITE_LOWER_PREFIX, WRITE_UPPER_PREFIX
+from splitgraph.core.overlay import (
+    WRITE_LOWER_PREFIX,
+    WRITE_MERGED_PREFIX,
+    WRITE_UPPER_PREFIX,
+)
 from splitgraph.core.types import TableColumn, TableSchema
 from splitgraph.engine import ResultShape
 
@@ -227,7 +231,11 @@ class SQLEngine(ABC):
 
         if not include_overlay_components:
             query += SQL(" AND table_name NOT LIKE ALL (ARRAY[%s, %s])")
-            args += [WRITE_LOWER_PREFIX + "%", WRITE_UPPER_PREFIX + "%"]
+            args += [
+                WRITE_LOWER_PREFIX + "%",
+                WRITE_UPPER_PREFIX + "%",
+                WRITE_MERGED_PREFIX + "%",
+            ]
 
         return cast(
             List[str],


### PR DESCRIPTION
This PR extends the writable LQ mechanism so that is can be adapted into Splitgraph's writable DDN feature. In particular, this concerns the differences in the naming convention of the overlay components on DDN:
- the LQFDW foreign table has no prefix at this time, as the users will directly interact with it.
- the unifying view now has a prexif `_sgov_merged_`.
- the pending changes, aka upper table keeps the same prefix.

CU-2p09y3v