### PR TITLE
Add support for writeable LQ to Splitfiles

### DIFF
--- a/splitgraph/commandline/cloud.py
+++ b/splitgraph/commandline/cloud.py
@@ -968,7 +968,9 @@ def upload_c(remote, file_format, repository, files):
 
     wait_for_load(client, repository.namespace, repository.repository, task_id)
 
-    web_url = _construct_repo_url(gql_endpoint=client.endpoint, full_repo=repository) + "/-/tables"
+    web_url = (
+        _construct_repo_url(gql_endpoint=client.endpoint, full_repo=repository) + "/latest/-/tables"
+    )
     click.echo()
     click.echo(
         "Success. See the repository at " + Color.BLUE + web_url + Color.END + " or query it with:"

--- a/splitgraph/commandline/splitfile.py
+++ b/splitgraph/commandline/splitfile.py
@@ -21,7 +21,13 @@ from .common import ImageType, RepositoryType
 @click.option(
     "-o", "--output-repository", help="Repository to store the result in.", type=RepositoryType()
 )
-def build_c(splitfile, args, output_repository):
+@click.option(
+    "-l",
+    "--layered-querying",
+    help="Use writeable layered querying when checking images out. Experimental.",
+    is_flag=True,
+)
+def build_c(splitfile, args, output_repository, layered_querying):
     """
     Build Splitgraph images.
 
@@ -54,7 +60,9 @@ def build_c(splitfile, args, output_repository):
         file_name = os.path.splitext(os.path.basename(splitfile.name))[0]
         output_repository = Repository.from_schema(file_name)
 
-    execute_commands(splitfile.read(), args, output=output_repository)
+    execute_commands(
+        splitfile.read(), args, output=output_repository, use_writeable_lq=layered_querying
+    )
 
 
 @click.command(name="provenance")
@@ -205,7 +213,13 @@ def dependents_c(image_spec, source_on, dependents_on):
     help="Images to substitute into the reconstructed Splitfile, of the form"
     " [NAMESPACE/]REPOSITORY[:HASH_OR_TAG]. Default tag is 'latest'.",
 )
-def rebuild_c(image_spec, update, against):
+@click.option(
+    "-l",
+    "--layered-querying",
+    help="Use writeable layered querying when checking images out. Experimental.",
+    is_flag=True,
+)
+def rebuild_c(image_spec, update, against, layered_querying):
     """
     Rebuild images against different dependencies.
 
@@ -244,4 +258,4 @@ def rebuild_c(image_spec, update, against):
 
     from splitgraph.splitfile.execution import rebuild_image
 
-    rebuild_image(image, new_images)
+    rebuild_image(image, new_images, use_writeable_lq=layered_querying)

--- a/test/splitgraph/commandline/snapshots/test_cloud_jobs/test_csv_upload/True/sgr_cloud_upload_success.txt
+++ b/test/splitgraph/commandline/snapshots/test_cloud_jobs/test_csv_upload/True/sgr_cloud_upload_success.txt
@@ -3,5 +3,5 @@ Uploading the files...
  (SUCCESS) Waiting for task ID ingest_task
 
 
-Success. See the repository at http://www.example.com/someuser/somerepo_1/-/tables or query it with:
+Success. See the repository at http://www.example.com/someuser/somerepo_1/latest/-/tables or query it with:
     sgr cloud sql 'SELECT * FROM "someuser/somerepo_1"."base_df"'


### PR DESCRIPTION
Pass `sgr build -l` to use writeable LQ where possible. Note that this won't
work if the user is altering the schema of an existing table that's checked
out with layered querying.