### PR TITLE
Fix Socrata data source introspection

### DIFF
--- a/.github/workflows/build_and_test_and_release.yml
+++ b/.github/workflows/build_and_test_and_release.yml
@@ -148,7 +148,7 @@ jobs:
         shell: bash
         run: |
           pip install dist/splitgraph-*-py3-none-any.whl
-          pip install pyinstaller
+          pip install pyinstaller==4.10
           pyinstaller -F splitgraph.spec
           dist/sgr.exe --version
       - name: Upload binary as artifact
@@ -175,7 +175,7 @@ jobs:
       - name: Build the binary
         run: |
           pip install dist/splitgraph-*-py3-none-any.whl
-          pip install pyinstaller
+          pip install pyinstaller==4.10
           pyinstaller -F splitgraph.spec
           dist/sgr --version
       - name: Smoke test the binary
@@ -213,7 +213,7 @@ jobs:
       - name: Build the single-file binary
         run: |
           pip install dist/splitgraph-*-py3-none-any.whl
-          pip install pyinstaller
+          pip install pyinstaller==4.10
           pyinstaller -F splitgraph.spec
           dist/sgr --version
       - name: Upload single-file binary as artifact

--- a/splitgraph/ingestion/socrata/mount.py
+++ b/splitgraph/ingestion/socrata/mount.py
@@ -2,7 +2,7 @@
 import json
 import logging
 from copy import deepcopy
-from typing import Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 from psycopg2.sql import SQL, Identifier
 
@@ -128,6 +128,14 @@ class SocrataDataSource(ForeignDataWrapperDataSource):
 
         self.engine.run_sql(SQL(";").join(mount_statements), mount_args)
         return []
+
+    def _get_foreign_table_options(self, schema: str) -> List[Tuple[str, Dict[str, Any]]]:
+        # We rename the "socrata_id" param into "table" when mounting, so rename it back
+        # here
+
+        options = super()._get_foreign_table_options(schema)
+
+        return [(t, {"socrata_id": d["table"]}) for t, d in options]
 
     def get_raw_url(
         self, tables: Optional[TableInfo] = None, expiry: int = 3600


### PR DESCRIPTION
We rename the "socrata_id" param into "table" when mounting, so make sure to
rename it back for `introspect()` by implementing `_get_foreign_table_options`.