### PR TITLE
Fix surrogate PK ordering

### DIFF
--- a/splitgraph/core/fragment_manager.py
+++ b/splitgraph/core/fragment_manager.py
@@ -1367,8 +1367,8 @@ class FragmentManager(MetadataManager):
                     return_shape=ResultShape.MANY_ONE,
                 )
             )
-        object_pks = list(zip(result[::2], result[1::2]))
-        return object_pks
+        object_pks = [tuple(sorted(t)) for t in zip(result[::2], result[1::2])]
+        return cast(List[Tuple[Any, Any]], object_pks)
 
     def _add_overlapping_objects(
         self, table: "Table", all_objects: List[str], filtered_objects: List[str]

--- a/splitgraph/core/image.py
+++ b/splitgraph/core/image.py
@@ -129,7 +129,7 @@ class Image(NamedTuple):
         )
 
     @manage_audit
-    def checkout(self, force: bool = False, layered: bool = False) -> None:
+    def checkout(self, force: bool = False, layered: bool = False, ddn_layout: bool = True) -> None:
         """
         Checks the image out, changing the current HEAD pointer. Raises an error
         if there are pending changes to its checkout.
@@ -137,6 +137,7 @@ class Image(NamedTuple):
         :param force: Discards all pending changes to the schema.
         :param layered: If True, uses layered querying to check out the image (doesn't materialize tables
             inside of it).
+        :param ddn_layout: Determines whether to rotate the name prefix of lower and overlay table/view
         """
         target_schema = self.repository.to_schema()
         if len(target_schema) > POSTGRES_MAX_IDENTIFIER:
@@ -166,7 +167,7 @@ class Image(NamedTuple):
             self.object_engine.delete_table(target_schema, table)
 
         if layered:
-            self.lq_checkout()
+            self.lq_checkout(ddn_layout=ddn_layout)
         else:
             for table in self.get_tables():
                 self.get_table(table).materialize(table)


### PR DESCRIPTION
When performing LQ on a table without PKs, we need to ensure that the surrogate PKs that we use
(the string representation of the entire row) is properly ordered. Otherwise we will end up with some
objects being wrongly categorised as singletons as opposed to being grouped together, which will
lead to wrong query results.